### PR TITLE
[PECO-319] Pending status should not be considered error

### DIFF
--- a/lib/DBSQLOperation/OperationStatusHelper.ts
+++ b/lib/DBSQLOperation/OperationStatusHelper.ts
@@ -4,6 +4,14 @@ import StatusFactory from '../factory/StatusFactory';
 import { OperationStatusCallback } from '../contracts/IOperation';
 import OperationStateError from '../errors/OperationStateError';
 
+async function delay(ms?: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve();
+    }, ms);
+  });
+}
+
 export default class OperationStatusHelper {
   private driver: HiveDriver;
 
@@ -104,6 +112,7 @@ export default class OperationStatusHelper {
     }
     const isReady = await this.isReady(progress, callback);
     if (!isReady) {
+      await delay(100); // add some delay between status requests
       return this.waitUntilReady(progress, callback);
     }
   }

--- a/lib/DBSQLOperation/OperationStatusHelper.ts
+++ b/lib/DBSQLOperation/OperationStatusHelper.ts
@@ -32,6 +32,7 @@ export default class OperationStatusHelper {
   private isInProgress(response: TGetOperationStatusResp) {
     switch (response.operationState) {
       case TOperationState.INITIALIZED_STATE:
+      case TOperationState.PENDING_STATE:
       case TOperationState.RUNNING_STATE:
         return true;
       default:
@@ -77,6 +78,8 @@ export default class OperationStatusHelper {
     switch (response.operationState) {
       case TOperationState.INITIALIZED_STATE:
         return false;
+      case TOperationState.PENDING_STATE:
+        return false;
       case TOperationState.RUNNING_STATE:
         return false;
       case TOperationState.FINISHED_STATE:
@@ -87,8 +90,6 @@ export default class OperationStatusHelper {
         throw new OperationStateError('The operation was closed by a client', response);
       case TOperationState.ERROR_STATE:
         throw new OperationStateError('The operation failed due to an error', response);
-      case TOperationState.PENDING_STATE:
-        throw new OperationStateError('The operation is in a pending state', response);
       case TOperationState.TIMEDOUT_STATE:
         throw new OperationStateError('The operation is in a timed out state', response);
       case TOperationState.UKNOWN_STATE:


### PR DESCRIPTION
Internal ticket number: [PECO-319]

Fixes databricks/databricks-sql-nodejs#58

When cluster is stopped, attempt to run any operation against it will initiate cluster start, and the operation will enter a `PENDING_STATE` state. Previously this state for some reason was considered an error, but in fact once cluster is up, operation moves on and is executed properly.

https://github.com/databricks/databricks-sql-nodejs/commit/8f8c5c6f53ff24c54eea14dcfbf8320720362088 contains the actual fix

https://github.com/databricks/databricks-sql-nodejs/commit/e50054d283a6fd856c26ef724df560c76c8325c8 is a minor improvement that adds some delay between requests for operation status