### PR TITLE
[PECO-222] Update Thrift definitions (part 3)

### DIFF
--- a/lib/HiveClient.ts
+++ b/lib/HiveClient.ts
@@ -1,6 +1,5 @@
 const thrift = require('thrift');
 
-import { ThriftClient } from './hive/Types/';
 import TCLIService from '../thrift/TCLIService';
 import { TOpenSessionReq } from '../thrift/TCLIService_types';
 import IHiveClient from './contracts/IHiveClient';
@@ -19,7 +18,7 @@ import HiveDriverError from './errors/HiveDriverError';
 import { definedOrError } from './utils';
 
 export default class HiveClient extends EventEmitter implements IHiveClient {
-  private client: ThriftClient | null;
+  private client: TCLIService.Client | null;
   private connection: IThriftConnection | null;
   private statusFactory: StatusFactory;
   private connectionProvider: IConnectionProvider;
@@ -94,7 +93,7 @@ export default class HiveClient extends EventEmitter implements IHiveClient {
     });
   }
 
-  getClient(): ThriftClient {
+  getClient() {
     if (!this.client) {
       throw new HiveDriverError('HiveClient: client is not initialized');
     }

--- a/lib/HiveClient.ts
+++ b/lib/HiveClient.ts
@@ -2,9 +2,9 @@ const thrift = require('thrift');
 
 import { ThriftClient } from './hive/Types/';
 import TCLIService from '../thrift/TCLIService';
+import { TOpenSessionReq } from '../thrift/TCLIService_types';
 import IHiveClient from './contracts/IHiveClient';
 import HiveDriver from './hive/HiveDriver';
-import { OpenSessionRequest, OpenSessionResponse } from './hive/Commands/OpenSessionCommand';
 import HiveSession from './HiveSession';
 import IHiveSession from './contracts/IHiveSession';
 import IThriftConnection from './connection/contracts/IThriftConnection';
@@ -16,6 +16,7 @@ import IConnectionOptions from './connection/contracts/IConnectionOptions';
 import { EventEmitter } from 'events';
 import StatusFactory from './factory/StatusFactory';
 import HiveDriverError from './errors/HiveDriverError';
+import { definedOrError } from './utils';
 
 export default class HiveClient extends EventEmitter implements IHiveClient {
   private client: ThriftClient | null;
@@ -77,17 +78,17 @@ export default class HiveClient extends EventEmitter implements IHiveClient {
    * @param request
    * @throws {StatusError}
    */
-  openSession(request: OpenSessionRequest): Promise<IHiveSession> {
+  openSession(request: TOpenSessionReq): Promise<IHiveSession> {
     if (!this.connection?.isConnected()) {
       return Promise.reject(new HiveDriverError('HiveClient: connection is lost'));
     }
 
     const driver = new HiveDriver(this.getClient());
 
-    return driver.openSession(request).then((response: OpenSessionResponse) => {
+    return driver.openSession(request).then((response) => {
       this.statusFactory.create(response.status);
 
-      const session = new HiveSession(driver, response.sessionHandle);
+      const session = new HiveSession(driver, definedOrError(response.sessionHandle));
 
       return session;
     });

--- a/lib/HiveSession.ts
+++ b/lib/HiveSession.ts
@@ -1,3 +1,4 @@
+import { TSessionHandle, TStatus, TOperationHandle } from '../thrift/TCLIService_types';
 import HiveDriver from './hive/HiveDriver';
 import IHiveSession, {
   ExecuteStatementOptions,
@@ -8,20 +9,19 @@ import IHiveSession, {
   FunctionNameRequest,
   CrossReferenceRequest,
 } from './contracts/IHiveSession';
-import { SessionHandle, Status as TStatus, OperationHandle } from './hive/Types';
-import { ExecuteStatementResponse } from './hive/Commands/ExecuteStatementCommand';
 import IOperation from './contracts/IOperation';
 import HiveOperation from './HiveOperation';
 import Status from './dto/Status';
 import StatusFactory from './factory/StatusFactory';
 import InfoValue from './dto/InfoValue';
+import { definedOrError } from './utils';
 
 export default class HiveSession implements IHiveSession {
   private driver: HiveDriver;
-  private sessionHandle: SessionHandle;
+  private sessionHandle: TSessionHandle;
   private statusFactory: StatusFactory;
 
-  constructor(driver: HiveDriver, sessionHandle: SessionHandle) {
+  constructor(driver: HiveDriver, sessionHandle: TSessionHandle) {
     this.driver = driver;
     this.sessionHandle = sessionHandle;
     this.statusFactory = new StatusFactory();
@@ -52,10 +52,10 @@ export default class HiveSession implements IHiveSession {
         statement,
         ...options,
       })
-      .then((response: ExecuteStatementResponse) => {
+      .then((response) => {
         this.assertStatus(response.status);
 
-        return this.createOperation(response.operationHandle);
+        return this.createOperation(definedOrError(response.operationHandle));
       });
   }
 
@@ -67,7 +67,7 @@ export default class HiveSession implements IHiveSession {
       .then((response) => {
         this.assertStatus(response.status);
 
-        return this.createOperation(response.operationHandle);
+        return this.createOperation(definedOrError(response.operationHandle));
       });
   }
 
@@ -79,7 +79,7 @@ export default class HiveSession implements IHiveSession {
       .then((response) => {
         this.assertStatus(response.status);
 
-        return this.createOperation(response.operationHandle);
+        return this.createOperation(definedOrError(response.operationHandle));
       });
   }
 
@@ -93,7 +93,7 @@ export default class HiveSession implements IHiveSession {
       .then((response) => {
         this.assertStatus(response.status);
 
-        return this.createOperation(response.operationHandle);
+        return this.createOperation(definedOrError(response.operationHandle));
       });
   }
 
@@ -109,7 +109,7 @@ export default class HiveSession implements IHiveSession {
       .then((response) => {
         this.assertStatus(response.status);
 
-        return this.createOperation(response.operationHandle);
+        return this.createOperation(definedOrError(response.operationHandle));
       });
   }
 
@@ -121,7 +121,7 @@ export default class HiveSession implements IHiveSession {
       .then((response) => {
         this.assertStatus(response.status);
 
-        return this.createOperation(response.operationHandle);
+        return this.createOperation(definedOrError(response.operationHandle));
       });
   }
 
@@ -137,7 +137,7 @@ export default class HiveSession implements IHiveSession {
       .then((response) => {
         this.assertStatus(response.status);
 
-        return this.createOperation(response.operationHandle);
+        return this.createOperation(definedOrError(response.operationHandle));
       });
   }
 
@@ -152,7 +152,7 @@ export default class HiveSession implements IHiveSession {
       .then((response) => {
         this.assertStatus(response.status);
 
-        return this.createOperation(response.operationHandle);
+        return this.createOperation(definedOrError(response.operationHandle));
       });
   }
 
@@ -167,7 +167,7 @@ export default class HiveSession implements IHiveSession {
       .then((response) => {
         this.assertStatus(response.status);
 
-        return this.createOperation(response.operationHandle);
+        return this.createOperation(definedOrError(response.operationHandle));
       });
   }
 
@@ -185,7 +185,7 @@ export default class HiveSession implements IHiveSession {
       .then((response) => {
         this.assertStatus(response.status);
 
-        return this.createOperation(response.operationHandle);
+        return this.createOperation(definedOrError(response.operationHandle));
       });
   }
 
@@ -239,7 +239,7 @@ export default class HiveSession implements IHiveSession {
       });
   }
 
-  private createOperation(handle: OperationHandle): IOperation {
+  private createOperation(handle: TOperationHandle): IOperation {
     return new HiveOperation(this.driver, handle);
   }
 

--- a/lib/contracts/IHiveClient.ts
+++ b/lib/contracts/IHiveClient.ts
@@ -1,5 +1,5 @@
+import { TOpenSessionReq } from '../../thrift/TCLIService_types';
 import IHiveSession from './IHiveSession';
-import { OpenSessionRequest } from '../hive/Commands/OpenSessionCommand';
 import IConnectionOptions from '../connection/contracts/IConnectionOptions';
 import IConnectionProvider from '../connection/contracts/IConnectionProvider';
 import IAuthentication from '../connection/contracts/IAuthentication';
@@ -11,7 +11,7 @@ export default interface IHiveClient {
     authProvider: IAuthentication,
   ): Promise<IHiveClient>;
 
-  openSession(request: OpenSessionRequest): Promise<IHiveSession>;
+  openSession(request: TOpenSessionReq): Promise<IHiveSession>;
 
   close(): void;
 }

--- a/lib/contracts/IOperation.ts
+++ b/lib/contracts/IOperation.ts
@@ -1,6 +1,5 @@
-import { GetOperationStatusResponse } from '../hive/Commands/GetOperationStatusCommand';
+import { TGetOperationStatusResp, TTableSchema, TRowSet } from '../../thrift/TCLIService_types';
 import Status from '../dto/Status';
-import { TableSchema, RowSet } from '../hive/Types';
 
 export default interface IOperation {
   /**
@@ -13,7 +12,7 @@ export default interface IOperation {
    *
    * @param progress
    */
-  status(progress: boolean): Promise<GetOperationStatusResponse>;
+  status(progress: boolean): Promise<TGetOperationStatusResp>;
 
   /**
    * Cancel operation
@@ -43,10 +42,10 @@ export default interface IOperation {
   /**
    * Return retrieved schema
    */
-  getSchema(): TableSchema | null;
+  getSchema(): TTableSchema | null;
 
   /**
    * Return retrieved data
    */
-  getData(): Array<RowSet>;
+  getData(): Array<TRowSet>;
 }

--- a/lib/dto/InfoValue.ts
+++ b/lib/dto/InfoValue.ts
@@ -1,11 +1,12 @@
-import { GetInfoValue } from '../hive/Types';
+import { TGetInfoValue } from '../../thrift/TCLIService_types';
+import { Int64 } from '../hive/Types';
 
-type InfoResultType = string | number | Buffer | null;
+type InfoResultType = string | number | Buffer | Int64 | null;
 
 export default class InfoValue {
-  private value: GetInfoValue;
+  private value: TGetInfoValue;
 
-  constructor(value: GetInfoValue) {
+  constructor(value: TGetInfoValue) {
     this.value = value;
   }
 

--- a/lib/errors/OperationStateError.ts
+++ b/lib/errors/OperationStateError.ts
@@ -1,10 +1,10 @@
 import HiveDriverError from './HiveDriverError';
-import { GetOperationStatusResponse } from '../hive/Commands/GetOperationStatusCommand';
+import { TGetOperationStatusResp } from '../../thrift/TCLIService_types';
 
 export default class OperationStateError extends HiveDriverError {
-  public response: GetOperationStatusResponse;
+  public response: TGetOperationStatusResp;
 
-  constructor(message: string, response: GetOperationStatusResponse) {
+  constructor(message: string, response: TGetOperationStatusResp) {
     super(message);
 
     this.response = response;

--- a/lib/errors/StatusError.ts
+++ b/lib/errors/StatusError.ts
@@ -1,4 +1,4 @@
-import { Status } from '../hive/Types';
+import { TStatus } from '../../thrift/TCLIService_types';
 
 export default class StatusError implements Error {
   public name: string;
@@ -6,7 +6,7 @@ export default class StatusError implements Error {
   public code: number;
   public stack?: string;
 
-  constructor(status: Status) {
+  constructor(status: TStatus) {
     this.name = 'Status Error';
     this.message = status.errorMessage || '';
     this.code = status.errorCode || -1;

--- a/lib/factory/StatusFactory.ts
+++ b/lib/factory/StatusFactory.ts
@@ -1,5 +1,4 @@
-import { Status as TStatus } from '../hive/Types';
-import TCLIService_types from '../../thrift/TCLIService_types';
+import { TStatusCode, TStatus } from '../../thrift/TCLIService_types';
 import Status from '../dto/Status';
 import StatusError from '../errors/StatusError';
 
@@ -22,19 +21,15 @@ export default class StatusFactory {
 
   private isSuccess(status: TStatus): boolean {
     return (
-      status.statusCode === TCLIService_types.TStatusCode.SUCCESS_STATUS ||
-      status.statusCode === TCLIService_types.TStatusCode.SUCCESS_WITH_INFO_STATUS
+      status.statusCode === TStatusCode.SUCCESS_STATUS || status.statusCode === TStatusCode.SUCCESS_WITH_INFO_STATUS
     );
   }
 
   private isError(status: TStatus): boolean {
-    return (
-      status.statusCode === TCLIService_types.TStatusCode.ERROR_STATUS ||
-      status.statusCode === TCLIService_types.TStatusCode.INVALID_HANDLE_STATUS
-    );
+    return status.statusCode === TStatusCode.ERROR_STATUS || status.statusCode === TStatusCode.INVALID_HANDLE_STATUS;
   }
 
   private isExecuting(status: TStatus): boolean {
-    return status.statusCode === TCLIService_types.TStatusCode.STILL_EXECUTING_STATUS;
+    return status.statusCode === TStatusCode.STILL_EXECUTING_STATUS;
   }
 }

--- a/lib/hive/Commands/BaseCommand.ts
+++ b/lib/hive/Commands/BaseCommand.ts
@@ -1,10 +1,10 @@
-import { ThriftClient } from '../Types';
+import TCLIService from '../../../thrift/TCLIService';
 import HiveDriverError from '../../errors/HiveDriverError';
 
 export default abstract class BaseCommand {
-  protected client: ThriftClient;
+  protected client: TCLIService.Client;
 
-  constructor(client: ThriftClient) {
+  constructor(client: TCLIService.Client) {
     this.client = client;
   }
 

--- a/lib/hive/Commands/CancelDelegationTokenCommand.ts
+++ b/lib/hive/Commands/CancelDelegationTokenCommand.ts
@@ -1,20 +1,10 @@
 import BaseCommand from './BaseCommand';
-import { Status, SessionHandle } from '../Types';
-import TCLIService_types from '../../../thrift/TCLIService_types';
-
-export type CancelDelegationTokenRequest = {
-  sessionHandle: SessionHandle;
-  delegationToken: string;
-};
-
-export type CancelDelegationTokenResponse = {
-  status: Status;
-};
+import { TCancelDelegationTokenReq, TCancelDelegationTokenResp } from '../../../thrift/TCLIService_types';
 
 export default class CancelDelegationTokenCommand extends BaseCommand {
-  execute(data: CancelDelegationTokenRequest): Promise<CancelDelegationTokenResponse> {
-    const request = new TCLIService_types.TCancelDelegationTokenReq(data);
+  execute(data: TCancelDelegationTokenReq): Promise<TCancelDelegationTokenResp> {
+    const request = new TCancelDelegationTokenReq(data);
 
-    return this.executeCommand<CancelDelegationTokenResponse>(request, this.client.CancelDelegationToken);
+    return this.executeCommand<TCancelDelegationTokenResp>(request, this.client.CancelDelegationToken);
   }
 }

--- a/lib/hive/Commands/CancelOperationCommand.ts
+++ b/lib/hive/Commands/CancelOperationCommand.ts
@@ -1,19 +1,10 @@
 import BaseCommand from './BaseCommand';
-import { Status, OperationHandle } from '../Types';
-import TCLIService_types from '../../../thrift/TCLIService_types';
-
-export type CancelOperationRequest = {
-  operationHandle: OperationHandle;
-};
-
-export type CancelOperationResponse = {
-  status: Status;
-};
+import { TCancelOperationReq, TCancelOperationResp } from '../../../thrift/TCLIService_types';
 
 export default class CancelOperationCommand extends BaseCommand {
-  execute(data: CancelOperationRequest): Promise<CancelOperationResponse> {
-    const request = new TCLIService_types.TCancelOperationReq(data);
+  execute(data: TCancelOperationReq): Promise<TCancelOperationResp> {
+    const request = new TCancelOperationReq(data);
 
-    return this.executeCommand<CancelOperationResponse>(request, this.client.CancelOperation);
+    return this.executeCommand<TCancelOperationResp>(request, this.client.CancelOperation);
   }
 }

--- a/lib/hive/Commands/CloseOperationCommand.ts
+++ b/lib/hive/Commands/CloseOperationCommand.ts
@@ -1,19 +1,10 @@
 import BaseCommand from './BaseCommand';
-import { Status, OperationHandle } from '../Types';
-import TCLIService_types from '../../../thrift/TCLIService_types';
-
-export type CloseOperationRequest = {
-  operationHandle: OperationHandle;
-};
-
-export type CloseOperationResponse = {
-  status: Status;
-};
+import { TCloseOperationReq, TCloseOperationResp } from '../../../thrift/TCLIService_types';
 
 export default class CloseOperationCommand extends BaseCommand {
-  execute(data: CloseOperationRequest): Promise<CloseOperationResponse> {
-    const request = new TCLIService_types.TCloseOperationReq(data);
+  execute(data: TCloseOperationReq): Promise<TCloseOperationResp> {
+    const request = new TCloseOperationReq(data);
 
-    return this.executeCommand<CloseOperationResponse>(request, this.client.CloseOperation);
+    return this.executeCommand<TCloseOperationResp>(request, this.client.CloseOperation);
   }
 }

--- a/lib/hive/Commands/CloseSessionCommand.ts
+++ b/lib/hive/Commands/CloseSessionCommand.ts
@@ -1,19 +1,10 @@
-import { SessionHandle, Status } from '../Types';
 import BaseCommand from './BaseCommand';
-import TCLIService_types from '../../../thrift/TCLIService_types';
-
-export type CloseSessionRequest = {
-  sessionHandle: SessionHandle;
-};
-
-export type CloseSessionResponse = {
-  status: Status;
-};
+import { TCloseSessionReq, TCloseSessionResp } from '../../../thrift/TCLIService_types';
 
 export default class CloseSessionCommand extends BaseCommand {
-  execute(openSessionRequest: CloseSessionRequest): Promise<CloseSessionResponse> {
-    const request = new TCLIService_types.TCloseSessionReq(openSessionRequest);
+  execute(openSessionRequest: TCloseSessionReq): Promise<TCloseSessionResp> {
+    const request = new TCloseSessionReq(openSessionRequest);
 
-    return this.executeCommand<CloseSessionResponse>(request, this.client.CloseSession);
+    return this.executeCommand<TCloseSessionResp>(request, this.client.CloseSession);
   }
 }

--- a/lib/hive/Commands/ExecuteStatementCommand.ts
+++ b/lib/hive/Commands/ExecuteStatementCommand.ts
@@ -1,24 +1,10 @@
-import { SessionHandle, Status, OperationHandle, Int64 } from '../Types';
 import BaseCommand from './BaseCommand';
-import TCLIService_types from '../../../thrift/TCLIService_types';
-
-export type ExecuteStatementRequest = {
-  sessionHandle: SessionHandle;
-  statement: string;
-  confOverlay?: Record<string, string>;
-  runAsync?: boolean;
-  queryTimeout?: Int64;
-};
-
-export type ExecuteStatementResponse = {
-  status: Status;
-  operationHandle: OperationHandle;
-};
+import { TExecuteStatementReq, TExecuteStatementResp } from '../../../thrift/TCLIService_types';
 
 export default class ExecuteStatementCommand extends BaseCommand {
-  execute(executeStatementRequest: ExecuteStatementRequest): Promise<ExecuteStatementResponse> {
-    const request = new TCLIService_types.TExecuteStatementReq(executeStatementRequest);
+  execute(executeStatementRequest: TExecuteStatementReq): Promise<TExecuteStatementResp> {
+    const request = new TExecuteStatementReq(executeStatementRequest);
 
-    return this.executeCommand<ExecuteStatementResponse>(request, this.client.ExecuteStatement);
+    return this.executeCommand<TExecuteStatementResp>(request, this.client.ExecuteStatement);
   }
 }

--- a/lib/hive/Commands/FetchResultsCommand.ts
+++ b/lib/hive/Commands/FetchResultsCommand.ts
@@ -1,28 +1,10 @@
 import BaseCommand from './BaseCommand';
-import { OperationHandle, Status, RowSet, Int64 } from '../Types';
-import TCLIService_types from '../../../thrift/TCLIService_types';
-
-/**
- * @param orientation - TCLIService_types.TFetchOrientation
- * @param fetchType - 0 represents Query output. 1 represents Log
- */
-export type FetchResultsRequest = {
-  operationHandle: OperationHandle;
-  orientation: number;
-  maxRows: Int64;
-  fetchType?: number;
-};
-
-export type FetchResultsResponse = {
-  status: Status;
-  hasMoreRows?: boolean;
-  results?: RowSet;
-};
+import { TFetchResultsReq, TFetchResultsResp } from '../../../thrift/TCLIService_types';
 
 export default class FetchResultsCommand extends BaseCommand {
-  execute(data: FetchResultsRequest): Promise<FetchResultsResponse> {
-    const request = new TCLIService_types.TFetchResultsReq(data);
+  execute(data: TFetchResultsReq): Promise<TFetchResultsResp> {
+    const request = new TFetchResultsReq(data);
 
-    return this.executeCommand<FetchResultsResponse>(request, this.client.FetchResults);
+    return this.executeCommand<TFetchResultsResp>(request, this.client.FetchResults);
   }
 }

--- a/lib/hive/Commands/FetchResultsCommand.ts
+++ b/lib/hive/Commands/FetchResultsCommand.ts
@@ -1,6 +1,9 @@
 import BaseCommand from './BaseCommand';
 import { TFetchResultsReq, TFetchResultsResp } from '../../../thrift/TCLIService_types';
 
+/**
+ * TFetchResultsReq.fetchType - 0 represents Query output. 1 represents Log
+ */
 export default class FetchResultsCommand extends BaseCommand {
   execute(data: TFetchResultsReq): Promise<TFetchResultsResp> {
     const request = new TFetchResultsReq(data);

--- a/lib/hive/Commands/GetCatalogsCommand.ts
+++ b/lib/hive/Commands/GetCatalogsCommand.ts
@@ -1,20 +1,10 @@
 import BaseCommand from './BaseCommand';
-import { Status, SessionHandle, OperationHandle } from '../Types';
-import TCLIService_types from '../../../thrift/TCLIService_types';
-
-export type GetCatalogsRequest = {
-  sessionHandle: SessionHandle;
-};
-
-export type GetCatalogsResponse = {
-  status: Status;
-  operationHandle: OperationHandle;
-};
+import { TGetCatalogsReq, TGetCatalogsResp } from '../../../thrift/TCLIService_types';
 
 export default class GetCatalogsCommand extends BaseCommand {
-  execute(data: GetCatalogsRequest): Promise<GetCatalogsResponse> {
-    const request = new TCLIService_types.TGetCatalogsReq(data);
+  execute(data: TGetCatalogsReq): Promise<TGetCatalogsResp> {
+    const request = new TGetCatalogsReq(data);
 
-    return this.executeCommand<GetCatalogsResponse>(request, this.client.GetCatalogs);
+    return this.executeCommand<TGetCatalogsResp>(request, this.client.GetCatalogs);
   }
 }

--- a/lib/hive/Commands/GetColumnsCommand.ts
+++ b/lib/hive/Commands/GetColumnsCommand.ts
@@ -1,24 +1,10 @@
 import BaseCommand from './BaseCommand';
-import { Status, SessionHandle, OperationHandle } from '../Types';
-import TCLIService_types from '../../../thrift/TCLIService_types';
-
-export type GetColumnsRequest = {
-  sessionHandle: SessionHandle;
-  catalogName?: string;
-  schemaName?: string;
-  tableName?: string;
-  columnName?: string;
-};
-
-export type GetColumnsResponse = {
-  status: Status;
-  operationHandle: OperationHandle;
-};
+import { TGetColumnsReq, TGetColumnsResp } from '../../../thrift/TCLIService_types';
 
 export default class GetColumnsCommand extends BaseCommand {
-  execute(data: GetColumnsRequest): Promise<GetColumnsResponse> {
-    const request = new TCLIService_types.TGetColumnsReq(data);
+  execute(data: TGetColumnsReq): Promise<TGetColumnsResp> {
+    const request = new TGetColumnsReq(data);
 
-    return this.executeCommand<GetColumnsResponse>(request, this.client.GetColumns);
+    return this.executeCommand<TGetColumnsResp>(request, this.client.GetColumns);
   }
 }

--- a/lib/hive/Commands/GetCrossReferenceCommand.ts
+++ b/lib/hive/Commands/GetCrossReferenceCommand.ts
@@ -1,26 +1,10 @@
 import BaseCommand from './BaseCommand';
-import { Status, SessionHandle, OperationHandle } from '../Types';
-import TCLIService_types from '../../../thrift/TCLIService_types';
-
-export type GetCrossReferenceRequest = {
-  sessionHandle: SessionHandle;
-  parentCatalogName?: string;
-  parentSchemaName: string;
-  parentTableName: string;
-  foreignCatalogName?: string;
-  foreignSchemaName: string;
-  foreignTableName: string;
-};
-
-export type GetCrossReferenceResponse = {
-  status: Status;
-  operationHandle: OperationHandle;
-};
+import { TGetCrossReferenceReq, TGetCrossReferenceResp } from '../../../thrift/TCLIService_types';
 
 export default class GetCrossReferenceCommand extends BaseCommand {
-  execute(data: GetCrossReferenceRequest): Promise<GetCrossReferenceResponse> {
-    const request = new TCLIService_types.TGetCrossReferenceReq(data);
+  execute(data: TGetCrossReferenceReq): Promise<TGetCrossReferenceResp> {
+    const request = new TGetCrossReferenceReq(data);
 
-    return this.executeCommand<GetCrossReferenceResponse>(request, this.client.GetCrossReference);
+    return this.executeCommand<TGetCrossReferenceResp>(request, this.client.GetCrossReference);
   }
 }

--- a/lib/hive/Commands/GetDelegationTokenCommand.ts
+++ b/lib/hive/Commands/GetDelegationTokenCommand.ts
@@ -1,22 +1,10 @@
 import BaseCommand from './BaseCommand';
-import { Status, SessionHandle } from '../Types';
-import TCLIService_types from '../../../thrift/TCLIService_types';
-
-export type GetDelegationTokenRequest = {
-  sessionHandle: SessionHandle;
-  owner: string;
-  renewer: string;
-};
-
-export type GetDelegationTokenResponse = {
-  status: Status;
-  delegationToken?: string;
-};
+import { TGetDelegationTokenReq, TGetDelegationTokenResp } from '../../../thrift/TCLIService_types';
 
 export default class GetDelegationTokenCommand extends BaseCommand {
-  execute(data: GetDelegationTokenRequest): Promise<GetDelegationTokenResponse> {
-    const request = new TCLIService_types.TGetDelegationTokenReq(data);
+  execute(data: TGetDelegationTokenReq): Promise<TGetDelegationTokenResp> {
+    const request = new TGetDelegationTokenReq(data);
 
-    return this.executeCommand<GetDelegationTokenResponse>(request, this.client.GetDelegationToken);
+    return this.executeCommand<TGetDelegationTokenResp>(request, this.client.GetDelegationToken);
   }
 }

--- a/lib/hive/Commands/GetFunctionsCommand.ts
+++ b/lib/hive/Commands/GetFunctionsCommand.ts
@@ -1,23 +1,10 @@
 import BaseCommand from './BaseCommand';
-import { Status, SessionHandle, OperationHandle } from '../Types';
-import TCLIService_types from '../../../thrift/TCLIService_types';
-
-export type GetFunctionsRequest = {
-  sessionHandle: SessionHandle;
-  catalogName?: string;
-  schemaName?: string;
-  functionName: string;
-};
-
-export type GetFunctionsResponse = {
-  status: Status;
-  operationHandle: OperationHandle;
-};
+import { TGetFunctionsReq, TGetFunctionsResp } from '../../../thrift/TCLIService_types';
 
 export default class GetFunctionsCommand extends BaseCommand {
-  execute(data: GetFunctionsRequest): Promise<GetFunctionsResponse> {
-    const request = new TCLIService_types.TGetFunctionsReq(data);
+  execute(data: TGetFunctionsReq): Promise<TGetFunctionsResp> {
+    const request = new TGetFunctionsReq(data);
 
-    return this.executeCommand<GetFunctionsResponse>(request, this.client.GetFunctions);
+    return this.executeCommand<TGetFunctionsResp>(request, this.client.GetFunctions);
   }
 }

--- a/lib/hive/Commands/GetInfoCommand.ts
+++ b/lib/hive/Commands/GetInfoCommand.ts
@@ -1,24 +1,10 @@
 import BaseCommand from './BaseCommand';
-import { Status, GetInfoValue, SessionHandle } from '../Types';
-import TCLIService_types from '../../../thrift/TCLIService_types';
-
-/**
- * @param infoType TCLISErvice_types.TGetInfoType
- */
-export type GetInfoRequest = {
-  sessionHandle: SessionHandle;
-  infoType: number;
-};
-
-export type GetInfoResponse = {
-  status: Status;
-  infoValue: GetInfoValue;
-};
+import { TGetInfoReq, TGetInfoResp } from '../../../thrift/TCLIService_types';
 
 export default class GetInfoCommand extends BaseCommand {
-  execute(data: GetInfoRequest): Promise<GetInfoResponse> {
-    const request = new TCLIService_types.TGetInfoReq(data);
+  execute(data: TGetInfoReq): Promise<TGetInfoResp> {
+    const request = new TGetInfoReq(data);
 
-    return this.executeCommand<GetInfoResponse>(request, this.client.GetInfo);
+    return this.executeCommand<TGetInfoResp>(request, this.client.GetInfo);
   }
 }

--- a/lib/hive/Commands/GetOperationStatusCommand.ts
+++ b/lib/hive/Commands/GetOperationStatusCommand.ts
@@ -1,30 +1,10 @@
 import BaseCommand from './BaseCommand';
-import { Status, OperationHandle, ProgressUpdateResponse } from '../Types';
-import TCLIService_types from '../../../thrift/TCLIService_types';
-
-export type GetOperationStatusRequest = {
-  operationHandle: OperationHandle;
-  getProgressUpdate?: boolean;
-};
-
-export type GetOperationStatusResponse = {
-  status: Status;
-  operationState?: number;
-  sqlState?: string;
-  errorCode?: number;
-  errorMessage?: string;
-  taskStatus?: string;
-  operationStarted?: Buffer;
-  operationCompleted?: Buffer;
-  hasResultSet?: boolean;
-  progressUpdateResponse?: ProgressUpdateResponse;
-  numModifiedRows?: Buffer;
-};
+import { TGetOperationStatusReq, TGetOperationStatusResp } from '../../../thrift/TCLIService_types';
 
 export default class GetOperationStatusCommand extends BaseCommand {
-  execute(data: GetOperationStatusRequest): Promise<GetOperationStatusResponse> {
-    const request = new TCLIService_types.TGetOperationStatusReq(data);
+  execute(data: TGetOperationStatusReq): Promise<TGetOperationStatusResp> {
+    const request = new TGetOperationStatusReq(data);
 
-    return this.executeCommand<GetOperationStatusResponse>(request, this.client.GetOperationStatus);
+    return this.executeCommand<TGetOperationStatusResp>(request, this.client.GetOperationStatus);
   }
 }

--- a/lib/hive/Commands/GetPrimaryKeysCommand.ts
+++ b/lib/hive/Commands/GetPrimaryKeysCommand.ts
@@ -1,23 +1,10 @@
 import BaseCommand from './BaseCommand';
-import { Status, SessionHandle, OperationHandle } from '../Types';
-import TCLIService_types from '../../../thrift/TCLIService_types';
-
-export type GetPrimaryKeysRequest = {
-  sessionHandle: SessionHandle;
-  catalogName?: string;
-  schemaName: string;
-  tableName: string;
-};
-
-export type GetPrimaryKeysResponse = {
-  status: Status;
-  operationHandle: OperationHandle;
-};
+import { TGetPrimaryKeysReq, TGetPrimaryKeysResp } from '../../../thrift/TCLIService_types';
 
 export default class GetPrimaryKeysCommand extends BaseCommand {
-  execute(data: GetPrimaryKeysRequest): Promise<GetPrimaryKeysResponse> {
-    const request = new TCLIService_types.TGetPrimaryKeysReq(data);
+  execute(data: TGetPrimaryKeysReq): Promise<TGetPrimaryKeysResp> {
+    const request = new TGetPrimaryKeysReq(data);
 
-    return this.executeCommand<GetPrimaryKeysResponse>(request, this.client.GetPrimaryKeys);
+    return this.executeCommand<TGetPrimaryKeysResp>(request, this.client.GetPrimaryKeys);
   }
 }

--- a/lib/hive/Commands/GetResultSetMetadataCommand.ts
+++ b/lib/hive/Commands/GetResultSetMetadataCommand.ts
@@ -1,20 +1,10 @@
-import { TableSchema, Status, OperationHandle } from '../Types';
 import BaseCommand from './BaseCommand';
-import TCLIService_types from '../../../thrift/TCLIService_types';
-
-export type GetResultSetMetadataRequest = {
-  operationHandle: OperationHandle;
-};
-
-export type GetResultSetMetadataResponse = {
-  status: Status;
-  schema: TableSchema;
-};
+import { TGetResultSetMetadataReq, TGetResultSetMetadataResp } from '../../../thrift/TCLIService_types';
 
 export default class GetResultSetMetadataCommand extends BaseCommand {
-  execute(getResultSetMetadataRequest: GetResultSetMetadataRequest): Promise<GetResultSetMetadataResponse> {
-    const request = new TCLIService_types.TGetResultSetMetadataReq(getResultSetMetadataRequest);
+  execute(getResultSetMetadataRequest: TGetResultSetMetadataReq): Promise<TGetResultSetMetadataResp> {
+    const request = new TGetResultSetMetadataReq(getResultSetMetadataRequest);
 
-    return this.executeCommand<GetResultSetMetadataResponse>(request, this.client.GetResultSetMetadata);
+    return this.executeCommand<TGetResultSetMetadataResp>(request, this.client.GetResultSetMetadata);
   }
 }

--- a/lib/hive/Commands/GetSchemasCommand.ts
+++ b/lib/hive/Commands/GetSchemasCommand.ts
@@ -1,22 +1,10 @@
 import BaseCommand from './BaseCommand';
-import { Status, SessionHandle, OperationHandle } from '../Types';
-import TCLIService_types from '../../../thrift/TCLIService_types';
-
-export type GetSchemasRequest = {
-  sessionHandle: SessionHandle;
-  catalogName?: string;
-  schemaName?: string;
-};
-
-export type GetSchemasResponse = {
-  status: Status;
-  operationHandle: OperationHandle;
-};
+import { TGetSchemasReq, TGetSchemasResp } from '../../../thrift/TCLIService_types';
 
 export default class GetSchemasCommand extends BaseCommand {
-  execute(data: GetSchemasRequest): Promise<GetSchemasResponse> {
-    const request = new TCLIService_types.TGetSchemasReq(data);
+  execute(data: TGetSchemasReq): Promise<TGetSchemasResp> {
+    const request = new TGetSchemasReq(data);
 
-    return this.executeCommand<GetSchemasResponse>(request, this.client.GetSchemas);
+    return this.executeCommand<TGetSchemasResp>(request, this.client.GetSchemas);
   }
 }

--- a/lib/hive/Commands/GetTableTypesCommand.ts
+++ b/lib/hive/Commands/GetTableTypesCommand.ts
@@ -1,20 +1,10 @@
 import BaseCommand from './BaseCommand';
-import { Status, SessionHandle, OperationHandle } from '../Types';
-import TCLIService_types from '../../../thrift/TCLIService_types';
-
-export type GetTableTypesRequest = {
-  sessionHandle: SessionHandle;
-};
-
-export type GetTableTypesResponse = {
-  status: Status;
-  operationHandle: OperationHandle;
-};
+import { TGetTableTypesReq, TGetTableTypesResp } from '../../../thrift/TCLIService_types';
 
 export default class GetTableTypesCommand extends BaseCommand {
-  execute(data: GetTableTypesRequest): Promise<GetTableTypesResponse> {
-    const request = new TCLIService_types.TGetTableTypesReq(data);
+  execute(data: TGetTableTypesReq): Promise<TGetTableTypesResp> {
+    const request = new TGetTableTypesReq(data);
 
-    return this.executeCommand<GetTableTypesResponse>(request, this.client.GetTableTypes);
+    return this.executeCommand<TGetTableTypesResp>(request, this.client.GetTableTypes);
   }
 }

--- a/lib/hive/Commands/GetTablesCommand.ts
+++ b/lib/hive/Commands/GetTablesCommand.ts
@@ -1,24 +1,10 @@
 import BaseCommand from './BaseCommand';
-import { Status, SessionHandle, OperationHandle } from '../Types';
-import TCLIService_types from '../../../thrift/TCLIService_types';
-
-export type GetTablesRequest = {
-  sessionHandle: SessionHandle;
-  catalogName?: string;
-  schemaName?: string;
-  tableName?: string;
-  tableTypes?: Array<string>;
-};
-
-export type GetTablesResponse = {
-  status: Status;
-  operationHandle: OperationHandle;
-};
+import { TGetTablesReq, TGetTablesResp } from '../../../thrift/TCLIService_types';
 
 export default class GetTablesCommand extends BaseCommand {
-  execute(data: GetTablesRequest): Promise<GetTablesResponse> {
-    const request = new TCLIService_types.TGetTablesReq(data);
+  execute(data: TGetTablesReq): Promise<TGetTablesResp> {
+    const request = new TGetTablesReq(data);
 
-    return this.executeCommand<GetTablesResponse>(request, this.client.GetTables);
+    return this.executeCommand<TGetTablesResp>(request, this.client.GetTables);
   }
 }

--- a/lib/hive/Commands/GetTypeInfoCommand.ts
+++ b/lib/hive/Commands/GetTypeInfoCommand.ts
@@ -1,20 +1,10 @@
 import BaseCommand from './BaseCommand';
-import { Status, SessionHandle, OperationHandle } from '../Types';
-import TCLIService_types from '../../../thrift/TCLIService_types';
-
-export type GetTypeInfoRequest = {
-  sessionHandle: SessionHandle;
-};
-
-export type GetTypeInfoResponse = {
-  status: Status;
-  operationHandle: OperationHandle;
-};
+import { TGetTypeInfoReq, TGetTypeInfoResp } from '../../../thrift/TCLIService_types';
 
 export default class GetTypeInfoCommand extends BaseCommand {
-  execute(data: GetTypeInfoRequest): Promise<GetTypeInfoResponse> {
-    const request = new TCLIService_types.TGetTypeInfoReq(data);
+  execute(data: TGetTypeInfoReq): Promise<TGetTypeInfoResp> {
+    const request = new TGetTypeInfoReq(data);
 
-    return this.executeCommand<GetTypeInfoResponse>(request, this.client.GetTypeInfo);
+    return this.executeCommand<TGetTypeInfoResp>(request, this.client.GetTypeInfo);
   }
 }

--- a/lib/hive/Commands/OpenSessionCommand.ts
+++ b/lib/hive/Commands/OpenSessionCommand.ts
@@ -1,41 +1,10 @@
-import { Status, SessionHandle } from '../Types';
 import BaseCommand from './BaseCommand';
-import TCLIService_types from '../../../thrift/TCLIService_types';
-
-/**
- * For auth mechanism GSSAPI the host and service should be provided when session is opened.
- */
-type SessionConfiguration = {
-  krb_host?: string;
-  krb_service?: string;
-  [key: string]: any;
-};
-
-/**
- * @param client_protocol  One of the values TCLIService_types.TProtocolVersion. May be different depends on version of Hive you use.
- *                         For instance, for Hive lower that 3.x it is better to use HIVE_CLI_SERVICE_PROTOCOL_V8.
- * @param username         if authorization is used you should define username and password
- * @param password
- * @param configuration    in case of GSSAPI you should define configuration
- */
-export type OpenSessionRequest = {
-  client_protocol: number;
-  username?: string;
-  password?: string;
-  configuration?: SessionConfiguration;
-};
-
-export type OpenSessionResponse = {
-  status: Status;
-  serverProtocolVersion: number;
-  sessionHandle: SessionHandle;
-  configuration?: SessionConfiguration;
-};
+import { TOpenSessionReq, TOpenSessionResp } from '../../../thrift/TCLIService_types';
 
 export default class OpenSessionCommand extends BaseCommand {
-  execute(openSessionRequest: OpenSessionRequest): Promise<OpenSessionResponse> {
-    const request = new TCLIService_types.TOpenSessionReq(openSessionRequest);
+  execute(openSessionRequest: TOpenSessionReq): Promise<TOpenSessionResp> {
+    const request = new TOpenSessionReq(openSessionRequest);
 
-    return this.executeCommand<OpenSessionResponse>(request, this.client.OpenSession);
+    return this.executeCommand<TOpenSessionResp>(request, this.client.OpenSession);
   }
 }

--- a/lib/hive/Commands/OpenSessionCommand.ts
+++ b/lib/hive/Commands/OpenSessionCommand.ts
@@ -1,6 +1,15 @@
 import BaseCommand from './BaseCommand';
 import { TOpenSessionReq, TOpenSessionResp } from '../../../thrift/TCLIService_types';
 
+/**
+ * For auth mechanism GSSAPI the host and service should be provided when session is opened.
+ *
+ * TOpenSessionReq.configuration: {
+ *   krb_host?: string;
+ *   krb_service?: string;
+ *   [key: string]: any;
+ * }
+ */
 export default class OpenSessionCommand extends BaseCommand {
   execute(openSessionRequest: TOpenSessionReq): Promise<TOpenSessionResp> {
     const request = new TOpenSessionReq(openSessionRequest);

--- a/lib/hive/Commands/RenewDelegationTokenCommand.ts
+++ b/lib/hive/Commands/RenewDelegationTokenCommand.ts
@@ -1,20 +1,10 @@
 import BaseCommand from './BaseCommand';
-import { Status, SessionHandle } from '../Types';
-import TCLIService_types from '../../../thrift/TCLIService_types';
-
-export type RenewDelegationTokenRequest = {
-  sessionHandle: SessionHandle;
-  delegationToken: string;
-};
-
-export type RenewDelegationTokenResponse = {
-  status: Status;
-};
+import { TRenewDelegationTokenReq, TRenewDelegationTokenResp } from '../../../thrift/TCLIService_types';
 
 export default class RenewDelegationTokenCommand extends BaseCommand {
-  execute(data: RenewDelegationTokenRequest): Promise<RenewDelegationTokenResponse> {
-    const request = new TCLIService_types.TRenewDelegationTokenReq(data);
+  execute(data: TRenewDelegationTokenReq): Promise<TRenewDelegationTokenResp> {
+    const request = new TRenewDelegationTokenReq(data);
 
-    return this.executeCommand<RenewDelegationTokenResponse>(request, this.client.RenewDelegationToken);
+    return this.executeCommand<TRenewDelegationTokenResp>(request, this.client.RenewDelegationToken);
   }
 }

--- a/lib/hive/HiveDriver.ts
+++ b/lib/hive/HiveDriver.ts
@@ -1,4 +1,4 @@
-import { ThriftClient } from './Types/';
+import TCLIService from '../../thrift/TCLIService';
 import {
   TOpenSessionReq,
   TCloseSessionReq,
@@ -45,9 +45,9 @@ import CancelDelegationTokenCommand from './Commands/CancelDelegationTokenComman
 import RenewDelegationTokenCommand from './Commands/RenewDelegationTokenCommand';
 
 export default class HiveDriver {
-  private client: ThriftClient;
+  private client: TCLIService.Client;
 
-  constructor(client: ThriftClient) {
+  constructor(client: TCLIService.Client) {
     this.client = client;
   }
 

--- a/lib/hive/HiveDriver.ts
+++ b/lib/hive/HiveDriver.ts
@@ -1,49 +1,48 @@
 import { ThriftClient } from './Types/';
-import OpenSessionCommand, { OpenSessionRequest, OpenSessionResponse } from './Commands/OpenSessionCommand';
-import CloseSessionCommand, { CloseSessionRequest, CloseSessionResponse } from './Commands/CloseSessionCommand';
-import ExecuteStatementCommand, {
-  ExecuteStatementResponse,
-  ExecuteStatementRequest,
-} from './Commands/ExecuteStatementCommand';
-import GetResultSetMetadataCommand, {
-  GetResultSetMetadataRequest,
-  GetResultSetMetadataResponse,
-} from './Commands/GetResultSetMetadataCommand';
-import FetchResultsCommand, { FetchResultsRequest, FetchResultsResponse } from './Commands/FetchResultsCommand';
-import GetInfoCommand, { GetInfoRequest, GetInfoResponse } from './Commands/GetInfoCommand';
-import GetTypeInfoCommand, { GetTypeInfoRequest, GetTypeInfoResponse } from './Commands/GetTypeInfoCommand';
-import GetCatalogsCommand, { GetCatalogsRequest, GetCatalogsResponse } from './Commands/GetCatalogsCommand';
-import GetSchemasCommand, { GetSchemasRequest, GetSchemasResponse } from './Commands/GetSchemasCommand';
-import GetTablesCommand, { GetTablesRequest, GetTablesResponse } from './Commands/GetTablesCommand';
-import GetTableTypesCommand, { GetTableTypesRequest, GetTableTypesResponse } from './Commands/GetTableTypesCommand';
-import GetColumnsCommand, { GetColumnsRequest, GetColumnsResponse } from './Commands/GetColumnsCommand';
-import GetFunctionsCommand, { GetFunctionsRequest, GetFunctionsResponse } from './Commands/GetFunctionsCommand';
-import GetPrimaryKeysCommand, { GetPrimaryKeysRequest, GetPrimaryKeysResponse } from './Commands/GetPrimaryKeysCommand';
-import GetCrossReferenceCommand, {
-  GetCrossReferenceRequest,
-  GetCrossReferenceResponse,
-} from './Commands/GetCrossReferenceCommand';
-import GetOperationStatusCommand, {
-  GetOperationStatusRequest,
-  GetOperationStatusResponse,
-} from './Commands/GetOperationStatusCommand';
-import CancelOperationCommand, {
-  CancelOperationRequest,
-  CancelOperationResponse,
-} from './Commands/CancelOperationCommand';
-import CloseOperationCommand, { CloseOperationRequest, CloseOperationResponse } from './Commands/CloseOperationCommand';
-import GetDelegationTokenCommand, {
-  GetDelegationTokenRequest,
-  GetDelegationTokenResponse,
-} from './Commands/GetDelegationTokenCommand';
-import CancelDelegationTokenCommand, {
-  CancelDelegationTokenRequest,
-  CancelDelegationTokenResponse,
-} from './Commands/CancelDelegationTokenCommand';
-import RenewDelegationTokenCommand, {
-  RenewDelegationTokenRequest,
-  RenewDelegationTokenResponse,
-} from './Commands/RenewDelegationTokenCommand';
+import {
+  TOpenSessionReq,
+  TCloseSessionReq,
+  TExecuteStatementReq,
+  TGetResultSetMetadataReq,
+  TFetchResultsReq,
+  TGetInfoReq,
+  TGetTypeInfoReq,
+  TGetCatalogsReq,
+  TGetSchemasReq,
+  TGetTablesReq,
+  TGetTableTypesReq,
+  TGetColumnsReq,
+  TGetFunctionsReq,
+  TGetPrimaryKeysReq,
+  TGetCrossReferenceReq,
+  TGetOperationStatusReq,
+  TCancelOperationReq,
+  TCloseOperationReq,
+  TGetDelegationTokenReq,
+  TCancelDelegationTokenReq,
+  TRenewDelegationTokenReq,
+} from '../../thrift/TCLIService_types';
+import OpenSessionCommand from './Commands/OpenSessionCommand';
+import CloseSessionCommand from './Commands/CloseSessionCommand';
+import ExecuteStatementCommand from './Commands/ExecuteStatementCommand';
+import GetResultSetMetadataCommand from './Commands/GetResultSetMetadataCommand';
+import FetchResultsCommand from './Commands/FetchResultsCommand';
+import GetInfoCommand from './Commands/GetInfoCommand';
+import GetTypeInfoCommand from './Commands/GetTypeInfoCommand';
+import GetCatalogsCommand from './Commands/GetCatalogsCommand';
+import GetSchemasCommand from './Commands/GetSchemasCommand';
+import GetTablesCommand from './Commands/GetTablesCommand';
+import GetTableTypesCommand from './Commands/GetTableTypesCommand';
+import GetColumnsCommand from './Commands/GetColumnsCommand';
+import GetFunctionsCommand from './Commands/GetFunctionsCommand';
+import GetPrimaryKeysCommand from './Commands/GetPrimaryKeysCommand';
+import GetCrossReferenceCommand from './Commands/GetCrossReferenceCommand';
+import GetOperationStatusCommand from './Commands/GetOperationStatusCommand';
+import CancelOperationCommand from './Commands/CancelOperationCommand';
+import CloseOperationCommand from './Commands/CloseOperationCommand';
+import GetDelegationTokenCommand from './Commands/GetDelegationTokenCommand';
+import CancelDelegationTokenCommand from './Commands/CancelDelegationTokenCommand';
+import RenewDelegationTokenCommand from './Commands/RenewDelegationTokenCommand';
 
 export default class HiveDriver {
   private client: ThriftClient;
@@ -52,127 +51,127 @@ export default class HiveDriver {
     this.client = client;
   }
 
-  openSession(request: OpenSessionRequest): Promise<OpenSessionResponse> {
+  openSession(request: TOpenSessionReq) {
     const action = new OpenSessionCommand(this.client);
 
     return action.execute(request);
   }
 
-  closeSession(request: CloseSessionRequest): Promise<CloseSessionResponse> {
+  closeSession(request: TCloseSessionReq) {
     const command = new CloseSessionCommand(this.client);
 
     return command.execute(request);
   }
 
-  executeStatement(request: ExecuteStatementRequest): Promise<ExecuteStatementResponse> {
+  executeStatement(request: TExecuteStatementReq) {
     const command = new ExecuteStatementCommand(this.client);
 
     return command.execute(request);
   }
 
-  getResultSetMetadata(request: GetResultSetMetadataRequest): Promise<GetResultSetMetadataResponse> {
+  getResultSetMetadata(request: TGetResultSetMetadataReq) {
     const command = new GetResultSetMetadataCommand(this.client);
 
     return command.execute(request);
   }
 
-  fetchResults(request: FetchResultsRequest): Promise<FetchResultsResponse> {
+  fetchResults(request: TFetchResultsReq) {
     const command = new FetchResultsCommand(this.client);
 
     return command.execute(request);
   }
 
-  getInfo(request: GetInfoRequest): Promise<GetInfoResponse> {
+  getInfo(request: TGetInfoReq) {
     const command = new GetInfoCommand(this.client);
 
     return command.execute(request);
   }
 
-  getTypeInfo(request: GetTypeInfoRequest): Promise<GetTypeInfoResponse> {
+  getTypeInfo(request: TGetTypeInfoReq) {
     const command = new GetTypeInfoCommand(this.client);
 
     return command.execute(request);
   }
 
-  getCatalogs(request: GetCatalogsRequest): Promise<GetCatalogsResponse> {
+  getCatalogs(request: TGetCatalogsReq) {
     const command = new GetCatalogsCommand(this.client);
 
     return command.execute(request);
   }
 
-  getSchemas(request: GetSchemasRequest): Promise<GetSchemasResponse> {
+  getSchemas(request: TGetSchemasReq) {
     const command = new GetSchemasCommand(this.client);
 
     return command.execute(request);
   }
 
-  getTables(request: GetTablesRequest): Promise<GetTablesResponse> {
+  getTables(request: TGetTablesReq) {
     const command = new GetTablesCommand(this.client);
 
     return command.execute(request);
   }
 
-  getTableTypes(request: GetTableTypesRequest): Promise<GetTableTypesResponse> {
+  getTableTypes(request: TGetTableTypesReq) {
     const command = new GetTableTypesCommand(this.client);
 
     return command.execute(request);
   }
 
-  getColumns(request: GetColumnsRequest): Promise<GetColumnsResponse> {
+  getColumns(request: TGetColumnsReq) {
     const command = new GetColumnsCommand(this.client);
 
     return command.execute(request);
   }
 
-  getFunctions(request: GetFunctionsRequest): Promise<GetFunctionsResponse> {
+  getFunctions(request: TGetFunctionsReq) {
     const command = new GetFunctionsCommand(this.client);
 
     return command.execute(request);
   }
 
-  getPrimaryKeys(request: GetPrimaryKeysRequest): Promise<GetPrimaryKeysResponse> {
+  getPrimaryKeys(request: TGetPrimaryKeysReq) {
     const command = new GetPrimaryKeysCommand(this.client);
 
     return command.execute(request);
   }
 
-  getCrossReference(request: GetCrossReferenceRequest): Promise<GetCrossReferenceResponse> {
+  getCrossReference(request: TGetCrossReferenceReq) {
     const command = new GetCrossReferenceCommand(this.client);
 
     return command.execute(request);
   }
 
-  getOperationStatus(request: GetOperationStatusRequest): Promise<GetOperationStatusResponse> {
+  getOperationStatus(request: TGetOperationStatusReq) {
     const command = new GetOperationStatusCommand(this.client);
 
     return command.execute(request);
   }
 
-  cancelOperation(request: CancelOperationRequest): Promise<CancelOperationResponse> {
+  cancelOperation(request: TCancelOperationReq) {
     const command = new CancelOperationCommand(this.client);
 
     return command.execute(request);
   }
 
-  closeOperation(request: CloseOperationRequest): Promise<CloseOperationResponse> {
+  closeOperation(request: TCloseOperationReq) {
     const command = new CloseOperationCommand(this.client);
 
     return command.execute(request);
   }
 
-  getDelegationToken(request: GetDelegationTokenRequest): Promise<GetDelegationTokenResponse> {
+  getDelegationToken(request: TGetDelegationTokenReq) {
     const command = new GetDelegationTokenCommand(this.client);
 
     return command.execute(request);
   }
 
-  cancelDelegationToken(request: CancelDelegationTokenRequest): Promise<CancelDelegationTokenResponse> {
+  cancelDelegationToken(request: TCancelDelegationTokenReq) {
     const command = new CancelDelegationTokenCommand(this.client);
 
     return command.execute(request);
   }
 
-  renewDelegationToken(request: RenewDelegationTokenRequest): Promise<RenewDelegationTokenResponse> {
+  renewDelegationToken(request: TRenewDelegationTokenReq) {
     const command = new RenewDelegationTokenCommand(this.client);
 
     return command.execute(request);

--- a/lib/hive/Types/index.ts
+++ b/lib/hive/Types/index.ts
@@ -1,5 +1,4 @@
 import Int64 from 'node-int64';
-import TCLIService from '../../../thrift/TCLIService';
 import {
   TBoolColumn,
   TByteColumn,
@@ -12,8 +11,6 @@ import {
 } from '../../../thrift/TCLIService_types';
 
 export { Int64 };
-
-export type ThriftClient = TCLIService.Client;
 
 export enum ColumnCode {
   boolVal = 'boolVal',

--- a/lib/hive/Types/index.ts
+++ b/lib/hive/Types/index.ts
@@ -1,148 +1,19 @@
 import Int64 from 'node-int64';
 import TCLIService from '../../../thrift/TCLIService';
+import {
+  TBoolColumn,
+  TByteColumn,
+  TI16Column,
+  TI32Column,
+  TI64Column,
+  TDoubleColumn,
+  TStringColumn,
+  TBinaryColumn,
+} from '../../../thrift/TCLIService_types';
 
 export { Int64 };
 
 export type ThriftClient = TCLIService.Client;
-
-export type ThriftSession = {
-  sessionHandle: any;
-};
-
-export type Status = {
-  statusCode: number;
-  infoMessages?: Array<string>;
-  sqlState?: string;
-  errorCode?: number;
-  errorMessage?: string;
-};
-
-export type ThriftBuffer = Buffer;
-
-type HandleIdentifier = {
-  guid: ThriftBuffer;
-  secret: ThriftBuffer;
-};
-
-export type SessionHandle = {
-  sessionId: HandleIdentifier;
-};
-
-export type OperationHandle = {
-  operationId: HandleIdentifier;
-  operationType: number;
-  hasResultSet: boolean;
-  modifiedRowCount?: number;
-};
-
-type TypeQualifiers = {
-  qualifiers: Map<
-    string,
-    {
-      i32Value?: number;
-      stringValue?: string;
-    }
-  >;
-};
-
-export type PrimitiveTypeEntry = {
-  type: number;
-  typeQualifiers?: TypeQualifiers;
-};
-
-type TypeEntryPtr = number;
-
-export type ArrayTypeEntry = {
-  objectTypePtr: TypeEntryPtr;
-};
-
-export type MapTypeEntry = {
-  keyTypePtr: TypeEntryPtr;
-  valueTypePtr: TypeEntryPtr;
-};
-
-export type StructTypeEntry = {
-  nameToTypePtr: Map<string, TypeEntryPtr>;
-};
-
-export type UnionTypeEntry = {
-  nameToTypePtr: Map<string, TypeEntryPtr>;
-};
-
-export type UserDefinedTypeEntry = {
-  typeClassName: string;
-};
-
-export type TypeEntry = {
-  primitiveEntry: PrimitiveTypeEntry;
-  arrayEntry: ArrayTypeEntry;
-  mapEntry: MapTypeEntry;
-  structEntry: StructTypeEntry;
-  unionEntry: UnionTypeEntry;
-  userDefinedTypeEntry: UserDefinedTypeEntry;
-};
-
-export type TypeDesc = {
-  types: Array<TypeEntry>;
-};
-
-export type ColumnDesc = {
-  columnName: string;
-  typeDesc: TypeDesc;
-  position: number;
-  comment?: string;
-};
-
-export type TableSchema = {
-  columns: Array<ColumnDesc>;
-};
-
-type ColumnValue = BoolValue | ByteValue | TI16Value | TI32Value | TI64Value | TDoubleValue | TStringValue;
-
-type BoolValue = { value: boolean };
-type ByteValue = { value: ThriftBuffer };
-type TI16Value = { value: number };
-type TI32Value = { value: number };
-type TI64Value = { value: ThriftBuffer };
-type TDoubleValue = { value: number };
-type TStringValue = { value: string };
-
-type Row = {
-  colVals: Array<ColumnValue>;
-};
-
-export type TBoolColumn = {
-  values: Array<boolean>;
-  nulls: ThriftBuffer;
-};
-export type TByteColumn = {
-  values: Array<ThriftBuffer>;
-  nulls: ThriftBuffer;
-};
-export type TI16Column = {
-  values: Array<number>;
-  nulls: ThriftBuffer;
-};
-export type TI32Column = {
-  values: Array<number>;
-  nulls: ThriftBuffer;
-};
-export type TI64Column = {
-  values: Array<ThriftBuffer>;
-  nulls: ThriftBuffer;
-};
-export type TDoubleColumn = {
-  values: Array<number>;
-  nulls: ThriftBuffer;
-};
-export type TStringColumn = {
-  values: Array<string>;
-  nulls: ThriftBuffer;
-};
-export type TBinaryColumn = {
-  values: Array<ThriftBuffer>;
-  nulls: ThriftBuffer;
-};
 
 export enum ColumnCode {
   boolVal = 'boolVal',
@@ -164,40 +35,3 @@ export type ColumnType =
   | TDoubleColumn
   | TStringColumn
   | TBinaryColumn;
-
-export type Column = {
-  [ColumnCode.boolVal]: TBoolColumn;
-  [ColumnCode.byteVal]: TByteColumn;
-  [ColumnCode.i16Val]: TI16Column;
-  [ColumnCode.i32Val]: TI32Column;
-  [ColumnCode.i64Val]: TI64Column;
-  [ColumnCode.doubleVal]: TDoubleColumn;
-  [ColumnCode.stringVal]: TStringColumn;
-  [ColumnCode.binaryVal]: TBinaryColumn;
-};
-
-export type RowSet = {
-  startRowOffset: ThriftBuffer;
-  rows: Array<Row>;
-  columns?: Array<Column>;
-  binaryColumns?: ThriftBuffer;
-  columnCount?: number;
-};
-
-export type GetInfoValue = {
-  stringValue: string;
-  smallIntValue: number;
-  integerBitmask: number;
-  integerFlag: number;
-  binaryValue: number;
-  lenValue: ThriftBuffer;
-};
-
-export type ProgressUpdateResponse = {
-  headerNames: Array<string>;
-  rows: Array<Array<string>>;
-  progressedPercentage: number;
-  status: number;
-  footerSummary: string;
-  startTime: ThriftBuffer;
-};

--- a/lib/result/IOperationResult.ts
+++ b/lib/result/IOperationResult.ts
@@ -1,4 +1,3 @@
-import { TableSchema, RowSet } from '../hive/Types';
 import IOperation from '../contracts/IOperation';
 
 export default interface IOperationResult {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,6 +4,13 @@ import os from 'os';
 
 const productName = 'NodejsDatabricksSqlConnector';
 
+export function definedOrError<T>(value: T | undefined): T {
+  if (value === undefined) {
+    throw new TypeError('Value is undefined');
+  }
+  return value;
+}
+
 function getPackageVersion(): string {
   const json = JSON.parse(fs.readFileSync(path.join(__dirname, '../package.json')).toString());
   return json.version;

--- a/lib/utils/HiveUtils.ts
+++ b/lib/utils/HiveUtils.ts
@@ -1,4 +1,4 @@
-import { ProgressUpdateResponse } from '../hive/Types';
+import { TProgressUpdateResp } from '../../thrift/TCLIService_types';
 import IOperation from '../contracts/IOperation';
 import WaitUntilReady from './WaitUntilReady';
 import IOperationResult from '../result/IOperationResult';
@@ -28,7 +28,7 @@ export default class HiveUtils {
     });
   }
 
-  formatProgress(progressUpdate: ProgressUpdateResponse): string {
+  formatProgress(progressUpdate: TProgressUpdateResp): string {
     return String(new ProgressUpdateTransformer(progressUpdate));
   }
 }

--- a/lib/utils/ProgressUpdateTransformer.ts
+++ b/lib/utils/ProgressUpdateTransformer.ts
@@ -1,10 +1,10 @@
-import { ProgressUpdateResponse } from '../hive/Types';
+import { TProgressUpdateResp } from '../../thrift/TCLIService_types';
 
 export default class ProgressUpdateTransformer {
-  private progressUpdate: ProgressUpdateResponse;
+  private progressUpdate: TProgressUpdateResp;
   private rowWidth: number = 10;
 
-  constructor(progressUpdate: ProgressUpdateResponse) {
+  constructor(progressUpdate: TProgressUpdateResp) {
     this.progressUpdate = progressUpdate;
   }
 

--- a/lib/utils/WaitUntilReady.ts
+++ b/lib/utils/WaitUntilReady.ts
@@ -1,6 +1,5 @@
 import IOperation from '../contracts/IOperation';
-import TCLIService_types from '../../thrift/TCLIService_types';
-import { GetOperationStatusResponse } from '../hive/Commands/GetOperationStatusCommand';
+import { TOperationState, TGetOperationStatusResp } from '../../thrift/TCLIService_types';
 import OperationStateError from '../errors/OperationStateError';
 
 export default class WaitUntilReady {
@@ -17,7 +16,7 @@ export default class WaitUntilReady {
    * @param callback if callback specified it will be called each time the operation status response received and it will be passed as first parameter
    */
   async execute(progress?: boolean, callback?: Function): Promise<IOperation> {
-    const response: GetOperationStatusResponse = await this.operation.status(Boolean(progress));
+    const response = await this.operation.status(Boolean(progress));
 
     if (typeof callback === 'function') {
       await this.executeCallback(callback.bind(null, response));
@@ -36,25 +35,25 @@ export default class WaitUntilReady {
     }
   }
 
-  private isReady(response: GetOperationStatusResponse): boolean {
+  private isReady(response: TGetOperationStatusResp): boolean {
     switch (response.operationState) {
-      case TCLIService_types.TOperationState.INITIALIZED_STATE:
+      case TOperationState.INITIALIZED_STATE:
         return false;
-      case TCLIService_types.TOperationState.RUNNING_STATE:
+      case TOperationState.RUNNING_STATE:
         return false;
-      case TCLIService_types.TOperationState.FINISHED_STATE:
+      case TOperationState.FINISHED_STATE:
         return true;
-      case TCLIService_types.TOperationState.CANCELED_STATE:
+      case TOperationState.CANCELED_STATE:
         throw new OperationStateError('The operation was canceled by a client', response);
-      case TCLIService_types.TOperationState.CLOSED_STATE:
+      case TOperationState.CLOSED_STATE:
         throw new OperationStateError('The operation was closed by a client', response);
-      case TCLIService_types.TOperationState.ERROR_STATE:
+      case TOperationState.ERROR_STATE:
         throw new OperationStateError('The operation failed due to an error', response);
-      case TCLIService_types.TOperationState.PENDING_STATE:
+      case TOperationState.PENDING_STATE:
         throw new OperationStateError('The operation is in a pending state', response);
-      case TCLIService_types.TOperationState.TIMEDOUT_STATE:
+      case TOperationState.TIMEDOUT_STATE:
         throw new OperationStateError('The operation is in a timedout state', response);
-      case TCLIService_types.TOperationState.UKNOWN_STATE:
+      case TOperationState.UKNOWN_STATE:
       default:
         throw new OperationStateError('The operation is in an unrecognized state', response);
     }


### PR DESCRIPTION
Use types directly from generated thrift files instead of out-of-sync manually created `./hive/Types`