### PR TITLE
Ability to specify tests to run

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ npm run build
 Run the tests
 
 ```bash
-npm run test
+npm test
 npm run e2e
 ```
 
@@ -104,6 +104,7 @@ npm run prettier
 npm run prettier:fix
 npm run lint
 npm run lint:fix
+npm run type-check
 ```
 
 ## Pull Request Process

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ npm test <path/to/file.test.js>
 
 ### e2e tests
 
-Before running end-to-end tests, create a  file named `tests/e2e/utils/config.local.js` and set the Databricks SQL connection info:
+Before running end-to-end tests, create a file named `tests/e2e/utils/config.local.js` and set the Databricks SQL connection info:
 
 ```javascript
 {

--- a/README.md
+++ b/README.md
@@ -61,29 +61,16 @@ client
 
 ### Unit tests
 
+You can run all unit tests, or specify a specific test to run:
+
 ```bash
-npm run test
-```
-
-You can specify a specific test to run by changing `package.json`:
-
-```json
-"scripts": {
-    "test": "nyc --reporter=lcov mocha 'tests/unit/result/JsonResult.test.js'",
-}
-```
-
-Or to run all unit tests:
-
-```json
-"scripts": {
-    "test": "nyc --reporter=lcov mocha 'tests/unit/**/*.test.js'",
-}
+npm test
+npm test <path/to/file.test.js>
 ```
 
 ### e2e tests
 
-Before running end-to-end tests, copy the [sample configuration file](tests/e2e/utils/config.js) into the repository root and set the Databricks SQL connection info:
+Before running end-to-end tests, create a  file named `tests/e2e/utils/config.local.js` and set the Databricks SQL connection info:
 
 ```javascript
 {
@@ -98,6 +85,7 @@ Then run
 
 ```bash
 npm run e2e
+npm run e2e <path/to/file.test.js>
 ```
 
 ## Contributing

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   },
   "scripts": {
     "prepare": "npm run build",
-    "e2e": "nyc --reporter=lcov --report-dir=coverage_e2e mocha 'tests/e2e/**/*.test.js' --timeout=300000",
-    "test": "nyc --reporter=lcov --report-dir=coverage_unit mocha 'tests/unit/**/*.test.js'",
+    "e2e": "nyc --reporter=lcov --report-dir=coverage_e2e mocha --config tests/e2e/.mocharc.js",
+    "test": "nyc --reporter=lcov --report-dir=coverage_unit mocha  --config tests/unit/.mocharc.js",
     "build": "tsc",
     "watch": "tsc -w",
     "type-check": "tsc --noEmit",

--- a/tests/e2e/.mocharc.js
+++ b/tests/e2e/.mocharc.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const allSpecs = 'tests/e2e/**/*.test.js';
+
+const argvSpecs = process.argv.slice(4);
+
+module.exports = {
+  spec: argvSpecs.length > 0 ? argvSpecs : allSpecs,
+  timeout: '300000',
+};

--- a/tests/unit/.mocharc.js
+++ b/tests/unit/.mocharc.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const allSpecs = 'tests/unit/**/*.test.js';
+
+const argvSpecs = process.argv.slice(4);
+
+module.exports = {
+  spec: argvSpecs.length > 0 ? argvSpecs : allSpecs,
+};


### PR DESCRIPTION
`npm test`/`npm run e2e` without arguments will run all the tests; if one (or multiple) files passed - only them will be used. See updated README for examples.

Also, fixed a typo about e2e config location.