### PR TITLE
Made initial changes for query parameterization

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,7 +12,9 @@
         "consistent-return": "off",
         "no-param-reassign": "off",
         "no-bitwise": "off",
-        "@typescript-eslint/no-throw-literal": "off"
+        "@typescript-eslint/no-throw-literal": "off",
+        "@typescript-eslint/no-use-before-define": "off",
+        "no-restricted-syntax": "off"
       }
     }
   ]

--- a/lib/DBSQLSession.ts
+++ b/lib/DBSQLSession.ts
@@ -15,6 +15,7 @@ import Status from './dto/Status';
 import StatusFactory from './factory/StatusFactory';
 import InfoValue from './dto/InfoValue';
 import { definedOrError } from './utils';
+import formatQuery from './utils/formatQuery';
 
 export default class DBSQLSession implements IDBSQLSession {
   private driver: HiveDriver;
@@ -47,6 +48,10 @@ export default class DBSQLSession implements IDBSQLSession {
       runAsync: false,
       ...options,
     };
+
+    if (options.queryParams) {
+      statement = formatQuery(statement, options.queryParams);
+    }
 
     return this.driver
       .executeStatement({

--- a/lib/contracts/IDBSQLSession.ts
+++ b/lib/contracts/IDBSQLSession.ts
@@ -16,6 +16,7 @@ export type ExecuteStatementOptions = {
   runAsync?: boolean;
   confOverlay?: Record<string, string>;
   queryTimeout?: Int64;
+  queryParams?: { [name: string]: any };
 };
 
 export type SchemasRequest = {

--- a/lib/utils/formatQuery.ts
+++ b/lib/utils/formatQuery.ts
@@ -1,0 +1,53 @@
+const formatUnicorn = require('format-unicorn/safe');
+
+function escapeNumber(param: Number): string {
+  return param.toString();
+}
+
+function escapeString(param: string): string {
+  return `'${param.replace("'", "''")}'`;
+}
+
+function escapeSequence(param: Array<any>): string {
+  const escapedArray: string[] = [];
+  param.forEach((element) => {
+    escapedArray.push(escapeItem(element));
+  });
+  return `(${escapedArray.join(',')})`;
+}
+
+function zeroPad(number: Number): string {
+  return number.toString().padStart(2);
+}
+
+function escapeDate(param: Date): string {
+  return `${param.getFullYear()}-${zeroPad(param.getMonth() + 1)}-${zeroPad(param.getDate())} ${zeroPad(
+    param.getHours(),
+  )}:${zeroPad(param.getMinutes())}:${zeroPad(param.getSeconds())}`;
+}
+
+function escapeItem(param: any): string {
+  switch (typeof param) {
+    case 'string':
+      return escapeString(param);
+    case 'number':
+      return escapeNumber(param);
+    case 'object':
+      if (param.isArray()) {
+        return escapeSequence(param);
+      }
+      if (param instanceof Date) return escapeDate(param);
+      break;
+    default:
+      break;
+  }
+  throw new Error('Unexpected parameter');
+}
+
+export default function formatQuery(statement: string, queryParams: { [name: string]: any }): string {
+  const sanitizedParams: { [name: string]: string } = {};
+  for (const [key, value] of Object.entries(queryParams)) {
+    sanitizedParams[key] = escapeItem(value);
+  }
+  return formatUnicorn(statement, sanitizedParams);
+}

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -1,5 +1,6 @@
 import definedOrError from './definedOrError';
 import buildUserAgentString from './buildUserAgentString';
 import formatProgress, { ProgressUpdateTransformer } from './formatProgress';
+import formatQuery from './formatQuery';
 
-export { definedOrError, buildUserAgentString, formatProgress, ProgressUpdateTransformer };
+export { definedOrError, buildUserAgentString, formatProgress, ProgressUpdateTransformer, formatQuery };

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   },
   "dependencies": {
     "commander": "^9.3.0",
+    "format-unicorn": "^1.1.1",
     "node-int64": "^0.4.0",
     "thrift": "^0.16.0"
   }

--- a/tests/unit/utils.test.js
+++ b/tests/unit/utils.test.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 
-const { buildUserAgentString, formatProgress, ProgressUpdateTransformer } = require('../../dist/utils');
+const { buildUserAgentString, formatProgress, ProgressUpdateTransformer, formatQuery } = require('../../dist/utils');
 
 describe('buildUserAgentString', () => {
   // It should follow https://www.rfc-editor.org/rfc/rfc7231#section-5.5.3 and
@@ -73,5 +73,15 @@ describe('ProgressUpdateTransformer', () => {
     expect(String(t)).to.be.eq(
       'Column 1  |Column 2  \n' + 'value 1.1 |value 1.2 \n' + 'value 2.1 |value 2.2 \n' + 'footer',
     );
+  });
+});
+
+describe('formatQuery', () => {
+  it('formats query', () => {
+    let options = {
+      table: ";' DROP TABLE USERS",
+    };
+    const result = formatQuery('select * from {table}', options);
+    expect(result).to.be.eq("select * from ';'' DROP TABLE USERS'");
   });
 });


### PR DESCRIPTION
Modeled escaping methods after Python version. I do have some reservations about the way strings are escaped/some things I'd like to clarify, but overall I think this is a good starting point. I'll add some more test cases over the next day, but apparently Jesse has a docker container that is designed to test malformed queries, so I'll only do more work on that end after syncing with him.