### PR TITLE
Peco 273: Add support for connector to be run in browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,6 @@ node_modules
 .nyc_output
 coverage_e2e
 coverage_unit
-*.code-workspace
-dist
 *.DS_Store
+dist
+*.code-workspace

--- a/lib/DBSQLClient.ts
+++ b/lib/DBSQLClient.ts
@@ -37,12 +37,10 @@ export default class DBSQLClient extends EventEmitter implements IDBSQLClient {
   constructor() {
     super();
     if(isNodejs()) {
-      console.log("Bad");
       this.connectionProvider = new HttpConnection();
     }
     else {
       this.connectionProvider = new XhrConnection();
-      console.log("Good");
     }
     this.statusFactory = new StatusFactory();
     this.client = null;
@@ -63,6 +61,7 @@ export default class DBSQLClient extends EventEmitter implements IDBSQLClient {
   }
 
   async connect(options: IDBSQLConnectionOptions): Promise<IDBSQLClient> {
+    let clientId = isNodejs() ? buildUserAgentString(options.clientId) : 'anonymous';
     this.authProvider = new PlainHttpAuthentication({
       username: 'token',
       password: options.token,

--- a/lib/DBSQLClient.ts
+++ b/lib/DBSQLClient.ts
@@ -74,10 +74,7 @@ export default class DBSQLClient extends EventEmitter implements IDBSQLClient {
     else {
       opts = {
         username: 'token',
-        password: options.token,
-        headers: {
-          'Content-Type': 'application/vnd.apache.thrift.binary'
-        }
+        password: options.token
       }
     }
     this.authProvider = new PlainHttpAuthentication(opts);

--- a/lib/DBSQLClient.ts
+++ b/lib/DBSQLClient.ts
@@ -61,12 +61,12 @@ export default class DBSQLClient extends EventEmitter implements IDBSQLClient {
   }
 
   async connect(options: IDBSQLConnectionOptions): Promise<IDBSQLClient> {
-    let clientId = isNodejs() ? buildUserAgentString(options.clientId) : 'anonymous';
+    let clientId = isNodejs() ? buildUserAgentString(options.clientId) : `NodejsDatabricksSqlConnector/0.1.8-beta.1 (${options.clientId})`;
     this.authProvider = new PlainHttpAuthentication({
       username: 'token',
       password: options.token,
       headers: {
-        'User-Agent': buildUserAgentString(options.clientId),
+        'User-Agent': buildUserAgentString(clientId),
       },
     });
 

--- a/lib/DBSQLClient.ts
+++ b/lib/DBSQLClient.ts
@@ -61,12 +61,12 @@ export default class DBSQLClient extends EventEmitter implements IDBSQLClient {
   }
 
   async connect(options: IDBSQLConnectionOptions): Promise<IDBSQLClient> {
-    let clientId = isNodejs() ? buildUserAgentString(options.clientId) : `NodejsDatabricksSqlConnector/0.1.8-beta.1 (${options.clientId})`;
+    let agentString = isNodejs() ? buildUserAgentString(options.clientId) : `NodejsDatabricksSqlConnector/0.1.8-beta.1 (${options.clientId})`;
     this.authProvider = new PlainHttpAuthentication({
       username: 'token',
       password: options.token,
       headers: {
-        'User-Agent': buildUserAgentString(clientId),
+        'User-Agent': agentString,
       },
     });
 

--- a/lib/DBSQLClient.ts
+++ b/lib/DBSQLClient.ts
@@ -61,14 +61,23 @@ export default class DBSQLClient extends EventEmitter implements IDBSQLClient {
   }
 
   async connect(options: IDBSQLConnectionOptions): Promise<IDBSQLClient> {
-    let opts = {
-      username: 'token',
-      password: options.token,
-      headers: {}
-    }
+    let opts;
     if(isNodejs()){
-      opts.headers = {
-        'User-Agent': buildUserAgentString(options.clientId)
+      opts = {
+        username: 'token',
+        password: options.token,
+        headers: {
+          'User-Agent': buildUserAgentString(options.clientId)
+        }
+      }
+    }
+    else {
+      opts = {
+        username: 'token',
+        password: options.token,
+        headers: {
+          'Content-Type': 'application/vnd.apache.thrift.binary'
+        }
       }
     }
     this.authProvider = new PlainHttpAuthentication(opts);

--- a/lib/DBSQLClient.ts
+++ b/lib/DBSQLClient.ts
@@ -72,8 +72,12 @@ export default class DBSQLClient extends EventEmitter implements IDBSQLClient {
 
     this.connection = await this.connectionProvider.connect(this.getConnectionOptions(options), this.authProvider);
 
-    this.client = this.thrift.createClient(TCLIService, this.connection.getConnection());
-
+    if(isNodejs()) {
+      this.client = this.thrift.createClient(TCLIService, this.connection.getConnection());
+    }
+    else {
+      this.client = this.thrift.createXHRClient(TCLIService, this.connection.getConnection());
+    }
     this.connection.getConnection().on('error', (error: Error) => {
       this.emit('error', error);
     });

--- a/lib/DBSQLClient.ts
+++ b/lib/DBSQLClient.ts
@@ -17,6 +17,9 @@ import StatusFactory from './factory/StatusFactory';
 import HiveDriverError from './errors/HiveDriverError';
 import { buildUserAgentString, definedOrError } from './utils';
 import PlainHttpAuthentication from './connection/auth/PlainHttpAuthentication';
+import XhrConnection from './connection/connections/XhrConnection';
+
+function isNodejs() { return typeof "process" !== "undefined" && process && process.versions && process.versions.node; }
 
 export default class DBSQLClient extends EventEmitter implements IDBSQLClient {
   private client: TCLIService.Client | null;
@@ -33,11 +36,18 @@ export default class DBSQLClient extends EventEmitter implements IDBSQLClient {
 
   constructor() {
     super();
-    this.connectionProvider = new HttpConnection();
-    this.authProvider = new NoSaslAuthentication();
+    if(isNodejs()) {
+      console.log("Bad");
+      this.connectionProvider = new HttpConnection();
+    }
+    else {
+      this.connectionProvider = new XhrConnection();
+      console.log("Good");
+    }
     this.statusFactory = new StatusFactory();
     this.client = null;
     this.connection = null;
+    this.authProvider = new NoSaslAuthentication();
   }
 
   private getConnectionOptions(options: IDBSQLConnectionOptions): IConnectionOptions {

--- a/lib/DBSQLClient.ts
+++ b/lib/DBSQLClient.ts
@@ -19,7 +19,9 @@ import { buildUserAgentString, definedOrError } from './utils';
 import PlainHttpAuthentication from './connection/auth/PlainHttpAuthentication';
 import XhrConnection from './connection/connections/XhrConnection';
 
-function isNodejs() { return typeof "process" !== "undefined" && process && process.versions && process.versions.node; }
+function isNodejs() {
+  return typeof 'process' !== 'undefined' && process && process.versions && process.versions.node;
+}
 
 export default class DBSQLClient extends EventEmitter implements IDBSQLClient {
   private client: TCLIService.Client | null;
@@ -36,10 +38,9 @@ export default class DBSQLClient extends EventEmitter implements IDBSQLClient {
 
   constructor() {
     super();
-    if(isNodejs()) {
+    if (isNodejs()) {
       this.connectionProvider = new HttpConnection();
-    }
-    else {
+    } else {
       this.connectionProvider = new XhrConnection();
     }
     this.statusFactory = new StatusFactory();
@@ -62,29 +63,27 @@ export default class DBSQLClient extends EventEmitter implements IDBSQLClient {
 
   async connect(options: IDBSQLConnectionOptions): Promise<IDBSQLClient> {
     let opts;
-    if(isNodejs()){
+    if (isNodejs()) {
       opts = {
         username: 'token',
         password: options.token,
         headers: {
-          'User-Agent': buildUserAgentString(options.clientId)
-        }
-      }
-    }
-    else {
+          'User-Agent': buildUserAgentString(options.clientId),
+        },
+      };
+    } else {
       opts = {
         username: 'token',
-        password: options.token
-      }
+        password: options.token,
+      };
     }
     this.authProvider = new PlainHttpAuthentication(opts);
 
     this.connection = await this.connectionProvider.connect(this.getConnectionOptions(options), this.authProvider);
 
-    if(isNodejs()) {
+    if (isNodejs()) {
       this.client = this.thrift.createClient(TCLIService, this.connection.getConnection());
-    }
-    else {
+    } else {
       this.client = this.thrift.createXHRClient(TCLIService, this.connection.getConnection());
     }
     this.connection.getConnection().on('error', (error: Error) => {

--- a/lib/DBSQLClient.ts
+++ b/lib/DBSQLClient.ts
@@ -61,14 +61,17 @@ export default class DBSQLClient extends EventEmitter implements IDBSQLClient {
   }
 
   async connect(options: IDBSQLConnectionOptions): Promise<IDBSQLClient> {
-    let agentString = isNodejs() ? buildUserAgentString(options.clientId) : `NodejsDatabricksSqlConnector/0.1.8-beta.1 (${options.clientId})`;
-    this.authProvider = new PlainHttpAuthentication({
+    let opts = {
       username: 'token',
       password: options.token,
-      headers: {
-        'User-Agent': agentString,
-      },
-    });
+      headers: {}
+    }
+    if(isNodejs()){
+      opts.headers = {
+        'User-Agent': buildUserAgentString(options.clientId)
+      }
+    }
+    this.authProvider = new PlainHttpAuthentication(opts);
 
     this.connection = await this.connectionProvider.connect(this.getConnectionOptions(options), this.authProvider);
 

--- a/lib/connection/connections/XhrConnection.ts
+++ b/lib/connection/connections/XhrConnection.ts
@@ -1,0 +1,37 @@
+import thrift from 'thrift';
+import https from 'https';
+
+import IThriftConnection from '../contracts/IThriftConnection';
+import IConnectionProvider from '../contracts/IConnectionProvider';
+import IConnectionOptions, { Options } from '../contracts/IConnectionOptions';
+import IAuthentication from '../contracts/IAuthentication';
+import XhrTransport from '../transports/XhrTransport';
+
+export default class XhrConnection implements IConnectionProvider, IThriftConnection {
+    private thrift = thrift;
+    private connection: any;
+  
+    connect(options: IConnectionOptions, authProvider: IAuthentication): Promise<IThriftConnection> {
+        const xhrTransport = new XhrTransport({
+            transport: thrift.TBufferedTransport,
+            protocol: thrift.TBinaryProtocol,
+            ...options.options,
+        });
+        return authProvider.authenticate(xhrTransport).then(() => {
+            this.connection = this.thrift.createXHRConnection(options.host, options.port, xhrTransport.getOptions());
+            return this;
+        });
+    }
+
+    isConnected(): boolean {
+        if (this.connection) {
+          return true;
+        } else {
+          return false;
+        }
+      }
+
+    getConnection() {
+        return this.connection;
+    }
+}

--- a/lib/connection/connections/XhrConnection.ts
+++ b/lib/connection/connections/XhrConnection.ts
@@ -14,7 +14,7 @@ export default class XhrConnection implements IConnectionProvider, IThriftConnec
     connect(options: IConnectionOptions, authProvider: IAuthentication): Promise<IThriftConnection> {
         const xhrTransport = new XhrTransport({
             transport: thrift.TBufferedTransport,
-            protocol: thrift.TBinaryProtocol,
+            protocol: thrift.TJSONProtocol,
             ...options.options,
         });
         return authProvider.authenticate(xhrTransport).then(() => {

--- a/lib/connection/connections/XhrConnection.ts
+++ b/lib/connection/connections/XhrConnection.ts
@@ -15,6 +15,9 @@ export default class XhrConnection implements IConnectionProvider, IThriftConnec
         const xhrTransport = new XhrTransport({
             transport: thrift.TBufferedTransport,
             protocol: thrift.TJSONProtocol,
+            headers: {
+              'Content-Type': 'application/vnd.apache.thrift.json',
+             },
             ...options.options,
         });
         return authProvider.authenticate(xhrTransport).then(() => {

--- a/lib/connection/connections/XhrConnection.ts
+++ b/lib/connection/connections/XhrConnection.ts
@@ -14,10 +14,7 @@ export default class XhrConnection implements IConnectionProvider, IThriftConnec
     connect(options: IConnectionOptions, authProvider: IAuthentication): Promise<IThriftConnection> {
         const xhrTransport = new XhrTransport({
             transport: thrift.TBufferedTransport,
-            protocol: thrift.TJSONProtocol,
-            headers: {
-              'Content-Type': 'application/vnd.apache.thrift.json',
-             },
+            protocol: thrift.TBinaryProtocol,
             ...options.options,
         });
         return authProvider.authenticate(xhrTransport).then(() => {

--- a/lib/connection/connections/XhrConnection.ts
+++ b/lib/connection/connections/XhrConnection.ts
@@ -15,6 +15,9 @@ export default class XhrConnection implements IConnectionProvider, IThriftConnec
         const xhrTransport = new XhrTransport({
             transport: thrift.TBufferedTransport,
             protocol: thrift.TBinaryProtocol,
+            headers: {
+              'Content-Type': 'application/vnd.apache.thrift.binary'
+            },
             ...options.options,
         });
         return authProvider.authenticate(xhrTransport).then(() => {

--- a/lib/connection/connections/XhrConnection.ts
+++ b/lib/connection/connections/XhrConnection.ts
@@ -1,40 +1,39 @@
 import thrift from 'thrift';
-import https from 'https';
 
 import IThriftConnection from '../contracts/IThriftConnection';
 import IConnectionProvider from '../contracts/IConnectionProvider';
-import IConnectionOptions, { Options } from '../contracts/IConnectionOptions';
+import IConnectionOptions from '../contracts/IConnectionOptions';
 import IAuthentication from '../contracts/IAuthentication';
 import XhrTransport from '../transports/XhrTransport';
 
 export default class XhrConnection implements IConnectionProvider, IThriftConnection {
-    private thrift = thrift;
-    private connection: any;
-  
-    connect(options: IConnectionOptions, authProvider: IAuthentication): Promise<IThriftConnection> {
-        const xhrTransport = new XhrTransport({
-            transport: thrift.TBufferedTransport,
-            protocol: thrift.TBinaryProtocol,
-            headers: {
-              'Content-Type': 'application/vnd.apache.thrift.binary'
-            },
-            ...options.options,
-        });
-        return authProvider.authenticate(xhrTransport).then(() => {
-            this.connection = this.thrift.createXHRConnection(options.host, options.port, xhrTransport.getOptions());
-            return this;
-        });
-    }
+  private thrift = thrift;
 
-    isConnected(): boolean {
-        if (this.connection) {
-          return true;
-        } else {
-          return false;
-        }
-      }
+  private connection: any;
 
-    getConnection() {
-        return this.connection;
+  connect(options: IConnectionOptions, authProvider: IAuthentication): Promise<IThriftConnection> {
+    const xhrTransport = new XhrTransport({
+      transport: thrift.TBufferedTransport,
+      protocol: thrift.TBinaryProtocol,
+      headers: {
+        'Content-Type': 'application/vnd.apache.thrift.binary',
+      },
+      ...options.options,
+    });
+    return authProvider.authenticate(xhrTransport).then(() => {
+      this.connection = this.thrift.createXHRConnection(options.host, options.port, xhrTransport.getOptions());
+      return this;
+    });
+  }
+
+  isConnected(): boolean {
+    if (this.connection) {
+      return true;
     }
+    return false;
+  }
+
+  getConnection() {
+    return this.connection;
+  }
 }

--- a/lib/connection/transports/XhrTransport.ts
+++ b/lib/connection/transports/XhrTransport.ts
@@ -1,32 +1,36 @@
 import ITransport from '../contracts/ITransport';
 
 export default class XhrTransport implements ITransport {
-    private xhrOptions: object;
-  
-    constructor(httpOptions: object = {}) {
-      this.xhrOptions = httpOptions;
-    }
-  
-    getTransport(): any {
-      return this.xhrOptions;
-    }
-  
-    setOptions(option: string, value: any) {
-      this.xhrOptions = {
-        ...this.xhrOptions,
-        [option]: value,
-      };
-    }
-  
-    getOptions(): object {
-      return this.xhrOptions;
-    }
-  
-    connect() {}
-    addListener() {}
-    removeListener() {}
-    write() {}
-    end() {}
-    emit() {}
+  private xhrOptions: object;
+
+  constructor(httpOptions: object = {}) {
+    this.xhrOptions = httpOptions;
   }
-  
+
+  getTransport(): any {
+    return this.xhrOptions;
+  }
+
+  setOptions(option: string, value: any) {
+    this.xhrOptions = {
+      ...this.xhrOptions,
+      [option]: value,
+    };
+  }
+
+  getOptions(): object {
+    return this.xhrOptions;
+  }
+
+  connect() {}
+
+  addListener() {}
+
+  removeListener() {}
+
+  write() {}
+
+  end() {}
+
+  emit() {}
+}

--- a/lib/connection/transports/XhrTransport.ts
+++ b/lib/connection/transports/XhrTransport.ts
@@ -1,0 +1,32 @@
+import ITransport from '../contracts/ITransport';
+
+export default class XhrTransport implements ITransport {
+    private xhrOptions: object;
+  
+    constructor(httpOptions: object = {}) {
+      this.xhrOptions = httpOptions;
+    }
+  
+    getTransport(): any {
+      return this.xhrOptions;
+    }
+  
+    setOptions(option: string, value: any) {
+      this.xhrOptions = {
+        ...this.xhrOptions,
+        [option]: value,
+      };
+    }
+  
+    getOptions(): object {
+      return this.xhrOptions;
+    }
+  
+    connect() {}
+    addListener() {}
+    removeListener() {}
+    write() {}
+    end() {}
+    emit() {}
+  }
+  

--- a/package.json
+++ b/package.json
@@ -69,6 +69,6 @@
   "dependencies": {
     "commander": "^9.3.0",
     "node-int64": "^0.4.0",
-    "thrift": "^0.16.0"
+    "thrift": "github:nithinkdb/thrift#xhr-binary"
   }
 }

--- a/package.json
+++ b/package.json
@@ -69,6 +69,6 @@
   "dependencies": {
     "commander": "^9.3.0",
     "node-int64": "^0.4.0",
-    "thrift": "github:nithinkdb/thrift#xhr-binary"
+    "thrift": "^0.16.0"
   }
 }


### PR DESCRIPTION
This PR enables XHR connections in the cases where our connector is run from the browser. A couple things to note:
1. There is currently a bug within the thrift project itself. I've drafted a PR to resolve the issue, and hopefully it will be merged/released soon. We can also consider forking the repo if necessary. Here's the link: https://github.com/apache/thrift/pull/2645
2. In order to avoid cors errors, all outgoing connections should be routed through a proxy. I've made a sample repo to show customers how it works.
https://github.com/nithinkdb/connectorjstest
I haven't made it public yet in order to avoid confusion, given that none of this code will actually work until the PR on the thrift side completes. In the meantime, though, I think it'd be good to merge this helper code.
Worst case scenario, I have a fork of the thrift repo with the correct code, but that seems like overkill/unnecessary.
Note: This is not a GA blocker.