### PR TITLE
[PECO-222] Update Thrift definitions (part 2)

### DIFF
--- a/lib/DBSQLClient.ts
+++ b/lib/DBSQLClient.ts
@@ -1,4 +1,3 @@
-import TCLIService from '../thrift/TCLIService';
 import TCLIService_types from '../thrift/TCLIService_types';
 import HiveClient from './HiveClient';
 import HiveUtils from './utils/HiveUtils';
@@ -36,9 +35,9 @@ function prependSlash(str: string): string {
 }
 
 export default class DBSQLClient implements IDBSQLClient, EventEmitter {
-  static utils = new HiveUtils(TCLIService_types);
+  static utils = new HiveUtils();
 
-  private client: HiveClient = new HiveClient(TCLIService, TCLIService_types);
+  private client: HiveClient = new HiveClient();
 
   connect(options: IConnectionOptions) {
     return this.client

--- a/lib/HiveOperation.ts
+++ b/lib/HiveOperation.ts
@@ -1,6 +1,7 @@
 import IOperation from './contracts/IOperation';
 import HiveDriver from './hive/HiveDriver';
-import { OperationHandle, TCLIServiceTypes, TableSchema, RowSet, ColumnCode, Column, Int64 } from './hive/Types';
+import TCLIService_types from '../thrift/TCLIService_types';
+import { OperationHandle, TableSchema, RowSet, ColumnCode, Column, Int64 } from './hive/Types';
 import Status from './dto/Status';
 import { GetOperationStatusResponse } from './hive/Commands/GetOperationStatusCommand';
 import { GetResultSetMetadataResponse } from './hive/Commands/GetResultSetMetadataCommand';
@@ -10,7 +11,6 @@ import StatusFactory from './factory/StatusFactory';
 export default class HiveOperation implements IOperation {
   private driver: HiveDriver;
   private operationHandle: OperationHandle;
-  private TCLIService_type: TCLIServiceTypes;
   private schema: TableSchema | null;
   private data: Array<RowSet>;
   private statusFactory: StatusFactory;
@@ -22,13 +22,12 @@ export default class HiveOperation implements IOperation {
   private state: number;
   private hasResultSet: boolean = false;
 
-  constructor(driver: HiveDriver, operationHandle: OperationHandle, TCLIService_type: TCLIServiceTypes) {
+  constructor(driver: HiveDriver, operationHandle: OperationHandle) {
     this.driver = driver;
     this.operationHandle = operationHandle;
     this.hasResultSet = operationHandle.hasResultSet;
-    this.TCLIService_type = TCLIService_type;
-    this.statusFactory = new StatusFactory(TCLIService_type);
-    this.state = TCLIService_type.TOperationState.INITIALIZED_STATE;
+    this.statusFactory = new StatusFactory();
+    this.state = TCLIService_types.TOperationState.INITIALIZED_STATE;
 
     this.schema = null;
     this.data = [];
@@ -42,7 +41,7 @@ export default class HiveOperation implements IOperation {
     if (!this.hasResultSet) {
       return Promise.resolve(
         this.statusFactory.create({
-          statusCode: this.TCLIService_type.TStatusCode.SUCCESS_STATUS,
+          statusCode: TCLIService_types.TStatusCode.SUCCESS_STATUS,
         }),
       );
     }
@@ -50,7 +49,7 @@ export default class HiveOperation implements IOperation {
     if (!this.finished()) {
       return Promise.resolve(
         this.statusFactory.create({
-          statusCode: this.TCLIService_type.TStatusCode.STILL_EXECUTING_STATUS,
+          statusCode: TCLIService_types.TStatusCode.STILL_EXECUTING_STATUS,
         }),
       );
     }
@@ -121,7 +120,7 @@ export default class HiveOperation implements IOperation {
   }
 
   finished(): boolean {
-    return this.state === this.TCLIService_type.TOperationState.FINISHED_STATE;
+    return this.state === TCLIService_types.TOperationState.FINISHED_STATE;
   }
 
   hasMoreRows(): boolean {
@@ -171,7 +170,7 @@ export default class HiveOperation implements IOperation {
   private firstFetch(): Promise<FetchResultsResponse> {
     return this.driver.fetchResults({
       operationHandle: this.operationHandle,
-      orientation: this.TCLIService_type.TFetchOrientation.FETCH_FIRST,
+      orientation: TCLIService_types.TFetchOrientation.FETCH_FIRST,
       maxRows: this.maxRows,
       fetchType: this.fetchType,
     });
@@ -180,7 +179,7 @@ export default class HiveOperation implements IOperation {
   private nextFetch(): Promise<FetchResultsResponse> {
     return this.driver.fetchResults({
       operationHandle: this.operationHandle,
-      orientation: this.TCLIService_type.TFetchOrientation.FETCH_NEXT,
+      orientation: TCLIService_types.TFetchOrientation.FETCH_NEXT,
       maxRows: this.maxRows,
       fetchType: this.fetchType,
     });

--- a/lib/HiveSession.ts
+++ b/lib/HiveSession.ts
@@ -8,7 +8,7 @@ import IHiveSession, {
   FunctionNameRequest,
   CrossReferenceRequest,
 } from './contracts/IHiveSession';
-import { SessionHandle, TCLIServiceTypes, Status as TStatus, OperationHandle } from './hive/Types';
+import { SessionHandle, Status as TStatus, OperationHandle } from './hive/Types';
 import { ExecuteStatementResponse } from './hive/Commands/ExecuteStatementCommand';
 import IOperation from './contracts/IOperation';
 import HiveOperation from './HiveOperation';
@@ -19,14 +19,12 @@ import InfoValue from './dto/InfoValue';
 export default class HiveSession implements IHiveSession {
   private driver: HiveDriver;
   private sessionHandle: SessionHandle;
-  private TCLIService_types: TCLIServiceTypes;
   private statusFactory: StatusFactory;
 
-  constructor(driver: HiveDriver, sessionHandle: SessionHandle, TCLIService_types: TCLIServiceTypes) {
+  constructor(driver: HiveDriver, sessionHandle: SessionHandle) {
     this.driver = driver;
     this.sessionHandle = sessionHandle;
-    this.TCLIService_types = TCLIService_types;
-    this.statusFactory = new StatusFactory(TCLIService_types);
+    this.statusFactory = new StatusFactory();
   }
 
   getInfo(infoType: number): Promise<InfoValue> {
@@ -242,7 +240,7 @@ export default class HiveSession implements IHiveSession {
   }
 
   private createOperation(handle: OperationHandle): IOperation {
-    return new HiveOperation(this.driver, handle, this.TCLIService_types);
+    return new HiveOperation(this.driver, handle);
   }
 
   private assertStatus(responseStatus: TStatus): void {

--- a/lib/factory/StatusFactory.ts
+++ b/lib/factory/StatusFactory.ts
@@ -1,14 +1,9 @@
-import { TCLIServiceTypes, Status as TStatus } from '../hive/Types';
+import { Status as TStatus } from '../hive/Types';
+import TCLIService_types from '../../thrift/TCLIService_types';
 import Status from '../dto/Status';
 import StatusError from '../errors/StatusError';
 
 export default class StatusFactory {
-  private TCLIService_types: TCLIServiceTypes;
-
-  constructor(TCLIService_types: TCLIServiceTypes) {
-    this.TCLIService_types = TCLIService_types;
-  }
-
   /**
    * @param status thrift status object from API responses
    * @throws {StatusError}
@@ -27,19 +22,19 @@ export default class StatusFactory {
 
   private isSuccess(status: TStatus): boolean {
     return (
-      status.statusCode === this.TCLIService_types.TStatusCode.SUCCESS_STATUS ||
-      status.statusCode === this.TCLIService_types.TStatusCode.SUCCESS_WITH_INFO_STATUS
+      status.statusCode === TCLIService_types.TStatusCode.SUCCESS_STATUS ||
+      status.statusCode === TCLIService_types.TStatusCode.SUCCESS_WITH_INFO_STATUS
     );
   }
 
   private isError(status: TStatus): boolean {
     return (
-      status.statusCode === this.TCLIService_types.TStatusCode.ERROR_STATUS ||
-      status.statusCode === this.TCLIService_types.TStatusCode.INVALID_HANDLE_STATUS
+      status.statusCode === TCLIService_types.TStatusCode.ERROR_STATUS ||
+      status.statusCode === TCLIService_types.TStatusCode.INVALID_HANDLE_STATUS
     );
   }
 
   private isExecuting(status: TStatus): boolean {
-    return status.statusCode === this.TCLIService_types.TStatusCode.STILL_EXECUTING_STATUS;
+    return status.statusCode === TCLIService_types.TStatusCode.STILL_EXECUTING_STATUS;
   }
 }

--- a/lib/hive/Commands/BaseCommand.ts
+++ b/lib/hive/Commands/BaseCommand.ts
@@ -1,13 +1,11 @@
-import { ThriftClient, TCLIServiceTypes } from '../Types';
+import { ThriftClient } from '../Types';
 import HiveDriverError from '../../errors/HiveDriverError';
 
 export default abstract class BaseCommand {
   protected client: ThriftClient;
-  protected TCLIService_types: TCLIServiceTypes;
 
-  constructor(client: ThriftClient, TCLIService_types: TCLIServiceTypes) {
+  constructor(client: ThriftClient) {
     this.client = client;
-    this.TCLIService_types = TCLIService_types;
   }
 
   executeCommand<Response>(request: object, command: Function | void): Promise<Response> {

--- a/lib/hive/Commands/CancelDelegationTokenCommand.ts
+++ b/lib/hive/Commands/CancelDelegationTokenCommand.ts
@@ -1,5 +1,6 @@
 import BaseCommand from './BaseCommand';
 import { Status, SessionHandle } from '../Types';
+import TCLIService_types from '../../../thrift/TCLIService_types';
 
 export type CancelDelegationTokenRequest = {
   sessionHandle: SessionHandle;
@@ -12,7 +13,7 @@ export type CancelDelegationTokenResponse = {
 
 export default class CancelDelegationTokenCommand extends BaseCommand {
   execute(data: CancelDelegationTokenRequest): Promise<CancelDelegationTokenResponse> {
-    const request = new this.TCLIService_types.TCancelDelegationTokenReq(data);
+    const request = new TCLIService_types.TCancelDelegationTokenReq(data);
 
     return this.executeCommand<CancelDelegationTokenResponse>(request, this.client.CancelDelegationToken);
   }

--- a/lib/hive/Commands/CancelOperationCommand.ts
+++ b/lib/hive/Commands/CancelOperationCommand.ts
@@ -1,5 +1,6 @@
 import BaseCommand from './BaseCommand';
 import { Status, OperationHandle } from '../Types';
+import TCLIService_types from '../../../thrift/TCLIService_types';
 
 export type CancelOperationRequest = {
   operationHandle: OperationHandle;
@@ -11,7 +12,7 @@ export type CancelOperationResponse = {
 
 export default class CancelOperationCommand extends BaseCommand {
   execute(data: CancelOperationRequest): Promise<CancelOperationResponse> {
-    const request = new this.TCLIService_types.TCancelOperationReq(data);
+    const request = new TCLIService_types.TCancelOperationReq(data);
 
     return this.executeCommand<CancelOperationResponse>(request, this.client.CancelOperation);
   }

--- a/lib/hive/Commands/CloseOperationCommand.ts
+++ b/lib/hive/Commands/CloseOperationCommand.ts
@@ -1,5 +1,6 @@
 import BaseCommand from './BaseCommand';
 import { Status, OperationHandle } from '../Types';
+import TCLIService_types from '../../../thrift/TCLIService_types';
 
 export type CloseOperationRequest = {
   operationHandle: OperationHandle;
@@ -11,7 +12,7 @@ export type CloseOperationResponse = {
 
 export default class CloseOperationCommand extends BaseCommand {
   execute(data: CloseOperationRequest): Promise<CloseOperationResponse> {
-    const request = new this.TCLIService_types.TCloseOperationReq(data);
+    const request = new TCLIService_types.TCloseOperationReq(data);
 
     return this.executeCommand<CloseOperationResponse>(request, this.client.CloseOperation);
   }

--- a/lib/hive/Commands/CloseSessionCommand.ts
+++ b/lib/hive/Commands/CloseSessionCommand.ts
@@ -1,5 +1,6 @@
-import { ThriftClient, TCLIServiceTypes, SessionHandle, Status } from '../Types';
+import { SessionHandle, Status } from '../Types';
 import BaseCommand from './BaseCommand';
+import TCLIService_types from '../../../thrift/TCLIService_types';
 
 export type CloseSessionRequest = {
   sessionHandle: SessionHandle;
@@ -11,7 +12,7 @@ export type CloseSessionResponse = {
 
 export default class CloseSessionCommand extends BaseCommand {
   execute(openSessionRequest: CloseSessionRequest): Promise<CloseSessionResponse> {
-    const request = new this.TCLIService_types.TCloseSessionReq(openSessionRequest);
+    const request = new TCLIService_types.TCloseSessionReq(openSessionRequest);
 
     return this.executeCommand<CloseSessionResponse>(request, this.client.CloseSession);
   }

--- a/lib/hive/Commands/ExecuteStatementCommand.ts
+++ b/lib/hive/Commands/ExecuteStatementCommand.ts
@@ -1,5 +1,6 @@
 import { SessionHandle, Status, OperationHandle, Int64 } from '../Types';
 import BaseCommand from './BaseCommand';
+import TCLIService_types from '../../../thrift/TCLIService_types';
 
 export type ExecuteStatementRequest = {
   sessionHandle: SessionHandle;
@@ -16,7 +17,7 @@ export type ExecuteStatementResponse = {
 
 export default class ExecuteStatementCommand extends BaseCommand {
   execute(executeStatementRequest: ExecuteStatementRequest): Promise<ExecuteStatementResponse> {
-    const request = new this.TCLIService_types.TExecuteStatementReq(executeStatementRequest);
+    const request = new TCLIService_types.TExecuteStatementReq(executeStatementRequest);
 
     return this.executeCommand<ExecuteStatementResponse>(request, this.client.ExecuteStatement);
   }

--- a/lib/hive/Commands/FetchResultsCommand.ts
+++ b/lib/hive/Commands/FetchResultsCommand.ts
@@ -1,5 +1,6 @@
 import BaseCommand from './BaseCommand';
 import { OperationHandle, Status, RowSet, Int64 } from '../Types';
+import TCLIService_types from '../../../thrift/TCLIService_types';
 
 /**
  * @param orientation - TCLIService_types.TFetchOrientation
@@ -20,7 +21,7 @@ export type FetchResultsResponse = {
 
 export default class FetchResultsCommand extends BaseCommand {
   execute(data: FetchResultsRequest): Promise<FetchResultsResponse> {
-    const request = new this.TCLIService_types.TFetchResultsReq(data);
+    const request = new TCLIService_types.TFetchResultsReq(data);
 
     return this.executeCommand<FetchResultsResponse>(request, this.client.FetchResults);
   }

--- a/lib/hive/Commands/GetCatalogsCommand.ts
+++ b/lib/hive/Commands/GetCatalogsCommand.ts
@@ -1,5 +1,6 @@
 import BaseCommand from './BaseCommand';
 import { Status, SessionHandle, OperationHandle } from '../Types';
+import TCLIService_types from '../../../thrift/TCLIService_types';
 
 export type GetCatalogsRequest = {
   sessionHandle: SessionHandle;
@@ -12,7 +13,7 @@ export type GetCatalogsResponse = {
 
 export default class GetCatalogsCommand extends BaseCommand {
   execute(data: GetCatalogsRequest): Promise<GetCatalogsResponse> {
-    const request = new this.TCLIService_types.TGetCatalogsReq(data);
+    const request = new TCLIService_types.TGetCatalogsReq(data);
 
     return this.executeCommand<GetCatalogsResponse>(request, this.client.GetCatalogs);
   }

--- a/lib/hive/Commands/GetColumnsCommand.ts
+++ b/lib/hive/Commands/GetColumnsCommand.ts
@@ -1,5 +1,6 @@
 import BaseCommand from './BaseCommand';
 import { Status, SessionHandle, OperationHandle } from '../Types';
+import TCLIService_types from '../../../thrift/TCLIService_types';
 
 export type GetColumnsRequest = {
   sessionHandle: SessionHandle;
@@ -16,7 +17,7 @@ export type GetColumnsResponse = {
 
 export default class GetColumnsCommand extends BaseCommand {
   execute(data: GetColumnsRequest): Promise<GetColumnsResponse> {
-    const request = new this.TCLIService_types.TGetColumnsReq(data);
+    const request = new TCLIService_types.TGetColumnsReq(data);
 
     return this.executeCommand<GetColumnsResponse>(request, this.client.GetColumns);
   }

--- a/lib/hive/Commands/GetCrossReferenceCommand.ts
+++ b/lib/hive/Commands/GetCrossReferenceCommand.ts
@@ -1,5 +1,6 @@
 import BaseCommand from './BaseCommand';
 import { Status, SessionHandle, OperationHandle } from '../Types';
+import TCLIService_types from '../../../thrift/TCLIService_types';
 
 export type GetCrossReferenceRequest = {
   sessionHandle: SessionHandle;
@@ -18,7 +19,7 @@ export type GetCrossReferenceResponse = {
 
 export default class GetCrossReferenceCommand extends BaseCommand {
   execute(data: GetCrossReferenceRequest): Promise<GetCrossReferenceResponse> {
-    const request = new this.TCLIService_types.TGetCrossReferenceReq(data);
+    const request = new TCLIService_types.TGetCrossReferenceReq(data);
 
     return this.executeCommand<GetCrossReferenceResponse>(request, this.client.GetCrossReference);
   }

--- a/lib/hive/Commands/GetDelegationTokenCommand.ts
+++ b/lib/hive/Commands/GetDelegationTokenCommand.ts
@@ -1,5 +1,6 @@
 import BaseCommand from './BaseCommand';
 import { Status, SessionHandle } from '../Types';
+import TCLIService_types from '../../../thrift/TCLIService_types';
 
 export type GetDelegationTokenRequest = {
   sessionHandle: SessionHandle;
@@ -14,7 +15,7 @@ export type GetDelegationTokenResponse = {
 
 export default class GetDelegationTokenCommand extends BaseCommand {
   execute(data: GetDelegationTokenRequest): Promise<GetDelegationTokenResponse> {
-    const request = new this.TCLIService_types.TGetDelegationTokenReq(data);
+    const request = new TCLIService_types.TGetDelegationTokenReq(data);
 
     return this.executeCommand<GetDelegationTokenResponse>(request, this.client.GetDelegationToken);
   }

--- a/lib/hive/Commands/GetFunctionsCommand.ts
+++ b/lib/hive/Commands/GetFunctionsCommand.ts
@@ -1,5 +1,6 @@
 import BaseCommand from './BaseCommand';
 import { Status, SessionHandle, OperationHandle } from '../Types';
+import TCLIService_types from '../../../thrift/TCLIService_types';
 
 export type GetFunctionsRequest = {
   sessionHandle: SessionHandle;
@@ -15,7 +16,7 @@ export type GetFunctionsResponse = {
 
 export default class GetFunctionsCommand extends BaseCommand {
   execute(data: GetFunctionsRequest): Promise<GetFunctionsResponse> {
-    const request = new this.TCLIService_types.TGetFunctionsReq(data);
+    const request = new TCLIService_types.TGetFunctionsReq(data);
 
     return this.executeCommand<GetFunctionsResponse>(request, this.client.GetFunctions);
   }

--- a/lib/hive/Commands/GetInfoCommand.ts
+++ b/lib/hive/Commands/GetInfoCommand.ts
@@ -1,5 +1,6 @@
 import BaseCommand from './BaseCommand';
 import { Status, GetInfoValue, SessionHandle } from '../Types';
+import TCLIService_types from '../../../thrift/TCLIService_types';
 
 /**
  * @param infoType TCLISErvice_types.TGetInfoType
@@ -16,7 +17,7 @@ export type GetInfoResponse = {
 
 export default class GetInfoCommand extends BaseCommand {
   execute(data: GetInfoRequest): Promise<GetInfoResponse> {
-    const request = new this.TCLIService_types.TGetInfoReq(data);
+    const request = new TCLIService_types.TGetInfoReq(data);
 
     return this.executeCommand<GetInfoResponse>(request, this.client.GetInfo);
   }

--- a/lib/hive/Commands/GetOperationStatusCommand.ts
+++ b/lib/hive/Commands/GetOperationStatusCommand.ts
@@ -1,5 +1,6 @@
 import BaseCommand from './BaseCommand';
 import { Status, OperationHandle, ProgressUpdateResponse } from '../Types';
+import TCLIService_types from '../../../thrift/TCLIService_types';
 
 export type GetOperationStatusRequest = {
   operationHandle: OperationHandle;
@@ -22,7 +23,7 @@ export type GetOperationStatusResponse = {
 
 export default class GetOperationStatusCommand extends BaseCommand {
   execute(data: GetOperationStatusRequest): Promise<GetOperationStatusResponse> {
-    const request = new this.TCLIService_types.TGetOperationStatusReq(data);
+    const request = new TCLIService_types.TGetOperationStatusReq(data);
 
     return this.executeCommand<GetOperationStatusResponse>(request, this.client.GetOperationStatus);
   }

--- a/lib/hive/Commands/GetPrimaryKeysCommand.ts
+++ b/lib/hive/Commands/GetPrimaryKeysCommand.ts
@@ -1,5 +1,6 @@
 import BaseCommand from './BaseCommand';
 import { Status, SessionHandle, OperationHandle } from '../Types';
+import TCLIService_types from '../../../thrift/TCLIService_types';
 
 export type GetPrimaryKeysRequest = {
   sessionHandle: SessionHandle;
@@ -15,7 +16,7 @@ export type GetPrimaryKeysResponse = {
 
 export default class GetPrimaryKeysCommand extends BaseCommand {
   execute(data: GetPrimaryKeysRequest): Promise<GetPrimaryKeysResponse> {
-    const request = new this.TCLIService_types.TGetPrimaryKeysReq(data);
+    const request = new TCLIService_types.TGetPrimaryKeysReq(data);
 
     return this.executeCommand<GetPrimaryKeysResponse>(request, this.client.GetPrimaryKeys);
   }

--- a/lib/hive/Commands/GetResultSetMetadataCommand.ts
+++ b/lib/hive/Commands/GetResultSetMetadataCommand.ts
@@ -1,5 +1,6 @@
 import { TableSchema, Status, OperationHandle } from '../Types';
 import BaseCommand from './BaseCommand';
+import TCLIService_types from '../../../thrift/TCLIService_types';
 
 export type GetResultSetMetadataRequest = {
   operationHandle: OperationHandle;
@@ -12,7 +13,7 @@ export type GetResultSetMetadataResponse = {
 
 export default class GetResultSetMetadataCommand extends BaseCommand {
   execute(getResultSetMetadataRequest: GetResultSetMetadataRequest): Promise<GetResultSetMetadataResponse> {
-    const request = new this.TCLIService_types.TGetResultSetMetadataReq(getResultSetMetadataRequest);
+    const request = new TCLIService_types.TGetResultSetMetadataReq(getResultSetMetadataRequest);
 
     return this.executeCommand<GetResultSetMetadataResponse>(request, this.client.GetResultSetMetadata);
   }

--- a/lib/hive/Commands/GetSchemasCommand.ts
+++ b/lib/hive/Commands/GetSchemasCommand.ts
@@ -1,5 +1,6 @@
 import BaseCommand from './BaseCommand';
 import { Status, SessionHandle, OperationHandle } from '../Types';
+import TCLIService_types from '../../../thrift/TCLIService_types';
 
 export type GetSchemasRequest = {
   sessionHandle: SessionHandle;
@@ -14,7 +15,7 @@ export type GetSchemasResponse = {
 
 export default class GetSchemasCommand extends BaseCommand {
   execute(data: GetSchemasRequest): Promise<GetSchemasResponse> {
-    const request = new this.TCLIService_types.TGetSchemasReq(data);
+    const request = new TCLIService_types.TGetSchemasReq(data);
 
     return this.executeCommand<GetSchemasResponse>(request, this.client.GetSchemas);
   }

--- a/lib/hive/Commands/GetTableTypesCommand.ts
+++ b/lib/hive/Commands/GetTableTypesCommand.ts
@@ -1,5 +1,6 @@
 import BaseCommand from './BaseCommand';
 import { Status, SessionHandle, OperationHandle } from '../Types';
+import TCLIService_types from '../../../thrift/TCLIService_types';
 
 export type GetTableTypesRequest = {
   sessionHandle: SessionHandle;
@@ -12,7 +13,7 @@ export type GetTableTypesResponse = {
 
 export default class GetTableTypesCommand extends BaseCommand {
   execute(data: GetTableTypesRequest): Promise<GetTableTypesResponse> {
-    const request = new this.TCLIService_types.TGetTableTypesReq(data);
+    const request = new TCLIService_types.TGetTableTypesReq(data);
 
     return this.executeCommand<GetTableTypesResponse>(request, this.client.GetTableTypes);
   }

--- a/lib/hive/Commands/GetTablesCommand.ts
+++ b/lib/hive/Commands/GetTablesCommand.ts
@@ -1,5 +1,6 @@
 import BaseCommand from './BaseCommand';
 import { Status, SessionHandle, OperationHandle } from '../Types';
+import TCLIService_types from '../../../thrift/TCLIService_types';
 
 export type GetTablesRequest = {
   sessionHandle: SessionHandle;
@@ -16,7 +17,7 @@ export type GetTablesResponse = {
 
 export default class GetTablesCommand extends BaseCommand {
   execute(data: GetTablesRequest): Promise<GetTablesResponse> {
-    const request = new this.TCLIService_types.TGetTablesReq(data);
+    const request = new TCLIService_types.TGetTablesReq(data);
 
     return this.executeCommand<GetTablesResponse>(request, this.client.GetTables);
   }

--- a/lib/hive/Commands/GetTypeInfoCommand.ts
+++ b/lib/hive/Commands/GetTypeInfoCommand.ts
@@ -1,5 +1,6 @@
 import BaseCommand from './BaseCommand';
 import { Status, SessionHandle, OperationHandle } from '../Types';
+import TCLIService_types from '../../../thrift/TCLIService_types';
 
 export type GetTypeInfoRequest = {
   sessionHandle: SessionHandle;
@@ -12,7 +13,7 @@ export type GetTypeInfoResponse = {
 
 export default class GetTypeInfoCommand extends BaseCommand {
   execute(data: GetTypeInfoRequest): Promise<GetTypeInfoResponse> {
-    const request = new this.TCLIService_types.TGetTypeInfoReq(data);
+    const request = new TCLIService_types.TGetTypeInfoReq(data);
 
     return this.executeCommand<GetTypeInfoResponse>(request, this.client.GetTypeInfo);
   }

--- a/lib/hive/Commands/OpenSessionCommand.ts
+++ b/lib/hive/Commands/OpenSessionCommand.ts
@@ -1,5 +1,6 @@
 import { Status, SessionHandle } from '../Types';
 import BaseCommand from './BaseCommand';
+import TCLIService_types from '../../../thrift/TCLIService_types';
 
 /**
  * For auth mechanism GSSAPI the host and service should be provided when session is opened.
@@ -33,7 +34,7 @@ export type OpenSessionResponse = {
 
 export default class OpenSessionCommand extends BaseCommand {
   execute(openSessionRequest: OpenSessionRequest): Promise<OpenSessionResponse> {
-    const request = new this.TCLIService_types.TOpenSessionReq(openSessionRequest);
+    const request = new TCLIService_types.TOpenSessionReq(openSessionRequest);
 
     return this.executeCommand<OpenSessionResponse>(request, this.client.OpenSession);
   }

--- a/lib/hive/Commands/RenewDelegationTokenCommand.ts
+++ b/lib/hive/Commands/RenewDelegationTokenCommand.ts
@@ -1,5 +1,6 @@
 import BaseCommand from './BaseCommand';
 import { Status, SessionHandle } from '../Types';
+import TCLIService_types from '../../../thrift/TCLIService_types';
 
 export type RenewDelegationTokenRequest = {
   sessionHandle: SessionHandle;
@@ -12,7 +13,7 @@ export type RenewDelegationTokenResponse = {
 
 export default class RenewDelegationTokenCommand extends BaseCommand {
   execute(data: RenewDelegationTokenRequest): Promise<RenewDelegationTokenResponse> {
-    const request = new this.TCLIService_types.TRenewDelegationTokenReq(data);
+    const request = new TCLIService_types.TRenewDelegationTokenReq(data);
 
     return this.executeCommand<RenewDelegationTokenResponse>(request, this.client.RenewDelegationToken);
   }

--- a/lib/hive/HiveDriver.ts
+++ b/lib/hive/HiveDriver.ts
@@ -1,4 +1,4 @@
-import { ThriftClient, TCLIServiceTypes } from './Types/';
+import { ThriftClient } from './Types/';
 import OpenSessionCommand, { OpenSessionRequest, OpenSessionResponse } from './Commands/OpenSessionCommand';
 import CloseSessionCommand, { CloseSessionRequest, CloseSessionResponse } from './Commands/CloseSessionCommand';
 import ExecuteStatementCommand, {
@@ -46,136 +46,134 @@ import RenewDelegationTokenCommand, {
 } from './Commands/RenewDelegationTokenCommand';
 
 export default class HiveDriver {
-  private TCLIService_types: TCLIServiceTypes;
   private client: ThriftClient;
 
-  constructor(TCLIService_types: TCLIServiceTypes, client: ThriftClient) {
-    this.TCLIService_types = TCLIService_types;
+  constructor(client: ThriftClient) {
     this.client = client;
   }
 
   openSession(request: OpenSessionRequest): Promise<OpenSessionResponse> {
-    const action = new OpenSessionCommand(this.client, this.TCLIService_types);
+    const action = new OpenSessionCommand(this.client);
 
     return action.execute(request);
   }
 
   closeSession(request: CloseSessionRequest): Promise<CloseSessionResponse> {
-    const command = new CloseSessionCommand(this.client, this.TCLIService_types);
+    const command = new CloseSessionCommand(this.client);
 
     return command.execute(request);
   }
 
   executeStatement(request: ExecuteStatementRequest): Promise<ExecuteStatementResponse> {
-    const command = new ExecuteStatementCommand(this.client, this.TCLIService_types);
+    const command = new ExecuteStatementCommand(this.client);
 
     return command.execute(request);
   }
 
   getResultSetMetadata(request: GetResultSetMetadataRequest): Promise<GetResultSetMetadataResponse> {
-    const command = new GetResultSetMetadataCommand(this.client, this.TCLIService_types);
+    const command = new GetResultSetMetadataCommand(this.client);
 
     return command.execute(request);
   }
 
   fetchResults(request: FetchResultsRequest): Promise<FetchResultsResponse> {
-    const command = new FetchResultsCommand(this.client, this.TCLIService_types);
+    const command = new FetchResultsCommand(this.client);
 
     return command.execute(request);
   }
 
   getInfo(request: GetInfoRequest): Promise<GetInfoResponse> {
-    const command = new GetInfoCommand(this.client, this.TCLIService_types);
+    const command = new GetInfoCommand(this.client);
 
     return command.execute(request);
   }
 
   getTypeInfo(request: GetTypeInfoRequest): Promise<GetTypeInfoResponse> {
-    const command = new GetTypeInfoCommand(this.client, this.TCLIService_types);
+    const command = new GetTypeInfoCommand(this.client);
 
     return command.execute(request);
   }
 
   getCatalogs(request: GetCatalogsRequest): Promise<GetCatalogsResponse> {
-    const command = new GetCatalogsCommand(this.client, this.TCLIService_types);
+    const command = new GetCatalogsCommand(this.client);
 
     return command.execute(request);
   }
 
   getSchemas(request: GetSchemasRequest): Promise<GetSchemasResponse> {
-    const command = new GetSchemasCommand(this.client, this.TCLIService_types);
+    const command = new GetSchemasCommand(this.client);
 
     return command.execute(request);
   }
 
   getTables(request: GetTablesRequest): Promise<GetTablesResponse> {
-    const command = new GetTablesCommand(this.client, this.TCLIService_types);
+    const command = new GetTablesCommand(this.client);
 
     return command.execute(request);
   }
 
   getTableTypes(request: GetTableTypesRequest): Promise<GetTableTypesResponse> {
-    const command = new GetTableTypesCommand(this.client, this.TCLIService_types);
+    const command = new GetTableTypesCommand(this.client);
 
     return command.execute(request);
   }
 
   getColumns(request: GetColumnsRequest): Promise<GetColumnsResponse> {
-    const command = new GetColumnsCommand(this.client, this.TCLIService_types);
+    const command = new GetColumnsCommand(this.client);
 
     return command.execute(request);
   }
 
   getFunctions(request: GetFunctionsRequest): Promise<GetFunctionsResponse> {
-    const command = new GetFunctionsCommand(this.client, this.TCLIService_types);
+    const command = new GetFunctionsCommand(this.client);
 
     return command.execute(request);
   }
 
   getPrimaryKeys(request: GetPrimaryKeysRequest): Promise<GetPrimaryKeysResponse> {
-    const command = new GetPrimaryKeysCommand(this.client, this.TCLIService_types);
+    const command = new GetPrimaryKeysCommand(this.client);
 
     return command.execute(request);
   }
 
   getCrossReference(request: GetCrossReferenceRequest): Promise<GetCrossReferenceResponse> {
-    const command = new GetCrossReferenceCommand(this.client, this.TCLIService_types);
+    const command = new GetCrossReferenceCommand(this.client);
 
     return command.execute(request);
   }
 
   getOperationStatus(request: GetOperationStatusRequest): Promise<GetOperationStatusResponse> {
-    const command = new GetOperationStatusCommand(this.client, this.TCLIService_types);
+    const command = new GetOperationStatusCommand(this.client);
 
     return command.execute(request);
   }
 
   cancelOperation(request: CancelOperationRequest): Promise<CancelOperationResponse> {
-    const command = new CancelOperationCommand(this.client, this.TCLIService_types);
+    const command = new CancelOperationCommand(this.client);
 
     return command.execute(request);
   }
 
   closeOperation(request: CloseOperationRequest): Promise<CloseOperationResponse> {
-    const command = new CloseOperationCommand(this.client, this.TCLIService_types);
+    const command = new CloseOperationCommand(this.client);
 
     return command.execute(request);
   }
 
   getDelegationToken(request: GetDelegationTokenRequest): Promise<GetDelegationTokenResponse> {
-    const command = new GetDelegationTokenCommand(this.client, this.TCLIService_types);
+    const command = new GetDelegationTokenCommand(this.client);
 
     return command.execute(request);
   }
 
   cancelDelegationToken(request: CancelDelegationTokenRequest): Promise<CancelDelegationTokenResponse> {
-    const command = new CancelDelegationTokenCommand(this.client, this.TCLIService_types);
+    const command = new CancelDelegationTokenCommand(this.client);
 
     return command.execute(request);
   }
 
   renewDelegationToken(request: RenewDelegationTokenRequest): Promise<RenewDelegationTokenResponse> {
-    const command = new RenewDelegationTokenCommand(this.client, this.TCLIService_types);
+    const command = new RenewDelegationTokenCommand(this.client);
 
     return command.execute(request);
   }

--- a/lib/hive/Types/index.ts
+++ b/lib/hive/Types/index.ts
@@ -1,12 +1,9 @@
 import Int64 from 'node-int64';
 import TCLIService from '../../../thrift/TCLIService';
-import * as TCLIService_types from '../../../thrift/TCLIService_types';
 
 export { Int64 };
 
 export type ThriftClient = TCLIService.Client;
-
-export type TCLIServiceTypes = typeof TCLIService_types;
 
 export type ThriftSession = {
   sessionHandle: any;

--- a/lib/result/JsonResult.ts
+++ b/lib/result/JsonResult.ts
@@ -1,5 +1,4 @@
 import {
-  TCLIServiceTypes,
   RowSet,
   TableSchema,
   ColumnDesc,
@@ -11,16 +10,15 @@ import {
   TByteColumn,
   ThriftBuffer,
 } from '../hive/Types';
+import TCLIService_types from '../../thrift/TCLIService_types';
 import IOperationResult from './IOperationResult';
 import IOperation from '../contracts/IOperation';
 
 export default class JsonResult implements IOperationResult {
-  private TCLIService_types: TCLIServiceTypes;
   private schema: TableSchema | null;
   private data: Array<RowSet> | null;
 
-  constructor(TCLIService_types: TCLIServiceTypes) {
-    this.TCLIService_types = TCLIService_types;
+  constructor() {
     this.schema = null;
     this.data = null;
   }
@@ -94,33 +92,33 @@ export default class JsonResult implements IOperationResult {
 
   private convertData(typeDescriptor: PrimitiveTypeEntry, value: ColumnType): any {
     switch (typeDescriptor.type) {
-      case this.TCLIService_types.TTypeId.TIMESTAMP_TYPE:
-      case this.TCLIService_types.TTypeId.DATE_TYPE:
-      case this.TCLIService_types.TTypeId.UNION_TYPE:
-      case this.TCLIService_types.TTypeId.USER_DEFINED_TYPE:
+      case TCLIService_types.TTypeId.TIMESTAMP_TYPE:
+      case TCLIService_types.TTypeId.DATE_TYPE:
+      case TCLIService_types.TTypeId.UNION_TYPE:
+      case TCLIService_types.TTypeId.USER_DEFINED_TYPE:
         return String(value);
-      case this.TCLIService_types.TTypeId.DECIMAL_TYPE:
+      case TCLIService_types.TTypeId.DECIMAL_TYPE:
         return Number(value);
-      case this.TCLIService_types.TTypeId.STRUCT_TYPE:
-      case this.TCLIService_types.TTypeId.MAP_TYPE:
+      case TCLIService_types.TTypeId.STRUCT_TYPE:
+      case TCLIService_types.TTypeId.MAP_TYPE:
         return this.toJSON(value, {});
-      case this.TCLIService_types.TTypeId.ARRAY_TYPE:
+      case TCLIService_types.TTypeId.ARRAY_TYPE:
         return this.toJSON(value, []);
-      case this.TCLIService_types.TTypeId.BIGINT_TYPE:
+      case TCLIService_types.TTypeId.BIGINT_TYPE:
         return this.convertBigInt(value);
-      case this.TCLIService_types.TTypeId.NULL_TYPE:
-      case this.TCLIService_types.TTypeId.BINARY_TYPE:
-      case this.TCLIService_types.TTypeId.INTERVAL_YEAR_MONTH_TYPE:
-      case this.TCLIService_types.TTypeId.INTERVAL_DAY_TIME_TYPE:
-      case this.TCLIService_types.TTypeId.FLOAT_TYPE:
-      case this.TCLIService_types.TTypeId.DOUBLE_TYPE:
-      case this.TCLIService_types.TTypeId.INT_TYPE:
-      case this.TCLIService_types.TTypeId.SMALLINT_TYPE:
-      case this.TCLIService_types.TTypeId.TINYINT_TYPE:
-      case this.TCLIService_types.TTypeId.BOOLEAN_TYPE:
-      case this.TCLIService_types.TTypeId.STRING_TYPE:
-      case this.TCLIService_types.TTypeId.CHAR_TYPE:
-      case this.TCLIService_types.TTypeId.VARCHAR_TYPE:
+      case TCLIService_types.TTypeId.NULL_TYPE:
+      case TCLIService_types.TTypeId.BINARY_TYPE:
+      case TCLIService_types.TTypeId.INTERVAL_YEAR_MONTH_TYPE:
+      case TCLIService_types.TTypeId.INTERVAL_DAY_TIME_TYPE:
+      case TCLIService_types.TTypeId.FLOAT_TYPE:
+      case TCLIService_types.TTypeId.DOUBLE_TYPE:
+      case TCLIService_types.TTypeId.INT_TYPE:
+      case TCLIService_types.TTypeId.SMALLINT_TYPE:
+      case TCLIService_types.TTypeId.TINYINT_TYPE:
+      case TCLIService_types.TTypeId.BOOLEAN_TYPE:
+      case TCLIService_types.TTypeId.STRING_TYPE:
+      case TCLIService_types.TTypeId.CHAR_TYPE:
+      case TCLIService_types.TTypeId.VARCHAR_TYPE:
       default:
         return value;
     }

--- a/lib/utils/GetResult.ts
+++ b/lib/utils/GetResult.ts
@@ -1,15 +1,12 @@
-import { TCLIServiceTypes } from '../hive/Types';
 import IOperationResult from '../result/IOperationResult';
 import NullResult from '../result/NullResult';
 import JsonResult from '../result/JsonResult';
 import IOperation from '../contracts/IOperation';
 
 export default class GetResult {
-  private TCLIService_types: TCLIServiceTypes;
   private operation: IOperation;
 
-  constructor(operation: IOperation, TCLIService_types: TCLIServiceTypes) {
-    this.TCLIService_types = TCLIService_types;
+  constructor(operation: IOperation) {
     this.operation = operation;
   }
 
@@ -35,7 +32,7 @@ export default class GetResult {
     if (schema === null) {
       return new NullResult();
     } else {
-      return new JsonResult(this.TCLIService_types);
+      return new JsonResult();
     }
   }
 }

--- a/lib/utils/HiveUtils.ts
+++ b/lib/utils/HiveUtils.ts
@@ -1,4 +1,4 @@
-import { TCLIServiceTypes, ProgressUpdateResponse } from '../hive/Types';
+import { ProgressUpdateResponse } from '../hive/Types';
 import IOperation from '../contracts/IOperation';
 import WaitUntilReady from './WaitUntilReady';
 import IOperationResult from '../result/IOperationResult';
@@ -6,20 +6,14 @@ import GetResult from './GetResult';
 import ProgressUpdateTransformer from './ProgressUpdateTransformer';
 
 export default class HiveUtils {
-  private TCLIService_types: TCLIServiceTypes;
-
-  constructor(TCLIService_types: TCLIServiceTypes) {
-    this.TCLIService_types = TCLIService_types;
-  }
-
   waitUntilReady(operation: IOperation, progress?: boolean, callback?: Function): Promise<IOperation> {
-    const waitUntilReady = new WaitUntilReady(operation, this.TCLIService_types);
+    const waitUntilReady = new WaitUntilReady(operation);
 
     return waitUntilReady.execute(progress, callback);
   }
 
   getResult(operation: IOperation, resultHandler?: IOperationResult): IOperationResult {
-    const getResult = new GetResult(operation, this.TCLIService_types);
+    const getResult = new GetResult(operation);
 
     return getResult.execute(resultHandler);
   }

--- a/lib/utils/WaitUntilReady.ts
+++ b/lib/utils/WaitUntilReady.ts
@@ -1,15 +1,13 @@
 import IOperation from '../contracts/IOperation';
-import { TCLIServiceTypes } from '../hive/Types';
+import TCLIService_types from '../../thrift/TCLIService_types';
 import { GetOperationStatusResponse } from '../hive/Commands/GetOperationStatusCommand';
 import OperationStateError from '../errors/OperationStateError';
 
 export default class WaitUntilReady {
   private operation: IOperation;
-  private TCLIService_types: TCLIServiceTypes;
 
-  constructor(operation: IOperation, TCLIService_types: TCLIServiceTypes) {
+  constructor(operation: IOperation) {
     this.operation = operation;
-    this.TCLIService_types = TCLIService_types;
   }
 
   /**
@@ -40,23 +38,23 @@ export default class WaitUntilReady {
 
   private isReady(response: GetOperationStatusResponse): boolean {
     switch (response.operationState) {
-      case this.TCLIService_types.TOperationState.INITIALIZED_STATE:
+      case TCLIService_types.TOperationState.INITIALIZED_STATE:
         return false;
-      case this.TCLIService_types.TOperationState.RUNNING_STATE:
+      case TCLIService_types.TOperationState.RUNNING_STATE:
         return false;
-      case this.TCLIService_types.TOperationState.FINISHED_STATE:
+      case TCLIService_types.TOperationState.FINISHED_STATE:
         return true;
-      case this.TCLIService_types.TOperationState.CANCELED_STATE:
+      case TCLIService_types.TOperationState.CANCELED_STATE:
         throw new OperationStateError('The operation was canceled by a client', response);
-      case this.TCLIService_types.TOperationState.CLOSED_STATE:
+      case TCLIService_types.TOperationState.CLOSED_STATE:
         throw new OperationStateError('The operation was closed by a client', response);
-      case this.TCLIService_types.TOperationState.ERROR_STATE:
+      case TCLIService_types.TOperationState.ERROR_STATE:
         throw new OperationStateError('The operation failed due to an error', response);
-      case this.TCLIService_types.TOperationState.PENDING_STATE:
+      case TCLIService_types.TOperationState.PENDING_STATE:
         throw new OperationStateError('The operation is in a pending state', response);
-      case this.TCLIService_types.TOperationState.TIMEDOUT_STATE:
+      case TCLIService_types.TOperationState.TIMEDOUT_STATE:
         throw new OperationStateError('The operation is in a timedout state', response);
-      case this.TCLIService_types.TOperationState.UKNOWN_STATE:
+      case TCLIService_types.TOperationState.UKNOWN_STATE:
       default:
         throw new OperationStateError('The operation is in an unrecognized state', response);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "mocha": "^10.0.0",
         "nyc": "^15.1.0",
         "prettier": "^2.7.1",
+        "sinon": "^14.0.0",
         "typescript": "^4.7.4"
       },
       "engines": {
@@ -527,6 +528,41 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
+      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
+      "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
     },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
@@ -1520,6 +1556,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1683,6 +1725,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -1702,6 +1750,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
+      "dev": true
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
     "node_modules/log-symbols": {
@@ -1852,6 +1906,19 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nise": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
+      "integrity": "sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": ">=5",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
       }
     },
     "node_modules/node-fetch": {
@@ -2167,6 +2234,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
+    },
     "node_modules/pathval": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
@@ -2428,6 +2504,36 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
+    },
+    "node_modules/sinon": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-14.0.0.tgz",
+      "integrity": "sha512-ugA6BFmE+WrJdh0owRZHToLd32Uw3Lxq6E6LtNRU+xTVBefx632h03Q7apXWRsRdZAJ41LB8aUfn2+O4jsDNMw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": "^9.1.2",
+        "@sinonjs/samsam": "^6.1.1",
+        "diff": "^5.0.0",
+        "nise": "^5.1.1",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -3254,6 +3360,41 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "@sinonjs/commons": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-9.1.2.tgz",
+      "integrity": "sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
+      "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -3975,6 +4116,12 @@
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
     },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -4099,6 +4246,12 @@
       "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
       "dev": true
     },
+    "just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -4112,6 +4265,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
     "log-symbols": {
@@ -4227,6 +4386,19 @@
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
       "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
       "dev": true
+    },
+    "nise": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
+      "integrity": "sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": ">=5",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
     },
     "node-fetch": {
       "version": "2.6.7",
@@ -4466,6 +4638,15 @@
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      }
+    },
     "pathval": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
@@ -4659,6 +4840,31 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
+    },
+    "sinon": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-14.0.0.tgz",
+      "integrity": "sha512-ugA6BFmE+WrJdh0owRZHToLd32Uw3Lxq6E6LtNRU+xTVBefx632h03Q7apXWRsRdZAJ41LB8aUfn2+O4jsDNMw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": "^9.1.2",
+        "@sinonjs/samsam": "^6.1.1",
+        "diff": "^5.0.0",
+        "nise": "^5.1.1",
+        "supports-color": "^7.2.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "mocha": "^10.0.0",
     "nyc": "^15.1.0",
     "prettier": "^2.7.1",
+    "sinon": "^14.0.0",
     "typescript": "^4.7.4"
   },
   "dependencies": {

--- a/tests/unit/HiveClient.test.js
+++ b/tests/unit/HiveClient.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const HiveClient = require('../../dist/HiveClient').default;
 const HiveSession = require('../../dist/HiveSession').default;
-const { TCLIService_types, TCLIService } = require('../../').thrift;
+const { TCLIService_types } = require('../../').thrift;
 const {
   auth: { NoSaslAuthentication },
   connections: { HttpConnection },
@@ -26,7 +26,7 @@ const ConnectionProviderMock = (connection) => ({
 
 describe('HiveClient.connect', () => {
   it('should set nosasl authenticator by default', () => {
-    const client = new HiveClient(TCLIService, TCLIService_types);
+    const client = new HiveClient();
     const connectionProvider = ConnectionProviderMock();
 
     return client.connect({}, connectionProvider).catch((error) => {
@@ -35,7 +35,7 @@ describe('HiveClient.connect', () => {
   });
 
   it('should handle network errors', (cb) => {
-    const client = new HiveClient(TCLIService, TCLIService_types);
+    const client = new HiveClient();
     client.thrift = {
       createClient() {},
     };
@@ -56,7 +56,7 @@ describe('HiveClient.connect', () => {
   });
 
   it('should use client auth provider', () => {
-    const client = new HiveClient(TCLIService, TCLIService_types);
+    const client = new HiveClient();
     client.thrift = {
       createClient() {},
     };
@@ -70,7 +70,7 @@ describe('HiveClient.connect', () => {
   });
 
   it('should use http connection by default', (cb) => {
-    const client = new HiveClient(TCLIService, TCLIService_types);
+    const client = new HiveClient();
     client.thrift = {
       createClient() {},
     };
@@ -87,7 +87,7 @@ describe('HiveClient.connect', () => {
 
 describe('HiveClient.openSession', () => {
   it('should successfully open session', () => {
-    const client = new HiveClient(TCLIService, TCLIService_types);
+    const client = new HiveClient();
     client.client = {
       OpenSession(req, cb) {
         cb(null, { status: {}, sessionHandle: {} });
@@ -108,7 +108,7 @@ describe('HiveClient.openSession', () => {
   });
 
   it('should throw an exception when the connection is lost', (done) => {
-    const client = new HiveClient(TCLIService, TCLIService_types);
+    const client = new HiveClient();
     client.connection = {
       isConnected() {
         return false;
@@ -128,14 +128,14 @@ describe('HiveClient.openSession', () => {
 
 describe('HiveClient.getClient', () => {
   it('should throw an error if the client is not set', () => {
-    const client = new HiveClient(TCLIService, TCLIService_types);
+    const client = new HiveClient();
     expect(() => client.getClient()).to.throw('HiveClient: client is not initialized');
   });
 });
 
 describe('HiveClient.close', () => {
   it('should close the connection if it was initiated', () => {
-    const client = new HiveClient(TCLIService, TCLIService_types);
+    const client = new HiveClient();
     let closed = false;
     client.connection = {
       getConnection: () => ({
@@ -149,13 +149,13 @@ describe('HiveClient.close', () => {
   });
 
   it('should do nothing if the connection does not exist', () => {
-    const client = new HiveClient(TCLIService, TCLIService_types);
+    const client = new HiveClient();
     client.close();
     expect(true).to.be.true;
   });
 
   it('should do nothing if the connection exists but cannot be finished', () => {
-    const client = new HiveClient(TCLIService, TCLIService_types);
+    const client = new HiveClient();
     client.connection = {
       getConnection: () => ({}),
     };

--- a/tests/unit/HiveSession.test.js
+++ b/tests/unit/HiveSession.test.js
@@ -17,7 +17,7 @@ const testMethod = (methodName, parameters, delegationToken) => {
         delegationToken,
       }),
   };
-  const session = new HiveSession(driver, { sessionId: 'id' }, TCLIService_types);
+  const session = new HiveSession(driver, { sessionId: 'id' });
 
   return session[methodName].apply(session, parameters);
 };
@@ -157,7 +157,7 @@ describe('HiveSession', () => {
           },
         }),
     };
-    const session = new HiveSession(driver, { sessionId: 'id' }, TCLIService_types);
+    const session = new HiveSession(driver, { sessionId: 'id' });
 
     return session.close().then((result) => {
       expect(result).instanceOf(Status);

--- a/tests/unit/factory/StatusFactory.test.js
+++ b/tests/unit/factory/StatusFactory.test.js
@@ -2,7 +2,7 @@ const { expect } = require('chai');
 const { TCLIService_types } = require('../../../').thrift;
 const StatusFactory = require('../../../dist/factory/StatusFactory').default;
 
-const statusFactory = new StatusFactory(TCLIService_types);
+const statusFactory = new StatusFactory();
 
 describe('StatusFactory', () => {
   it('should be success', () => {

--- a/tests/unit/hive/HiveDriver.test.js
+++ b/tests/unit/hive/HiveDriver.test.js
@@ -6,7 +6,7 @@ const toTitleCase = (str) => str[0].toUpperCase() + str.slice(1);
 
 const testCommand = (command, request) => {
   const client = {};
-  const driver = new HiveDriver(TCLIService_types, client);
+  const driver = new HiveDriver(client);
   const response = { response: 'value' };
   client[toTitleCase(command)] = function (req, cb) {
     expect(req).to.be.deep.eq(new TCLIService_types[`T${toTitleCase(command)}Req`](request));

--- a/tests/unit/hive/commands/CancelDelegationTokenCommand.test.js
+++ b/tests/unit/hive/commands/CancelDelegationTokenCommand.test.js
@@ -1,4 +1,6 @@
 const { expect } = require('chai');
+const sinon = require('sinon');
+const TCLIService_types = require('../../../../thrift/TCLIService_types');
 const CancelDelegationTokenCommand = require('../../../../dist/hive/Commands/CancelDelegationTokenCommand').default;
 
 const requestMock = {
@@ -8,17 +10,16 @@ const requestMock = {
   delegationToken: 'token',
 };
 
-const TCLIService_types = {
-  TCancelDelegationTokenReq: function (options) {
-    this.options = options;
-
-    expect(options).to.be.deep.eq(requestMock);
-  },
-};
-
 const responseMock = {
   status: { statusCode: 0 },
 };
+
+function TCancelDelegationTokenReqMock(options) {
+  this.options = options;
+
+  expect(options).to.be.deep.eq(requestMock);
+}
+
 const thriftClientMock = {
   CancelDelegationToken(request, callback) {
     return callback(null, responseMock);
@@ -26,8 +27,19 @@ const thriftClientMock = {
 };
 
 describe('CancelDelegationTokenCommand', () => {
+  let sandbox;
+
+  before(() => {
+    sandbox = sinon.createSandbox();
+    sandbox.replace(TCLIService_types, 'TCancelDelegationTokenReq', TCancelDelegationTokenReqMock);
+  });
+
+  after(() => {
+    sandbox.restore();
+  });
+
   it('should return response', (cb) => {
-    const command = new CancelDelegationTokenCommand(thriftClientMock, TCLIService_types);
+    const command = new CancelDelegationTokenCommand(thriftClientMock);
 
     command
       .execute(requestMock)

--- a/tests/unit/hive/commands/CancelOperationCommand.test.js
+++ b/tests/unit/hive/commands/CancelOperationCommand.test.js
@@ -1,4 +1,6 @@
 const { expect } = require('chai');
+const sinon = require('sinon');
+const TCLIService_types = require('../../../../thrift/TCLIService_types');
 const CancelOperationCommand = require('../../../../dist/hive/Commands/CancelOperationCommand').default;
 
 const requestMock = {
@@ -10,17 +12,16 @@ const requestMock = {
   },
 };
 
-const TCLIService_types = {
-  TCancelOperationReq: function (options) {
-    this.options = options;
-
-    expect(options).to.be.deep.eq(requestMock);
-  },
-};
-
 const responseMock = {
   status: { statusCode: 0 },
 };
+
+function TCancelOperationReqMock(options) {
+  this.options = options;
+
+  expect(options).to.be.deep.eq(requestMock);
+}
+
 const thriftClientMock = {
   CancelOperation(request, callback) {
     return callback(null, responseMock);
@@ -28,8 +29,19 @@ const thriftClientMock = {
 };
 
 describe('CancelOperationCommand', () => {
+  let sandbox;
+
+  before(() => {
+    sandbox = sinon.createSandbox();
+    sandbox.replace(TCLIService_types, 'TCancelOperationReq', TCancelOperationReqMock);
+  });
+
+  after(() => {
+    sandbox.restore();
+  });
+
   it('should return response', (cb) => {
-    const command = new CancelOperationCommand(thriftClientMock, TCLIService_types);
+    const command = new CancelOperationCommand(thriftClientMock);
 
     command
       .execute(requestMock)

--- a/tests/unit/hive/commands/CloseOperationCommand.test.js
+++ b/tests/unit/hive/commands/CloseOperationCommand.test.js
@@ -1,4 +1,6 @@
 const { expect } = require('chai');
+const sinon = require('sinon');
+const TCLIService_types = require('../../../../thrift/TCLIService_types');
 const CloseOperationCommand = require('../../../../dist/hive/Commands/CloseOperationCommand').default;
 
 const requestMock = {
@@ -10,17 +12,16 @@ const requestMock = {
   },
 };
 
-const TCLIService_types = {
-  TCloseOperationReq: function (options) {
-    this.options = options;
-
-    expect(options).to.be.deep.eq(requestMock);
-  },
-};
-
 const responseMock = {
   status: { statusCode: 0 },
 };
+
+function TCloseOperationReqMock(options) {
+  this.options = options;
+
+  expect(options).to.be.deep.eq(requestMock);
+}
+
 const thriftClientMock = {
   CloseOperation(request, callback) {
     return callback(null, responseMock);
@@ -28,8 +29,19 @@ const thriftClientMock = {
 };
 
 describe('CloseOperationCommand', () => {
+  let sandbox;
+
+  before(() => {
+    sandbox = sinon.createSandbox();
+    sandbox.replace(TCLIService_types, 'TCloseOperationReq', TCloseOperationReqMock);
+  });
+
+  after(() => {
+    sandbox.restore();
+  });
+
   it('should return response', (cb) => {
-    const command = new CloseOperationCommand(thriftClientMock, TCLIService_types);
+    const command = new CloseOperationCommand(thriftClientMock);
 
     command
       .execute(requestMock)

--- a/tests/unit/hive/commands/CloseSessionCommand.test.js
+++ b/tests/unit/hive/commands/CloseSessionCommand.test.js
@@ -1,16 +1,18 @@
 const { expect } = require('chai');
+const sinon = require('sinon');
+const TCLIService_types = require('../../../../thrift/TCLIService_types');
 const CloseSessionCommand = require('../../../../dist/hive/Commands/CloseSessionCommand').default;
 
-const TCLIService_types = {
-  TCloseSessionReq: function (options) {
-    this.options = options;
-
-    expect(options).has.property('sessionHandle');
-  },
-};
 const responseMock = {
   status: { statusCode: 0 },
 };
+
+function TCloseSessionReqMock(options) {
+  this.options = options;
+
+  expect(options).has.property('sessionHandle');
+}
+
 const thriftClientMock = {
   CloseSession(request, callback) {
     return callback(null, responseMock);
@@ -18,8 +20,19 @@ const thriftClientMock = {
 };
 
 describe('CloseSessionCommand', () => {
+  let sandbox;
+
+  before(() => {
+    sandbox = sinon.createSandbox();
+    sandbox.replace(TCLIService_types, 'TCloseSessionReq', TCloseSessionReqMock);
+  });
+
+  after(() => {
+    sandbox.restore();
+  });
+
   it('should return response', (cb) => {
-    const command = new CloseSessionCommand(thriftClientMock, TCLIService_types);
+    const command = new CloseSessionCommand(thriftClientMock);
 
     command
       .execute({

--- a/tests/unit/hive/commands/FetchResultsCommand.test.js
+++ b/tests/unit/hive/commands/FetchResultsCommand.test.js
@@ -1,4 +1,6 @@
 const { expect } = require('chai');
+const sinon = require('sinon');
+const TCLIService_types = require('../../../../thrift/TCLIService_types');
 const FetchResultsCommand = require('../../../../dist/hive/Commands/FetchResultsCommand').default;
 
 const requestMock = {
@@ -8,14 +10,6 @@ const requestMock = {
   orientation: 0,
   maxRows: 100,
   fetchType: 0,
-};
-
-const TCLIService_types = {
-  TFetchResultsReq: function (options) {
-    this.options = options;
-
-    expect(options).to.be.deep.eq(requestMock);
-  },
 };
 
 const responseMock = {
@@ -40,6 +34,13 @@ const responseMock = {
     columnCount: 2,
   },
 };
+
+function TFetchResultsReqMock(options) {
+  this.options = options;
+
+  expect(options).to.be.deep.eq(requestMock);
+}
+
 const thriftClientMock = {
   FetchResults(request, callback) {
     return callback(null, responseMock);
@@ -47,8 +48,19 @@ const thriftClientMock = {
 };
 
 describe('FetchResultsCommand', () => {
+  let sandbox;
+
+  before(() => {
+    sandbox = sinon.createSandbox();
+    sandbox.replace(TCLIService_types, 'TFetchResultsReq', TFetchResultsReqMock);
+  });
+
+  after(() => {
+    sandbox.restore();
+  });
+
   it('should return response', (cb) => {
-    const command = new FetchResultsCommand(thriftClientMock, TCLIService_types);
+    const command = new FetchResultsCommand(thriftClientMock);
 
     command
       .execute(requestMock)

--- a/tests/unit/hive/commands/GetCatalogsCommand.test.js
+++ b/tests/unit/hive/commands/GetCatalogsCommand.test.js
@@ -1,17 +1,11 @@
 const { expect } = require('chai');
+const sinon = require('sinon');
+const TCLIService_types = require('../../../../thrift/TCLIService_types');
 const GetCatalogsCommand = require('../../../../dist/hive/Commands/GetCatalogsCommand').default;
 
 const requestMock = {
   sessionHandle: {
     sessionId: { guid: '', secret: '' },
-  },
-};
-
-const TCLIService_types = {
-  TGetCatalogsReq: function (options) {
-    this.options = options;
-
-    expect(options).to.be.deep.eq(requestMock);
   },
 };
 
@@ -26,6 +20,13 @@ const responseMock = {
     modifiedRowCount: 0,
   },
 };
+
+function TGetCatalogsReqMock(options) {
+  this.options = options;
+
+  expect(options).to.be.deep.eq(requestMock);
+}
+
 const thriftClientMock = {
   GetCatalogs(request, callback) {
     return callback(null, responseMock);
@@ -33,8 +34,19 @@ const thriftClientMock = {
 };
 
 describe('GetCatalogsCommand', () => {
+  let sandbox;
+
+  before(() => {
+    sandbox = sinon.createSandbox();
+    sandbox.replace(TCLIService_types, 'TGetCatalogsReq', TGetCatalogsReqMock);
+  });
+
+  after(() => {
+    sandbox.restore();
+  });
+
   it('should return response', (cb) => {
-    const command = new GetCatalogsCommand(thriftClientMock, TCLIService_types);
+    const command = new GetCatalogsCommand(thriftClientMock);
 
     command
       .execute(requestMock)

--- a/tests/unit/hive/commands/GetColumnsCommand.test.js
+++ b/tests/unit/hive/commands/GetColumnsCommand.test.js
@@ -1,17 +1,11 @@
 const { expect } = require('chai');
+const sinon = require('sinon');
+const TCLIService_types = require('../../../../thrift/TCLIService_types');
 const GetColumnsCommand = require('../../../../dist/hive/Commands/GetColumnsCommand').default;
 
 const requestMock = {
   sessionHandle: {
     sessionId: { guid: '', secret: '' },
-  },
-};
-
-const TCLIService_types = {
-  TGetColumnsReq: function (options) {
-    this.options = options;
-
-    expect(options).to.be.deep.eq(requestMock);
   },
 };
 
@@ -26,6 +20,13 @@ const responseMock = {
     modifiedRowCount: 0,
   },
 };
+
+function TGetColumnsReqMock(options) {
+  this.options = options;
+
+  expect(options).to.be.deep.eq(requestMock);
+}
+
 const thriftClientMock = {
   GetColumns(request, callback) {
     return callback(null, responseMock);
@@ -33,8 +34,19 @@ const thriftClientMock = {
 };
 
 describe('GetColumnsCommand', () => {
+  let sandbox;
+
+  before(() => {
+    sandbox = sinon.createSandbox();
+    sandbox.replace(TCLIService_types, 'TGetColumnsReq', TGetColumnsReqMock);
+  });
+
+  after(() => {
+    sandbox.restore();
+  });
+
   it('should return response', (cb) => {
-    const command = new GetColumnsCommand(thriftClientMock, TCLIService_types);
+    const command = new GetColumnsCommand(thriftClientMock);
 
     command
       .execute(requestMock)

--- a/tests/unit/hive/commands/GetCrossReferenceCommand.test.js
+++ b/tests/unit/hive/commands/GetCrossReferenceCommand.test.js
@@ -1,4 +1,6 @@
 const { expect } = require('chai');
+const sinon = require('sinon');
+const TCLIService_types = require('../../../../thrift/TCLIService_types');
 const GetCrossReferenceCommand = require('../../../../dist/hive/Commands/GetCrossReferenceCommand').default;
 
 const requestMock = {
@@ -13,14 +15,6 @@ const requestMock = {
   foreignTableName: 'foreignTableName',
 };
 
-const TCLIService_types = {
-  TGetCrossReferenceReq: function (options) {
-    this.options = options;
-
-    expect(options).to.be.deep.eq(requestMock);
-  },
-};
-
 const GET_CROSS_REFERENCE = 7;
 
 const responseMock = {
@@ -32,6 +26,13 @@ const responseMock = {
     modifiedRowCount: 0,
   },
 };
+
+function TGetCrossReferenceReqMock(options) {
+  this.options = options;
+
+  expect(options).to.be.deep.eq(requestMock);
+}
+
 const thriftClientMock = {
   GetCrossReference(request, callback) {
     return callback(null, responseMock);
@@ -39,8 +40,19 @@ const thriftClientMock = {
 };
 
 describe('GetCrossReferenceCommand', () => {
+  let sandbox;
+
+  before(() => {
+    sandbox = sinon.createSandbox();
+    sandbox.replace(TCLIService_types, 'TGetCrossReferenceReq', TGetCrossReferenceReqMock);
+  });
+
+  after(() => {
+    sandbox.restore();
+  });
+
   it('should return response', (cb) => {
-    const command = new GetCrossReferenceCommand(thriftClientMock, TCLIService_types);
+    const command = new GetCrossReferenceCommand(thriftClientMock);
 
     command
       .execute(requestMock)

--- a/tests/unit/hive/commands/GetFunctionsCommand.test.js
+++ b/tests/unit/hive/commands/GetFunctionsCommand.test.js
@@ -1,17 +1,11 @@
 const { expect } = require('chai');
+const sinon = require('sinon');
+const TCLIService_types = require('../../../../thrift/TCLIService_types');
 const GetFunctionsCommand = require('../../../../dist/hive/Commands/GetFunctionsCommand').default;
 
 const requestMock = {
   sessionHandle: {
     sessionId: { guid: '', secret: '' },
-  },
-};
-
-const TCLIService_types = {
-  TGetFunctionsReq: function (options) {
-    this.options = options;
-
-    expect(options).to.be.deep.eq(requestMock);
   },
 };
 
@@ -26,6 +20,13 @@ const responseMock = {
     modifiedRowCount: 0,
   },
 };
+
+function TGetFunctionsReqMock(options) {
+  this.options = options;
+
+  expect(options).to.be.deep.eq(requestMock);
+}
+
 const thriftClientMock = {
   GetFunctions(request, callback) {
     return callback(null, responseMock);
@@ -33,8 +34,19 @@ const thriftClientMock = {
 };
 
 describe('GetFunctionsCommand', () => {
+  let sandbox;
+
+  before(() => {
+    sandbox = sinon.createSandbox();
+    sandbox.replace(TCLIService_types, 'TGetFunctionsReq', TGetFunctionsReqMock);
+  });
+
+  after(() => {
+    sandbox.restore();
+  });
+
   it('should return response', (cb) => {
-    const command = new GetFunctionsCommand(thriftClientMock, TCLIService_types);
+    const command = new GetFunctionsCommand(thriftClientMock);
 
     command
       .execute(requestMock)

--- a/tests/unit/hive/commands/GetInfoCommand.test.js
+++ b/tests/unit/hive/commands/GetInfoCommand.test.js
@@ -1,4 +1,6 @@
 const { expect } = require('chai');
+const sinon = require('sinon');
+const TCLIService_types = require('../../../../thrift/TCLIService_types');
 const GetInfoCommand = require('../../../../dist/hive/Commands/GetInfoCommand').default;
 
 const requestMock = {
@@ -6,14 +8,6 @@ const requestMock = {
     sessionId: { guid: '', secret: '' },
   },
   infoType: 0,
-};
-
-const TCLIService_types = {
-  TGetInfoReq: function (options) {
-    this.options = options;
-
-    expect(options).to.be.deep.eq(requestMock);
-  },
 };
 
 const responseMock = {
@@ -27,6 +21,13 @@ const responseMock = {
     lenValue: Buffer.from([]),
   },
 };
+
+function TGetInfoReqMock(options) {
+  this.options = options;
+
+  expect(options).to.be.deep.eq(requestMock);
+}
+
 const thriftClientMock = {
   GetInfo(request, callback) {
     return callback(null, responseMock);
@@ -34,8 +35,19 @@ const thriftClientMock = {
 };
 
 describe('GetInfoCommand', () => {
+  let sandbox;
+
+  before(() => {
+    sandbox = sinon.createSandbox();
+    sandbox.replace(TCLIService_types, 'TGetInfoReq', TGetInfoReqMock);
+  });
+
+  after(() => {
+    sandbox.restore();
+  });
+
   it('should return response', (cb) => {
-    const command = new GetInfoCommand(thriftClientMock, TCLIService_types);
+    const command = new GetInfoCommand(thriftClientMock);
 
     command
       .execute(requestMock)

--- a/tests/unit/hive/commands/GetPrimaryKeysCommand.test.js
+++ b/tests/unit/hive/commands/GetPrimaryKeysCommand.test.js
@@ -1,17 +1,11 @@
 const { expect } = require('chai');
+const sinon = require('sinon');
+const TCLIService_types = require('../../../../thrift/TCLIService_types');
 const GetPrimaryKeysCommand = require('../../../../dist/hive/Commands/GetPrimaryKeysCommand').default;
 
 const requestMock = {
   sessionHandle: {
     sessionId: { guid: '', secret: '' },
-  },
-};
-
-const TCLIService_types = {
-  TGetPrimaryKeysReq: function (options) {
-    this.options = options;
-
-    expect(options).to.be.deep.eq(requestMock);
   },
 };
 
@@ -26,6 +20,13 @@ const responseMock = {
     modifiedRowCount: 0,
   },
 };
+
+function TGetPrimaryKeysReqMock(options) {
+  this.options = options;
+
+  expect(options).to.be.deep.eq(requestMock);
+}
+
 const thriftClientMock = {
   GetPrimaryKeys(request, callback) {
     return callback(null, responseMock);
@@ -33,8 +34,19 @@ const thriftClientMock = {
 };
 
 describe('GetPrimaryKeysCommand', () => {
+  let sandbox;
+
+  before(() => {
+    sandbox = sinon.createSandbox();
+    sandbox.replace(TCLIService_types, 'TGetPrimaryKeysReq', TGetPrimaryKeysReqMock);
+  });
+
+  after(() => {
+    sandbox.restore();
+  });
+
   it('should return response', (cb) => {
-    const command = new GetPrimaryKeysCommand(thriftClientMock, TCLIService_types);
+    const command = new GetPrimaryKeysCommand(thriftClientMock);
 
     command
       .execute(requestMock)

--- a/tests/unit/hive/commands/GetResultSetMetadataCommand.test.js
+++ b/tests/unit/hive/commands/GetResultSetMetadataCommand.test.js
@@ -1,17 +1,11 @@
 const { expect } = require('chai');
+const sinon = require('sinon');
+const TCLIService_types = require('../../../../thrift/TCLIService_types');
 const GetResultSetMetadataCommand = require('../../../../dist/hive/Commands/GetResultSetMetadataCommand').default;
 
 const requestMock = {
   operationHandle: {
     sessionId: { guid: '', secret: '' },
-  },
-};
-
-const TCLIService_types = {
-  TGetResultSetMetadataReq: function (options) {
-    this.options = options;
-
-    expect(options).to.be.deep.eq(requestMock);
   },
 };
 
@@ -34,6 +28,13 @@ const responseMock = {
     ],
   },
 };
+
+function TGetResultSetMetadataReqMock(options) {
+  this.options = options;
+
+  expect(options).to.be.deep.eq(requestMock);
+}
+
 const thriftClientMock = {
   GetResultSetMetadata(request, callback) {
     return callback(null, responseMock);
@@ -41,8 +42,19 @@ const thriftClientMock = {
 };
 
 describe('GetResultSetMetadataCommand', () => {
+  let sandbox;
+
+  before(() => {
+    sandbox = sinon.createSandbox();
+    sandbox.replace(TCLIService_types, 'TGetResultSetMetadataReq', TGetResultSetMetadataReqMock);
+  });
+
+  after(() => {
+    sandbox.restore();
+  });
+
   it('should return response', (cb) => {
-    const command = new GetResultSetMetadataCommand(thriftClientMock, TCLIService_types);
+    const command = new GetResultSetMetadataCommand(thriftClientMock);
 
     command
       .execute(requestMock)

--- a/tests/unit/hive/commands/GetSchemasCommand.test.js
+++ b/tests/unit/hive/commands/GetSchemasCommand.test.js
@@ -1,4 +1,6 @@
 const { expect } = require('chai');
+const sinon = require('sinon');
+const TCLIService_types = require('../../../../thrift/TCLIService_types');
 const GetSchemasCommand = require('../../../../dist/hive/Commands/GetSchemasCommand').default;
 
 const requestMock = {
@@ -7,14 +9,6 @@ const requestMock = {
   },
   catalogName: 'catalog',
   schemaName: 'schema',
-};
-
-const TCLIService_types = {
-  TGetSchemasReq: function (options) {
-    this.options = options;
-
-    expect(options).to.be.deep.eq(requestMock);
-  },
 };
 
 const GET_SCHEMAS = 3;
@@ -28,6 +22,13 @@ const responseMock = {
     modifiedRowCount: 0,
   },
 };
+
+function TGetSchemasReqMock(options) {
+  this.options = options;
+
+  expect(options).to.be.deep.eq(requestMock);
+}
+
 const thriftClientMock = {
   GetSchemas(request, callback) {
     return callback(null, responseMock);
@@ -35,8 +36,19 @@ const thriftClientMock = {
 };
 
 describe('GetSchemasCommand', () => {
+  let sandbox;
+
+  before(() => {
+    sandbox = sinon.createSandbox();
+    sandbox.replace(TCLIService_types, 'TGetSchemasReq', TGetSchemasReqMock);
+  });
+
+  after(() => {
+    sandbox.restore();
+  });
+
   it('should return response', (cb) => {
-    const command = new GetSchemasCommand(thriftClientMock, TCLIService_types);
+    const command = new GetSchemasCommand(thriftClientMock);
 
     command
       .execute(requestMock)

--- a/tests/unit/hive/commands/GetTableTypesCommand.test.js
+++ b/tests/unit/hive/commands/GetTableTypesCommand.test.js
@@ -1,17 +1,11 @@
 const { expect } = require('chai');
+const sinon = require('sinon');
+const TCLIService_types = require('../../../../thrift/TCLIService_types');
 const GetTableTypesCommand = require('../../../../dist/hive/Commands/GetTableTypesCommand').default;
 
 const requestMock = {
   sessionHandle: {
     sessionId: { guid: '', secret: '' },
-  },
-};
-
-const TCLIService_types = {
-  TGetTableTypesReq: function (options) {
-    this.options = options;
-
-    expect(options).to.be.deep.eq(requestMock);
   },
 };
 
@@ -26,6 +20,13 @@ const responseMock = {
     modifiedRowCount: 0,
   },
 };
+
+function TGetTableTypesReqMock(options) {
+  this.options = options;
+
+  expect(options).to.be.deep.eq(requestMock);
+}
+
 const thriftClientMock = {
   GetTableTypes(request, callback) {
     return callback(null, responseMock);
@@ -33,8 +34,19 @@ const thriftClientMock = {
 };
 
 describe('GetTableTypesCommand', () => {
+  let sandbox;
+
+  before(() => {
+    sandbox = sinon.createSandbox();
+    sandbox.replace(TCLIService_types, 'TGetTableTypesReq', TGetTableTypesReqMock);
+  });
+
+  after(() => {
+    sandbox.restore();
+  });
+
   it('should return response', (cb) => {
-    const command = new GetTableTypesCommand(thriftClientMock, TCLIService_types);
+    const command = new GetTableTypesCommand(thriftClientMock);
 
     command
       .execute(requestMock)

--- a/tests/unit/hive/commands/GetTypeInfoCommand.test.js
+++ b/tests/unit/hive/commands/GetTypeInfoCommand.test.js
@@ -1,17 +1,11 @@
 const { expect } = require('chai');
+const sinon = require('sinon');
+const TCLIService_types = require('../../../../thrift/TCLIService_types');
 const GetTypeInfoCommand = require('../../../../dist/hive/Commands/GetTypeInfoCommand').default;
 
 const requestMock = {
   sessionHandle: {
     sessionId: { guid: '', secret: '' },
-  },
-};
-
-const TCLIService_types = {
-  TGetTypeInfoReq: function (options) {
-    this.options = options;
-
-    expect(options).to.be.deep.eq(requestMock);
   },
 };
 
@@ -26,6 +20,13 @@ const responseMock = {
     modifiedRowCount: 0,
   },
 };
+
+function TGetTypeInfoReqMock(options) {
+  this.options = options;
+
+  expect(options).to.be.deep.eq(requestMock);
+}
+
 const thriftClientMock = {
   GetTypeInfo(request, callback) {
     return callback(null, responseMock);
@@ -33,8 +34,19 @@ const thriftClientMock = {
 };
 
 describe('GetTypeInfoCommand', () => {
+  let sandbox;
+
+  before(() => {
+    sandbox = sinon.createSandbox();
+    sandbox.replace(TCLIService_types, 'TGetTypeInfoReq', TGetTypeInfoReqMock);
+  });
+
+  after(() => {
+    sandbox.restore();
+  });
+
   it('should return response', (cb) => {
-    const command = new GetTypeInfoCommand(thriftClientMock, TCLIService_types);
+    const command = new GetTypeInfoCommand(thriftClientMock);
 
     command
       .execute(requestMock)

--- a/tests/unit/hive/commands/RenewDelegationTokenCommand.test.js
+++ b/tests/unit/hive/commands/RenewDelegationTokenCommand.test.js
@@ -1,4 +1,6 @@
 const { expect } = require('chai');
+const sinon = require('sinon');
+const TCLIService_types = require('../../../../thrift/TCLIService_types');
 const RenewDelegationTokenCommand = require('../../../../dist/hive/Commands/RenewDelegationTokenCommand').default;
 
 const requestMock = {
@@ -8,17 +10,16 @@ const requestMock = {
   delegationToken: 'token',
 };
 
-const TCLIService_types = {
-  TRenewDelegationTokenReq: function (options) {
-    this.options = options;
-
-    expect(options).to.be.deep.eq(requestMock);
-  },
-};
-
 const responseMock = {
   status: { statusCode: 0 },
 };
+
+function TRenewDelegationTokenReqMock(options) {
+  this.options = options;
+
+  expect(options).to.be.deep.eq(requestMock);
+}
+
 const thriftClientMock = {
   RenewDelegationToken(request, callback) {
     return callback(null, responseMock);
@@ -26,8 +27,19 @@ const thriftClientMock = {
 };
 
 describe('RenewDelegationTokenCommand', () => {
+  let sandbox;
+
+  before(() => {
+    sandbox = sinon.createSandbox();
+    sandbox.replace(TCLIService_types, 'TRenewDelegationTokenReq', TRenewDelegationTokenReqMock);
+  });
+
+  after(() => {
+    sandbox.restore();
+  });
+
   it('should return response', (cb) => {
-    const command = new RenewDelegationTokenCommand(thriftClientMock, TCLIService_types);
+    const command = new RenewDelegationTokenCommand(thriftClientMock);
 
     command
       .execute(requestMock)

--- a/tests/unit/result/JsonResult.test.js
+++ b/tests/unit/result/JsonResult.test.js
@@ -101,7 +101,7 @@ describe('JsonResult', () => {
       },
     ];
 
-    const result = new JsonResult(TCLIService_types);
+    const result = new JsonResult();
     result.setOperation({
       getSchema: () => schema,
       getData: () => data,
@@ -175,7 +175,7 @@ describe('JsonResult', () => {
       },
     ];
 
-    const result = new JsonResult(TCLIService_types);
+    const result = new JsonResult();
     result.setOperation({
       getSchema: () => schema,
       getData: () => data,
@@ -218,7 +218,7 @@ describe('JsonResult', () => {
       },
     ];
 
-    const result = new JsonResult(TCLIService_types);
+    const result = new JsonResult();
     result.setOperation({
       getSchema: () => schema,
       getData: () => data,
@@ -228,7 +228,7 @@ describe('JsonResult', () => {
   });
 
   it('should detect nulls', () => {
-    const result = new JsonResult(TCLIService_types);
+    const result = new JsonResult();
     const buf = Buffer.from([0x55, 0xaa, 0xc3]);
 
     [
@@ -340,7 +340,7 @@ describe('JsonResult', () => {
       },
     ];
 
-    const result = new JsonResult(TCLIService_types);
+    const result = new JsonResult();
     result.setOperation({
       getSchema: () => schema,
       getData: () => data,

--- a/tests/unit/utils/HiveUtils.test.js
+++ b/tests/unit/utils/HiveUtils.test.js
@@ -1,7 +1,6 @@
 const { expect } = require('chai');
 const HiveUtils = require('../../../dist/utils/HiveUtils').default;
 const NullResult = require('../../../dist/result/NullResult').default;
-const { TCLIService_types } = require('../../../').thrift;
 
 describe('HiveUtils', () => {
   it('waitUntilReady', () => {
@@ -11,7 +10,7 @@ describe('HiveUtils', () => {
           operationState: 2,
         }),
     };
-    const utils = new HiveUtils(TCLIService_types);
+    const utils = new HiveUtils();
     let executed = false;
 
     return utils
@@ -25,7 +24,7 @@ describe('HiveUtils', () => {
   });
 
   it('getResult', () => {
-    const utils = new HiveUtils(TCLIService_types);
+    const utils = new HiveUtils();
     const result = utils.getResult({
       getSchema: () => null,
     });
@@ -33,7 +32,7 @@ describe('HiveUtils', () => {
   });
 
   it('fetchAll', () => {
-    const utils = new HiveUtils(TCLIService_types);
+    const utils = new HiveUtils();
     const operation = {
       n: 0,
       _hasMoreRows: true,
@@ -53,7 +52,7 @@ describe('HiveUtils', () => {
   });
 
   it('formatProgress', () => {
-    const utils = new HiveUtils(TCLIService_types);
+    const utils = new HiveUtils();
     const result = utils.formatProgress({
       headerNames: [],
       rows: [],

--- a/tests/unit/utils/WaitUntilReady.test.js
+++ b/tests/unit/utils/WaitUntilReady.test.js
@@ -15,7 +15,7 @@ const operation = (state) => ({
 describe('WaitUntilReady', () => {
   it('should return operation when state is finished', (cb) => {
     const op = operation(TCLIService_types.TOperationState.FINISHED_STATE);
-    const waitUntilReady = new WaitUntilReady(op, TCLIService_types);
+    const waitUntilReady = new WaitUntilReady(op);
 
     waitUntilReady
       .execute()
@@ -28,7 +28,7 @@ describe('WaitUntilReady', () => {
 
   it('should call callback until state is not finished', (cb) => {
     const op = operation(TCLIService_types.TOperationState.INITIALIZED_STATE);
-    const waitUntilReady = new WaitUntilReady(op, TCLIService_types);
+    const waitUntilReady = new WaitUntilReady(op);
     let states = [
       TCLIService_types.TOperationState.INITIALIZED_STATE,
       TCLIService_types.TOperationState.RUNNING_STATE,
@@ -49,7 +49,7 @@ describe('WaitUntilReady', () => {
 
   it('should throw error if state is invalid', () => {
     const execute = (state) => {
-      const waitUntilReady = new WaitUntilReady(operation(state), TCLIService_types);
+      const waitUntilReady = new WaitUntilReady(operation(state));
       return waitUntilReady.execute();
     };
 
@@ -83,7 +83,7 @@ describe('WaitUntilReady', () => {
 
   it('should wait until callback is finished', () => {
     const op = operation(TCLIService_types.TOperationState.INITIALIZED_STATE);
-    const waitUntilReady = new WaitUntilReady(op, TCLIService_types);
+    const waitUntilReady = new WaitUntilReady(op);
     let i = 0;
 
     return waitUntilReady


### PR DESCRIPTION
Intermediate step: import thrift files directly instead of injecting instances into every class (and drilling them down through the whole hierarchy). This simplifies library API and will help to improve type-checking (in next PR of the batch)
