### PR TITLE
Export the DBSQLSession

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,7 @@
 import TCLIService from '../thrift/TCLIService';
 import TCLIService_types from '../thrift/TCLIService_types';
 import DBSQLClient from './DBSQLClient';
+import DBSQLSession from './DBSQLSession';
 import NoSaslAuthentication from './connection/auth/NoSaslAuthentication';
 import PlainHttpAuthentication from './connection/auth/PlainHttpAuthentication';
 import HttpConnection from './connection/connections/HttpConnection';
@@ -19,4 +20,4 @@ export const thrift = {
   TCLIService_types,
 };
 
-export { DBSQLClient };
+export { DBSQLClient, DBSQLSession };


### PR DESCRIPTION
As per this issue https://github.com/databricks/databricks-sql-nodejs/issues/44

This is a small change, but I have run these anyway and no issues:
```sh
npm run type-check
npm run prettier:check
npm run test
```
I didn't run the E2E but there's no logic changes here, just exposing the type.