### PR TITLE
Peco 219 - Enable chunked fetch

### DIFF
--- a/lib/DBSQLClient.ts
+++ b/lib/DBSQLClient.ts
@@ -1,276 +1,134 @@
-import IOperation from './contracts/IOperation';
+import thrift from 'thrift';
+
+import TCLIService from '../thrift/TCLIService';
+import TCLIService_types, { TOpenSessionReq } from '../thrift/TCLIService_types';
+import IDBSQLClient, { IDBSQLConnectionOptions } from './contracts/IDBSQLClient';
 import HiveDriver from './hive/HiveDriver';
-import {
-  TOperationState,
-  TStatusCode,
-  TFetchOrientation,
-  TFetchResultsResp,
-  TColumn,
-  TTableSchema,
-  TRowSet,
-  TOperationHandle,
-  TRow,
-} from '../thrift/TCLIService_types';
-import { ColumnCode, Int64 } from './hive/Types';
-import Status from './dto/Status';
+import DBSQLSession from './DBSQLSession';
+import IDBSQLSession from './contracts/IDBSQLSession';
+import IThriftConnection from './connection/contracts/IThriftConnection';
+import IConnectionProvider from './connection/contracts/IConnectionProvider';
+import IAuthentication from './connection/contracts/IAuthentication';
+import NoSaslAuthentication from './connection/auth/NoSaslAuthentication';
+import HttpConnection from './connection/connections/HttpConnection';
+import IConnectionOptions from './connection/contracts/IConnectionOptions';
+import { EventEmitter } from 'events';
 import StatusFactory from './factory/StatusFactory';
-import { definedOrError } from './utils';
-import WaitUntilReady from './utils/WaitUntilReady';
-import { parse } from 'path';
+import HiveDriverError from './errors/HiveDriverError';
+import { buildUserAgentString, definedOrError } from './utils';
+import PlainHttpAuthentication from './connection/auth/PlainHttpAuthentication';
+import HiveUtils from './utils/HiveUtils';
 
