### PR TITLE
Support http agent for non https connections

### DIFF
--- a/lib/connection/connections/HttpConnection.ts
+++ b/lib/connection/connections/HttpConnection.ts
@@ -21,7 +21,7 @@ export default class HttpConnection implements IConnectionProvider, IThriftConne
   private connection: any;
 
   connect(options: IConnectionOptions, authProvider: IAuthentication): Promise<IThriftConnection> {
-    const Agent = options.options?.https === false ? http.Agent : https.Agent;
+    const Agent = options.options?.https ? https.Agent : http.Agent;
     const httpTransport = new HttpTransport({
       transport: thrift.TBufferedTransport,
       protocol: thrift.TBinaryProtocol,

--- a/lib/connection/connections/HttpConnection.ts
+++ b/lib/connection/connections/HttpConnection.ts
@@ -1,7 +1,7 @@
 import thrift from 'thrift';
 import https from 'https';
 
-import { IncomingMessage } from 'http';
+import http, { IncomingMessage } from 'http';
 import IThriftConnection from '../contracts/IThriftConnection';
 import IConnectionProvider from '../contracts/IConnectionProvider';
 import IConnectionOptions, { Options } from '../contracts/IConnectionOptions';
@@ -21,12 +21,13 @@ export default class HttpConnection implements IConnectionProvider, IThriftConne
   private connection: any;
 
   connect(options: IConnectionOptions, authProvider: IAuthentication): Promise<IThriftConnection> {
+    const Agent = options.options?.https === false ? http.Agent : https.Agent;
     const httpTransport = new HttpTransport({
       transport: thrift.TBufferedTransport,
       protocol: thrift.TBinaryProtocol,
       ...options.options,
       nodeOptions: {
-        agent: new https.Agent({
+        agent: new Agent({
           keepAlive: true,
           maxSockets: 5,
           keepAliveMsecs: 10000,

--- a/tests/unit/connection/connections/HttpConnection.test.js
+++ b/tests/unit/connection/connections/HttpConnection.test.js
@@ -1,3 +1,4 @@
+const http = require('http');
 const { expect } = require('chai');
 const HttpConnection = require('../../../../').connections.HttpConnection;
 
@@ -159,6 +160,31 @@ describe('HttpConnection.connect', () => {
         resultConnection.responseCallback({ headers: {} });
         expect(resultConnection.executed).to.be.true;
         expect(Object.keys(connection.thrift.options.nodeOptions)).to.be.deep.eq(['agent']);
+      });
+  });
+
+  it('should use a http agent if https is not enabled', () => {
+    const connection = new HttpConnection();
+    const authenticator = authProviderMock();
+    const resultConnection = {
+      responseCallback() {},
+    };
+    connection.thrift = thriftMock(resultConnection);
+
+    return connection
+      .connect(
+        {
+          host: 'localhost',
+          port: 10001,
+          options: {
+            https: false,
+            path: '/hive',
+          },
+        },
+        authenticator,
+      )
+      .then(() => {
+        expect(connection.thrift.options.nodeOptions.agent).to.be.instanceOf(http.Agent);
       });
   });
 });


### PR DESCRIPTION
Currently connections using `https: false` still attempt to use the `https.Agent`. This causes thrift to throw an error. This PR uses the plain `http.Agent` in the case `https: false` in order to fix this.

<details>
<summary>Code + Error</summary>

```javascript
const client = new DBSQLClient();
const conn = await client.connect({
  host: "redacted",
  path: "redacted",
  // other options
  https: false,
  ssl: false,
  headers: {'X-redacted': 'true'},
});

const sess = await conn.openSession();
const queryOp = await sess.executeStatement('SELECT "Hello, World!"', { runAsync: true });
const result = await queryOperation.fetchAll();
console.table(result);
await queryOperation.close();
await sess.close();
await conn.close();
```

```
TypeError [ERR_INVALID_PROTOCOL]: Protocol "http:" not supported. Expected "https:"
    at new NodeError (node:internal/errors:393:5)
    at new ClientRequest (node:_http_client:186:11)
    at Object.request (node:http:97:10)
    at HttpConnection.write (/databricks-sql-nodejs-main/node_modules/thrift/lib/nodejs/lib/thrift/http_connection.js:223:12)
    at TBufferedTransport.writeCb [as onFlush] (/databricks-sql-nodejs-main/node_modules/thrift/lib/nodejs/lib/thrift/create_client.js:47:16)
    at TBufferedTransport.flush (/databricks-sql-nodejs-main/node_modules/thrift/lib/nodejs/lib/thrift/buffered_transport.js:181:10)
    at TCLIServiceClient.send_OpenSession (/databricks-sql-nodejs-main/thrift/TCLIService.js:2198:24)
    at TCLIServiceClient.OpenSession (/databricks-sql-nodejs-main/thrift/TCLIService.js:2184:10)
    at /databricks-sql-nodejs-main/dist/hive/Commands/BaseCommand.js:19:25
    at new Promise (<anonymous>) {
  code: 'ERR_INVALID_PROTOCOL'
}
```
</details>