-export default class DBSQLOperation implements IOperation {
-  private driver: HiveDriver;
-  private operationHandle: TOperationHandle;
-  private schema: TTableSchema | null;
-  private data: Array<TRowSet>;
+export default class DBSQLClient extends EventEmitter implements IDBSQLClient {
+  static utils = new HiveUtils();
+
+  private client: TCLIService.Client | null;
+  private connection: IThriftConnection | null;
   private statusFactory: StatusFactory;
+  private connectionProvider: IConnectionProvider;
+  private authProvider: IAuthentication;
+  private thrift = thrift;
 
-  private maxRows: Int64 = new Int64(100000);
-  private fetchType: number = 0;
-
-  private _hasMoreRows: boolean = false;
-  private state: number;
-  private hasResultSet: boolean = false;
-
-  constructor(driver: HiveDriver, operationHandle: TOperationHandle) {
-    this.driver = driver;
-    this.operationHandle = operationHandle;
-    this.hasResultSet = operationHandle.hasResultSet;
+  constructor() {
+    super();
+    this.connectionProvider = new HttpConnection();
+    this.authProvider = new NoSaslAuthentication();
     this.statusFactory = new StatusFactory();
-    this.state = TOperationState.INITIALIZED_STATE;
+    this.client = null;
+    this.connection = null;
+  }
 
-    this.schema = null;
-    this.data = [];
+  private getConnectionOptions(options: IDBSQLConnectionOptions): IConnectionOptions {
+    const { host, port, token, clientId, ...otherOptions } = options;
+    return {
+      host,
+      port: port || 443,
+      options: {
+        https: true,
+        ...otherOptions,
+      },
+    };
+  }
+
+  async connect(options: IDBSQLConnectionOptions): Promise<IDBSQLClient> {
+    this.authProvider = new PlainHttpAuthentication({
+      username: 'token',
+      password: options.token,
+      headers: {
+        'User-Agent': buildUserAgentString(options.clientId),
+      },
+    });
+
+    this.connection = await this.connectionProvider.connect(this.getConnectionOptions(options), this.authProvider);
+
+    this.client = this.thrift.createClient(TCLIService, this.connection.getConnection());
+
+    this.connection.getConnection().on('error', (error: Error) => {
+      this.emit('error', error);
+    });
+
+    this.connection.getConnection().on('reconnecting', (params: { delay: number; attempt: number }) => {
+      this.emit('reconnecting', params);
+    });
+
+    this.connection.getConnection().on('close', () => {
+      this.emit('close');
+    });
+
+    this.connection.getConnection().on('timeout', () => {
+      this.emit('timeout');
+    });
+
+    return this;
   }
 
   /**
-   * Fetches result and schema from operation
+   * Starts new session
+   *
+   * @param request
    * @throws {StatusError}
    */
-  fetch(maxRowSize = this.maxRows): Promise<Status> {
-    if (!this.hasResultSet) {
-      return Promise.resolve(
-        this.statusFactory.create({
-          statusCode: TStatusCode.SUCCESS_STATUS,
-        }),
-      );
+  openSession(request?: TOpenSessionReq): Promise<IDBSQLSession> {
+    if (!this.connection?.isConnected()) {
+      return Promise.reject(new HiveDriverError('DBSQLClient: connection is lost'));
     }
 
-    if (!this.finished()) {
-      return Promise.resolve(
-        this.statusFactory.create({
-          statusCode: TStatusCode.STILL_EXECUTING_STATUS,
-        }),
-      );
+    const driver = new HiveDriver(this.getClient());
+
+    if (!request) {
+      request = {
+        client_protocol: TCLIService_types.TProtocolVersion.SPARK_CLI_SERVICE_PROTOCOL_V6,
+      };
     }
 
-    if (this.schema === null) {
-      return this.initializeSchema()
-        .then((schema) => {
-          this.schema = schema;
+    return driver.openSession(request).then((response) => {
+      this.statusFactory.create(response.status);
 
-          return this.firstFetch();
-        })
-        .then((response) => this.processFetchResponse(response));
-    } else {
-      return this.nextFetch(maxRowSize).then((response) => this.processFetchResponse(response));
-    }
-  }
+      const session = new DBSQLSession(driver, definedOrError(response.sessionHandle));
 
-  async fetchAll(): Promise<TRowSet[] | null> {
-    return this.fetchChunk(new Int64(Number.MAX_SAFE_INTEGER));
-  }
-
-  async fetchChunk(chunkSize: Int64): Promise<TRowSet[] | null>  {
-    let rowsWritten = new Int64(0);
-    let resultSet = this.data;
-    if (!this.hasResultSet) {
-      return Promise.resolve(
-        null,
-      );
-    }
-
-    await new WaitUntilReady(this).execute();
-
-    let fetchSize = new Int64(Math.min(Number(this.maxRows), Number(chunkSize) - Number(rowsWritten)));
-    
-    // Need initial fetch to populate _hasMoreRows
-    //
-    await this.fetch(fetchSize).then(() => {
-      while(this.hasMoreRows()) {
-        rowsWritten = new Int64(Number(rowsWritten) + Number(fetchSize));
-        if(rowsWritten >= chunkSize) {
-          this.flush();
-          return Promise.resolve(
-            resultSet,);
-        }
-        fetchSize = new Int64(Math.min(Number(this.maxRows), Number(chunkSize) - Number(rowsWritten)));
-        this.fetch(fetchSize);
-      }
-      this.flush();
-      return Promise.resolve(
-        resultSet,);
-      });
-    return null;
-  }
-
-  /**
-   * Requests operation status
-   * @param progress
-   * @throws {StatusError}
-   */
-  status(progress: boolean = false) {
-    return this.driver
-      .getOperationStatus({
-        operationHandle: this.operationHandle,
-        getProgressUpdate: progress,
-      })
-      .then((response) => {
-        this.statusFactory.create(response.status);
-
-        this.state = response.operationState ?? this.state;
-
-        if (typeof response.hasResultSet === 'boolean') {
-          this.hasResultSet = response.hasResultSet;
-        }
-
-        return response;
-      });
-  }
-
-  /**
-   * Cancels operation
-   * @throws {StatusError}
-   */
-  cancel(): Promise<Status> {
-    return this.driver
-      .cancelOperation({
-        operationHandle: this.operationHandle,
-      })
-      .then((response) => {
-        return this.statusFactory.create(response.status);
-      });
-  }
-
-  /**
-   * Closes operation
-   * @throws {StatusError}
-   */
-  close(): Promise<Status> {
-    return this.driver
-      .closeOperation({
-        operationHandle: this.operationHandle,
-      })
-      .then((response) => {
-        return this.statusFactory.create(response.status);
-      });
-  }
-
-  finished(): boolean {
-    return this.state === TOperationState.FINISHED_STATE;
-  }
-
-  hasMoreRows(): boolean {
-    return this._hasMoreRows;
-  }
-
-  setMaxRows(maxRows: number): void {
-    this.maxRows = new Int64(maxRows);
-  }
-
-  setFetchType(fetchType: number): void {
-    this.fetchType = fetchType;
-  }
-
-  getSchema() {
-    return this.schema;
-  }
-
-  getData() {
-    return this.data;
-  }
-
-  /**
-   * Resets `this.data` buffer.
-   * Needs to be called when working with massive data.
-   */
-  flush(): void {
-    this.data = [];
-  }
-
-  /**
-   * Retrieves schema
-   * @throws {StatusError}
-   */
-  private initializeSchema(): Promise<TTableSchema> {
-    return this.driver
-      .getResultSetMetadata({
-        operationHandle: this.operationHandle,
-      })
-      .then((schema) => {
-        this.statusFactory.create(schema.status);
-
-        return definedOrError(schema.schema);
-      });
-  }
-
-  private firstFetch() {
-    return this.driver.fetchResults({
-      operationHandle: this.operationHandle,
-      orientation: TFetchOrientation.FETCH_FIRST,
-      maxRows: this.maxRows,
-      fetchType: this.fetchType,
+      return session;
     });
   }
 
-  private nextFetch(maxRowSize = this.maxRows) {
-    return this.driver.fetchResults({
-      operationHandle: this.operationHandle,
-      orientation: TFetchOrientation.FETCH_NEXT,
-      maxRows: maxRowSize,
-      fetchType: this.fetchType,
-    });
+  getClient() {
+    if (!this.client) {
+      throw new HiveDriverError('DBSQLClient: client is not initialized');
+    }
+
+    return this.client;
   }
 
-  /**
-   * @param response
-   * @throws {StatusError}
-   */
-  private processFetchResponse(response: TFetchResultsResp): Status {
-    const status = this.statusFactory.create(response.status);
-
-    this._hasMoreRows = this.checkIfOperationHasMoreRows(response);
-
-    if (response.results) {
-      this.data.push(response.results);
+  close(): Promise<void> {
+    if (!this.connection) {
+      return Promise.resolve();
     }
 
-    return status;
-  }
+    const thriftConnection = this.connection.getConnection();
 
-  private checkIfOperationHasMoreRows(response: TFetchResultsResp): boolean {
-    if (response.hasMoreRows) {
-      return true;
+    if (typeof thriftConnection.end === 'function') {
+      this.connection.getConnection().end();
     }
 
-    const columns = response.results?.columns || [];
-
-    if (!columns.length) {
-      return false;
-    }
-
-    const column: TColumn = columns[0];
-
-    const columnValue =
-      column[ColumnCode.binaryVal] ||
-      column[ColumnCode.boolVal] ||
-      column[ColumnCode.byteVal] ||
-      column[ColumnCode.doubleVal] ||
-      column[ColumnCode.i16Val] ||
-      column[ColumnCode.i32Val] ||
-      column[ColumnCode.i64Val] ||
-      column[ColumnCode.stringVal];
-
-    return (columnValue?.values?.length || 0) > 0;
+    return Promise.resolve();
   }
 }

--- a/lib/DBSQLClient.ts
+++ b/lib/DBSQLClient.ts
@@ -1,134 +1,276 @@
-import thrift from 'thrift';
-
-import TCLIService from '../thrift/TCLIService';
-import TCLIService_types, { TOpenSessionReq } from '../thrift/TCLIService_types';
-import IDBSQLClient, { IDBSQLConnectionOptions } from './contracts/IDBSQLClient';
+import IOperation from './contracts/IOperation';
 import HiveDriver from './hive/HiveDriver';
-import DBSQLSession from './DBSQLSession';
-import IDBSQLSession from './contracts/IDBSQLSession';
-import IThriftConnection from './connection/contracts/IThriftConnection';
-import IConnectionProvider from './connection/contracts/IConnectionProvider';
-import IAuthentication from './connection/contracts/IAuthentication';
-import NoSaslAuthentication from './connection/auth/NoSaslAuthentication';
-import HttpConnection from './connection/connections/HttpConnection';
-import IConnectionOptions from './connection/contracts/IConnectionOptions';
-import { EventEmitter } from 'events';
+import {
+  TOperationState,
+  TStatusCode,
+  TFetchOrientation,
+  TFetchResultsResp,
+  TColumn,
+  TTableSchema,
+  TRowSet,
+  TOperationHandle,
+  TRow,
+} from '../thrift/TCLIService_types';
+import { ColumnCode, Int64 } from './hive/Types';
+import Status from './dto/Status';
 import StatusFactory from './factory/StatusFactory';
-import HiveDriverError from './errors/HiveDriverError';
-import { buildUserAgentString, definedOrError } from './utils';
-import PlainHttpAuthentication from './connection/auth/PlainHttpAuthentication';
-import HiveUtils from './utils/HiveUtils';
+import { definedOrError } from './utils';
+import WaitUntilReady from './utils/WaitUntilReady';
+import { parse } from 'path';
 
-export default class DBSQLClient extends EventEmitter implements IDBSQLClient {
-  static utils = new HiveUtils();
-
-  private client: TCLIService.Client | null;
-  private connection: IThriftConnection | null;
+export default class DBSQLOperation implements IOperation {
+  private driver: HiveDriver;
+  private operationHandle: TOperationHandle;
+  private schema: TTableSchema | null;
+  private data: Array<TRowSet>;
   private statusFactory: StatusFactory;
-  private connectionProvider: IConnectionProvider;
-  private authProvider: IAuthentication;
-  private thrift = thrift;
 
-  constructor() {
-    super();
-    this.connectionProvider = new HttpConnection();
-    this.authProvider = new NoSaslAuthentication();
+  private maxRows: Int64 = new Int64(100000);
+  private fetchType: number = 0;
+
+  private _hasMoreRows: boolean = false;
+  private state: number;
+  private hasResultSet: boolean = false;
+
+  constructor(driver: HiveDriver, operationHandle: TOperationHandle) {
+    this.driver = driver;
+    this.operationHandle = operationHandle;
+    this.hasResultSet = operationHandle.hasResultSet;
     this.statusFactory = new StatusFactory();
-    this.client = null;
-    this.connection = null;
-  }
+    this.state = TOperationState.INITIALIZED_STATE;
 
-  private getConnectionOptions(options: IDBSQLConnectionOptions): IConnectionOptions {
-    const { host, port, token, clientId, ...otherOptions } = options;
-    return {
-      host,
-      port: port || 443,
-      options: {
-        https: true,
-        ...otherOptions,
-      },
-    };
-  }
-
-  async connect(options: IDBSQLConnectionOptions): Promise<IDBSQLClient> {
-    this.authProvider = new PlainHttpAuthentication({
-      username: 'token',
-      password: options.token,
-      headers: {
-        'User-Agent': buildUserAgentString(options.clientId),
-      },
-    });
-
-    this.connection = await this.connectionProvider.connect(this.getConnectionOptions(options), this.authProvider);
-
-    this.client = this.thrift.createClient(TCLIService, this.connection.getConnection());
-
-    this.connection.getConnection().on('error', (error: Error) => {
-      this.emit('error', error);
-    });
-
-    this.connection.getConnection().on('reconnecting', (params: { delay: number; attempt: number }) => {
-      this.emit('reconnecting', params);
-    });
-
-    this.connection.getConnection().on('close', () => {
-      this.emit('close');
-    });
-
-    this.connection.getConnection().on('timeout', () => {
-      this.emit('timeout');
-    });
-
-    return this;
+    this.schema = null;
+    this.data = [];
   }
 
   /**
-   * Starts new session
-   *
-   * @param request
+   * Fetches result and schema from operation
    * @throws {StatusError}
    */
-  openSession(request?: TOpenSessionReq): Promise<IDBSQLSession> {
-    if (!this.connection?.isConnected()) {
-      return Promise.reject(new HiveDriverError('DBSQLClient: connection is lost'));
+  fetch(maxRowSize = this.maxRows): Promise<Status> {
+    if (!this.hasResultSet) {
+      return Promise.resolve(
+        this.statusFactory.create({
+          statusCode: TStatusCode.SUCCESS_STATUS,
+        }),
+      );
     }
 
-    const driver = new HiveDriver(this.getClient());
-
-    if (!request) {
-      request = {
-        client_protocol: TCLIService_types.TProtocolVersion.SPARK_CLI_SERVICE_PROTOCOL_V6,
-      };
+    if (!this.finished()) {
+      return Promise.resolve(
+        this.statusFactory.create({
+          statusCode: TStatusCode.STILL_EXECUTING_STATUS,
+        }),
+      );
     }
 
-    return driver.openSession(request).then((response) => {
-      this.statusFactory.create(response.status);
+    if (this.schema === null) {
+      return this.initializeSchema()
+        .then((schema) => {
+          this.schema = schema;
 
-      const session = new DBSQLSession(driver, definedOrError(response.sessionHandle));
+          return this.firstFetch();
+        })
+        .then((response) => this.processFetchResponse(response));
+    } else {
+      return this.nextFetch(maxRowSize).then((response) => this.processFetchResponse(response));
+    }
+  }
 
-      return session;
+  async fetchAll(): Promise<TRowSet[] | null> {
+    return this.fetchChunk(new Int64(Number.MAX_SAFE_INTEGER));
+  }
+
+  async fetchChunk(chunkSize: Int64): Promise<TRowSet[] | null>  {
+    let rowsWritten = new Int64(0);
+    let resultSet = this.data;
+    if (!this.hasResultSet) {
+      return Promise.resolve(
+        null,
+      );
+    }
+
+    await new WaitUntilReady(this).execute();
+
+    let fetchSize = new Int64(Math.min(Number(this.maxRows), Number(chunkSize) - Number(rowsWritten)));
+    
+    // Need initial fetch to populate _hasMoreRows
+    //
+    await this.fetch(fetchSize).then(() => {
+      while(this.hasMoreRows()) {
+        rowsWritten = new Int64(Number(rowsWritten) + Number(fetchSize));
+        if(rowsWritten >= chunkSize) {
+          this.flush();
+          return Promise.resolve(
+            resultSet,);
+        }
+        fetchSize = new Int64(Math.min(Number(this.maxRows), Number(chunkSize) - Number(rowsWritten)));
+        this.fetch(fetchSize);
+      }
+      this.flush();
+      return Promise.resolve(
+        resultSet,);
+      });
+    return null;
+  }
+
+  /**
+   * Requests operation status
+   * @param progress
+   * @throws {StatusError}
+   */
+  status(progress: boolean = false) {
+    return this.driver
+      .getOperationStatus({
+        operationHandle: this.operationHandle,
+        getProgressUpdate: progress,
+      })
+      .then((response) => {
+        this.statusFactory.create(response.status);
+
+        this.state = response.operationState ?? this.state;
+
+        if (typeof response.hasResultSet === 'boolean') {
+          this.hasResultSet = response.hasResultSet;
+        }
+
+        return response;
+      });
+  }
+
+  /**
+   * Cancels operation
+   * @throws {StatusError}
+   */
+  cancel(): Promise<Status> {
+    return this.driver
+      .cancelOperation({
+        operationHandle: this.operationHandle,
+      })
+      .then((response) => {
+        return this.statusFactory.create(response.status);
+      });
+  }
+
+  /**
+   * Closes operation
+   * @throws {StatusError}
+   */
+  close(): Promise<Status> {
+    return this.driver
+      .closeOperation({
+        operationHandle: this.operationHandle,
+      })
+      .then((response) => {
+        return this.statusFactory.create(response.status);
+      });
+  }
+
+  finished(): boolean {
+    return this.state === TOperationState.FINISHED_STATE;
+  }
+
+  hasMoreRows(): boolean {
+    return this._hasMoreRows;
+  }
+
+  setMaxRows(maxRows: number): void {
+    this.maxRows = new Int64(maxRows);
+  }
+
+  setFetchType(fetchType: number): void {
+    this.fetchType = fetchType;
+  }
+
+  getSchema() {
+    return this.schema;
+  }
+
+  getData() {
+    return this.data;
+  }
+
+  /**
+   * Resets `this.data` buffer.
+   * Needs to be called when working with massive data.
+   */
+  flush(): void {
+    this.data = [];
+  }
+
+  /**
+   * Retrieves schema
+   * @throws {StatusError}
+   */
+  private initializeSchema(): Promise<TTableSchema> {
+    return this.driver
+      .getResultSetMetadata({
+        operationHandle: this.operationHandle,
+      })
+      .then((schema) => {
+        this.statusFactory.create(schema.status);
+
+        return definedOrError(schema.schema);
+      });
+  }
+
+  private firstFetch() {
+    return this.driver.fetchResults({
+      operationHandle: this.operationHandle,
+      orientation: TFetchOrientation.FETCH_FIRST,
+      maxRows: this.maxRows,
+      fetchType: this.fetchType,
     });
   }
 
-  getClient() {
-    if (!this.client) {
-      throw new HiveDriverError('DBSQLClient: client is not initialized');
-    }
-
-    return this.client;
+  private nextFetch(maxRowSize = this.maxRows) {
+    return this.driver.fetchResults({
+      operationHandle: this.operationHandle,
+      orientation: TFetchOrientation.FETCH_NEXT,
+      maxRows: maxRowSize,
+      fetchType: this.fetchType,
+    });
   }
 
-  close(): Promise<void> {
-    if (!this.connection) {
-      return Promise.resolve();
+  /**
+   * @param response
+   * @throws {StatusError}
+   */
+  private processFetchResponse(response: TFetchResultsResp): Status {
+    const status = this.statusFactory.create(response.status);
+
+    this._hasMoreRows = this.checkIfOperationHasMoreRows(response);
+
+    if (response.results) {
+      this.data.push(response.results);
     }
 
-    const thriftConnection = this.connection.getConnection();
+    return status;
+  }
 
-    if (typeof thriftConnection.end === 'function') {
-      this.connection.getConnection().end();
+  private checkIfOperationHasMoreRows(response: TFetchResultsResp): boolean {
+    if (response.hasMoreRows) {
+      return true;
     }
 
-    return Promise.resolve();
+    const columns = response.results?.columns || [];
+
+    if (!columns.length) {
+      return false;
+    }
+
+    const column: TColumn = columns[0];
+
+    const columnValue =
+      column[ColumnCode.binaryVal] ||
+      column[ColumnCode.boolVal] ||
+      column[ColumnCode.byteVal] ||
+      column[ColumnCode.doubleVal] ||
+      column[ColumnCode.i16Val] ||
+      column[ColumnCode.i32Val] ||
+      column[ColumnCode.i64Val] ||
+      column[ColumnCode.stringVal];
+
+    return (columnValue?.values?.length || 0) > 0;
   }
 }

--- a/lib/DBSQLOperation.ts
+++ b/lib/DBSQLOperation.ts
@@ -43,14 +43,13 @@ export default class DBSQLOperation implements IOperation {
   }
 
   private async wait(): Promise<void> {
-    if(this.finished()) {
-      return
+    if (this.finished()) {
+      return;
     }
-    if(await this.isReady()) {
-      return
-    }
-    else{
-      return this.wait()
+    if (await this.isReady()) {
+      return;
+    } else {
+      return this.wait();
     }
   }
 
@@ -89,30 +88,27 @@ export default class DBSQLOperation implements IOperation {
   }
 
   async fetchAll(): Promise<Array<object> | null> {
-    let data = new Array<object>;
+    let data = new Array<object>();
     do {
-      let chunk = await this.fetchChunk()
-      if(chunk) {
+      let chunk = await this.fetchChunk();
+      if (chunk) {
         data.push(...chunk);
       }
-    }
-    while(this.hasMoreRows())
+    } while (this.hasMoreRows());
     return data;
   }
 
-  async fetchChunk(chunkSize: Int64 = new Int64(100000)): Promise<Array<object> | null>  {
+  async fetchChunk(chunkSize: Int64 = new Int64(100000)): Promise<Array<object> | null> {
     if (!this.hasResultSet) {
-      return Promise.resolve(
-        null,
-      );
+      return Promise.resolve(null);
     }
 
     await this.wait();
-    
+
     return await this.fetch(chunkSize).then(() => {
       let data = new GetResult(this).execute().getValue();
       this.flush();
-      return Promise.resolve(data,);
+      return Promise.resolve(data);
     });
   }
 
@@ -296,5 +292,3 @@ export default class DBSQLOperation implements IOperation {
     }
   }
 }
-
-

--- a/lib/DBSQLOperation.ts
+++ b/lib/DBSQLOperation.ts
@@ -78,11 +78,11 @@ export default class DBSQLOperation implements IOperation {
   }
 
   async fetchAll(): Promise<TRowSet[] | null> {
-    return this.fetchChunk(new Int64(Number.MAX_SAFE_INTEGER));
+    return this.fetchChunk(Number.MAX_SAFE_INTEGER);
   }
 
-  async fetchChunk(chunkSize: Int64): Promise<TRowSet[] | null>  {
-    let rowsWritten = new Int64(0);
+  async fetchChunk(chunkSize: Number): Promise<TRowSet[] | null>  {
+    let rowsWritten = 0;
     let resultSet = this.data;
     if (!this.hasResultSet) {
       return Promise.resolve(
@@ -98,7 +98,7 @@ export default class DBSQLOperation implements IOperation {
     //
     await this.fetch(fetchSize).then(() => {
       while(this.hasMoreRows()) {
-        rowsWritten = new Int64(Number(rowsWritten) + Number(fetchSize));
+        rowsWritten = rowsWritten + Number(fetchSize);
         if(rowsWritten >= chunkSize) {
           this.flush();
           return Promise.resolve(

--- a/lib/DBSQLOperation.ts
+++ b/lib/DBSQLOperation.ts
@@ -9,6 +9,7 @@ import {
   TTableSchema,
   TRowSet,
   TOperationHandle,
+  TGetOperationStatusResp,
   TRow,
 } from '../thrift/TCLIService_types';
 import { ColumnCode, Int64 } from './hive/Types';
@@ -17,6 +18,8 @@ import StatusFactory from './factory/StatusFactory';
 import { definedOrError } from './utils';
 import WaitUntilReady from './utils/WaitUntilReady';
 import { parse } from 'path';
+import OperationStateError from './errors/OperationStateError';
+import { time } from 'console';
 
 export default class DBSQLOperation implements IOperation {
   private driver: HiveDriver;
@@ -41,6 +44,21 @@ export default class DBSQLOperation implements IOperation {
 
     this.schema = null;
     this.data = [];
+  }
+
+  async wait(maxWaitMs = 600000): Promise<void> {
+    let startTime = Date.now();
+    let timeElapsed = Date.now() - startTime;
+    while(timeElapsed < maxWaitMs) {
+      if(await this.isReady()) {
+        break;
+      }
+      timeElapsed = Date.now() - startTime;
+    }
+    if(timeElapsed >= maxWaitMs) {
+      throw new Error("Operation exceeded max wait time");
+    }
+    return
   }
 
   /**
@@ -90,7 +108,8 @@ export default class DBSQLOperation implements IOperation {
       );
     }
 
-    await new WaitUntilReady(this).execute();
+    // await new WaitUntilReady(this).execute();
+    await this.wait();
 
     let fetchSize = new Int64(Math.min(Number(this.maxRows), Number(chunkSize) - Number(rowsWritten)));
     
@@ -273,4 +292,30 @@ export default class DBSQLOperation implements IOperation {
 
     return (columnValue?.values?.length || 0) > 0;
   }
+  async isReady(): Promise<boolean> {
+    let response = await this.status();
+    switch (response.operationState) {
+      case TOperationState.INITIALIZED_STATE:
+        return false;
+      case TOperationState.RUNNING_STATE:
+        return false;
+      case TOperationState.FINISHED_STATE:
+        return true;
+      case TOperationState.CANCELED_STATE:
+        throw new OperationStateError('The operation was canceled by a client', response);
+      case TOperationState.CLOSED_STATE:
+        throw new OperationStateError('The operation was closed by a client', response);
+      case TOperationState.ERROR_STATE:
+        throw new OperationStateError('The operation failed due to an error', response);
+      case TOperationState.PENDING_STATE:
+        throw new OperationStateError('The operation is in a pending state', response);
+      case TOperationState.TIMEDOUT_STATE:
+        throw new OperationStateError('The operation is in a timedout state', response);
+      case TOperationState.UKNOWN_STATE:
+      default:
+        throw new OperationStateError('The operation is in an unrecognized state', response);
+    }
+  }
 }
+
+

--- a/lib/DBSQLOperation.ts
+++ b/lib/DBSQLOperation.ts
@@ -9,17 +9,12 @@ import {
   TTableSchema,
   TRowSet,
   TOperationHandle,
-  TGetOperationStatusResp,
-  TRow,
 } from '../thrift/TCLIService_types';
 import { ColumnCode, Int64 } from './hive/Types';
 import Status from './dto/Status';
 import StatusFactory from './factory/StatusFactory';
 import { definedOrError } from './utils';
-import WaitUntilReady from './utils/WaitUntilReady';
-import { parse } from 'path';
 import OperationStateError from './errors/OperationStateError';
-import { time } from 'console';
 import GetResult from './utils/GetResult';
 
 export default class DBSQLOperation implements IOperation {

--- a/lib/contracts/IOperation.ts
+++ b/lib/contracts/IOperation.ts
@@ -5,7 +5,7 @@ export default interface IOperation {
   /**
    * Fetch schema and a portion of data
    */
-  fetch(): Promise<Status>;
+  fetch(chunkSize?: number): Promise<Status>;
 
   /**
    * Request status of operation

--- a/lib/contracts/IOperation.ts
+++ b/lib/contracts/IOperation.ts
@@ -35,11 +35,6 @@ export default interface IOperation {
   hasMoreRows(): boolean;
 
   /**
-   * Set the max fetch size
-   */
-  setMaxRows(maxRows: number): void;
-
-  /**
    * Return retrieved schema
    */
   getSchema(): TTableSchema | null;

--- a/tests/e2e/batched_fetch.test.js
+++ b/tests/e2e/batched_fetch.test.js
@@ -1,0 +1,36 @@
+const { expect } = require('chai');
+const config = require('./utils/config');
+const logger = require('./utils/logger')(config.logger);
+const { DBSQLClient, thrift } = require('../..');
+
+const utils = DBSQLClient.utils;
+
+const openSession = async () => {
+  const client = new DBSQLClient();
+
+  const connection = await client.connect({
+    host: config.host,
+    path: config.path,
+    token: config.token,
+  });
+
+  const openSessionRequest = {};
+
+  if (config.database.length === 2) {
+    openSessionRequest.initialNamespace = {
+      catalogName: config.database[0],
+      schemaName: config.database[1],
+    };
+  }
+
+  const session = await connection.openSession(openSessionRequest);
+
+  return session;
+};
+
+it('fetch chunks should return a max row set of chunkSize', async () => {
+    const session = await openSession();
+    const operation = await session.executeStatement(`SELECT * FROM trips`, { runAsync: true });
+    let chunkedOp = await operation.fetchChunk(100);
+    expect(chunkedOp.length == 100);
+})

--- a/tests/e2e/batched_fetch.test.js
+++ b/tests/e2e/batched_fetch.test.js
@@ -30,7 +30,8 @@ const openSession = async () => {
 
 it('fetch chunks should return a max row set of chunkSize', async () => {
     const session = await openSession();
-    const operation = await session.executeStatement(`SELECT * FROM trips`, { runAsync: true });
+    const operation = await session.executeStatement(`SELECT * FROM samples.nyctaxi.trips LIMIT 1000`, { runAsync: true });
     let chunkedOp = await operation.fetchChunk(100);
+    logger(chunkedOp.length);
     expect(chunkedOp.length == 100);
 })

--- a/tests/e2e/batched_fetch.test.js
+++ b/tests/e2e/batched_fetch.test.js
@@ -29,14 +29,14 @@ const openSession = async () => {
 };
 
 it('fetch chunks should return a max row set of chunkSize', async () => {
-    const session = await openSession();
-    const operation = await session.executeStatement(`SELECT * FROM default.diamonds`, { runAsync: true });
-    let chunkedOp = await operation.fetchChunk(100).catch(error=>logger(error));
-    expect(chunkedOp.length == 100);
-})
+  const session = await openSession();
+  const operation = await session.executeStatement(`SELECT * FROM default.diamonds`, { runAsync: true });
+  let chunkedOp = await operation.fetchChunk(100).catch((error) => logger(error));
+  expect(chunkedOp.length == 100);
+});
 it('fetch all should fetch all records', async () => {
-    const session = await openSession();
-    const operation = await session.executeStatement(`SELECT * FROM default.diamonds LIMIT 1000`, { runAsync: true });
-    let all = await operation.fetchAll();
-    expect(all.length == 1000);
-})
+  const session = await openSession();
+  const operation = await session.executeStatement(`SELECT * FROM default.diamonds LIMIT 1000`, { runAsync: true });
+  let all = await operation.fetchAll();
+  expect(all.length == 1000);
+});

--- a/tests/e2e/batched_fetch.test.js
+++ b/tests/e2e/batched_fetch.test.js
@@ -30,8 +30,13 @@ const openSession = async () => {
 
 it('fetch chunks should return a max row set of chunkSize', async () => {
     const session = await openSession();
-    const operation = await session.executeStatement(`SELECT * FROM samples.nyctaxi.trips LIMIT 1000`, { runAsync: true });
-    let chunkedOp = await operation.fetchChunk(100);
-    logger(chunkedOp.length);
+    const operation = await session.executeStatement(`SELECT * FROM default.diamonds`, { runAsync: true });
+    let chunkedOp = await operation.fetchChunk(100).catch(error=>logger(error));
     expect(chunkedOp.length == 100);
+})
+it('fetch all should fetch all records', async () => {
+    const session = await openSession();
+    const operation = await session.executeStatement(`SELECT * FROM default.diamonds LIMIT 1000`, { runAsync: true });
+    let all = await operation.fetchAll();
+    expect(all.length == 1000);
 })


### PR DESCRIPTION
Data fetching currently relies on functionality from HiveUtils class and is too low-level for end user. This PR moves fetch use-case into the operation class and enables users to fetch by chunk in cases where they need to conserve memory.