### PR TITLE
[PECO-237] Direct results support for all operations

### DIFF
--- a/lib/contracts/IDBSQLSession.ts
+++ b/lib/contracts/IDBSQLSession.ts
@@ -3,15 +3,6 @@ import Status from '../dto/Status';
 import InfoValue from '../dto/InfoValue';
 import { Int64 } from '../hive/Types';
 
-export type CrossReferenceRequest = {
-  parentCatalogName: string;
-  parentSchemaName: string;
-  parentTableName: string;
-  foreignCatalogName: string;
-  foreignSchemaName: string;
-  foreignTableName: string;
-};
-
 export type ExecuteStatementOptions = {
   runAsync?: boolean;
   confOverlay?: Record<string, string>;
@@ -19,9 +10,18 @@ export type ExecuteStatementOptions = {
   maxRows?: number;
 };
 
+export type TypeInfoRequest = {
+  maxRows?: number;
+};
+
+export type CatalogsRequest = {
+  maxRows?: number;
+};
+
 export type SchemasRequest = {
-  schemaName?: string;
   catalogName?: string;
+  schemaName?: string;
+  maxRows?: number;
 };
 
 export type TablesRequest = {
@@ -29,25 +29,43 @@ export type TablesRequest = {
   schemaName?: string;
   tableName?: string;
   tableTypes?: Array<string>;
+  maxRows?: number;
 };
 
-export type ColumnRequest = {
+export type TableTypesRequest = {
+  maxRows?: number;
+};
+
+export type ColumnsRequest = {
   catalogName?: string;
   schemaName?: string;
   tableName?: string;
   columnName?: string;
+  maxRows?: number;
 };
 
-export type FunctionNameRequest = {
-  functionName: string;
+export type FunctionsRequest = {
   catalogName?: string;
   schemaName?: string;
+  functionName: string;
+  maxRows?: number;
 };
 
 export type PrimaryKeysRequest = {
+  catalogName?: string;
   schemaName: string;
   tableName: string;
-  catalogName?: string;
+  maxRows?: number;
+};
+
+export type CrossReferenceRequest = {
+  parentCatalogName: string;
+  parentSchemaName: string;
+  parentTableName: string;
+  foreignCatalogName: string;
+  foreignSchemaName: string;
+  foreignTableName: string;
+  maxRows?: number;
 };
 
 export default interface IDBSQLSession {
@@ -67,47 +85,53 @@ export default interface IDBSQLSession {
   executeStatement(statement: string, options?: ExecuteStatementOptions): Promise<IOperation>;
 
   /**
-   * Informataion about supported data types
+   * Information about supported data types
+   *
+   * @param request
    */
-  getTypeInfo(): Promise<IOperation>;
+  getTypeInfo(request?: TypeInfoRequest): Promise<IOperation>;
 
   /**
    * Get list of catalogs
+   *
+   * @param request
    */
-  getCatalogs(): Promise<IOperation>;
+  getCatalogs(request?: CatalogsRequest): Promise<IOperation>;
 
   /**
    * Get list of databases
    *
    * @param request
    */
-  getSchemas(request: SchemasRequest): Promise<IOperation>;
+  getSchemas(request?: SchemasRequest): Promise<IOperation>;
 
   /**
    * Get list of tables
    *
    * @param request
    */
-  getTables(request: TablesRequest): Promise<IOperation>;
+  getTables(request?: TablesRequest): Promise<IOperation>;
 
   /**
    * Get list of supported table types
+   *
+   * @param request
    */
-  getTableTypes(): Promise<IOperation>;
+  getTableTypes(request?: TableTypesRequest): Promise<IOperation>;
 
   /**
    * Get full information about columns of the table
    *
    * @param request
    */
-  getColumns(request: ColumnRequest): Promise<IOperation>;
+  getColumns(request?: ColumnsRequest): Promise<IOperation>;
 
   /**
    * Get information about function
    *
    * @param request
    */
-  getFunctions(request: FunctionNameRequest): Promise<IOperation>;
+  getFunctions(request: FunctionsRequest): Promise<IOperation>;
 
   /**
    * Get primary keys of table

--- a/tests/unit/DBSQLSession.test.js
+++ b/tests/unit/DBSQLSession.test.js
@@ -66,6 +66,12 @@ describe('DBSQLSession', () => {
       const result = await session.getTypeInfo();
       expect(result).instanceOf(DBSQLOperation);
     });
+
+    it('should use direct results', async () => {
+      const session = createSession();
+      const result = await session.getTypeInfo({ maxRows: 10 });
+      expect(result).instanceOf(DBSQLOperation);
+    });
   });
 
   describe('getCatalogs', () => {
@@ -74,14 +80,34 @@ describe('DBSQLSession', () => {
       const result = await session.getCatalogs();
       expect(result).instanceOf(DBSQLOperation);
     });
+
+    it('should use direct results', async () => {
+      const session = createSession();
+      const result = await session.getCatalogs({ maxRows: 10 });
+      expect(result).instanceOf(DBSQLOperation);
+    });
   });
 
   describe('getSchemas', () => {
     it('should run operation', async () => {
       const session = createSession();
+      const result = await session.getSchemas();
+      expect(result).instanceOf(DBSQLOperation);
+    });
+
+    it('should use filters', async () => {
+      const session = createSession();
       const result = await session.getSchemas({
         catalogName: 'catalog',
         schemaName: 'schema',
+      });
+      expect(result).instanceOf(DBSQLOperation);
+    });
+
+    it('should use direct results', async () => {
+      const session = createSession();
+      const result = await session.getSchemas({
+        maxRows: 10,
       });
       expect(result).instanceOf(DBSQLOperation);
     });
@@ -90,11 +116,25 @@ describe('DBSQLSession', () => {
   describe('getTables', () => {
     it('should run operation', async () => {
       const session = createSession();
+      const result = await session.getTables();
+      expect(result).instanceOf(DBSQLOperation);
+    });
+
+    it('should use filters', async () => {
+      const session = createSession();
       const result = await session.getTables({
         catalogName: 'catalog',
         schemaName: 'default',
         tableName: 't1',
         tableTypes: ['external'],
+      });
+      expect(result).instanceOf(DBSQLOperation);
+    });
+
+    it('should use direct results', async () => {
+      const session = createSession();
+      const result = await session.getTables({
+        maxRows: 10,
       });
       expect(result).instanceOf(DBSQLOperation);
     });
@@ -106,16 +146,36 @@ describe('DBSQLSession', () => {
       const result = await session.getTableTypes();
       expect(result).instanceOf(DBSQLOperation);
     });
+
+    it('should use direct results', async () => {
+      const session = createSession();
+      const result = await session.getTableTypes({ maxRows: 10 });
+      expect(result).instanceOf(DBSQLOperation);
+    });
   });
 
   describe('getColumns', () => {
     it('should run operation', async () => {
+      const session = createSession();
+      const result = await session.getColumns();
+      expect(result).instanceOf(DBSQLOperation);
+    });
+
+    it('should use filters', async () => {
       const session = createSession();
       const result = await session.getColumns({
         catalogName: 'catalog',
         schemaName: 'schema',
         tableName: 'table',
         columnName: 'column',
+      });
+      expect(result).instanceOf(DBSQLOperation);
+    });
+
+    it('should use direct results', async () => {
+      const session = createSession();
+      const result = await session.getColumns({
+        maxRows: 10,
       });
       expect(result).instanceOf(DBSQLOperation);
     });
@@ -131,6 +191,17 @@ describe('DBSQLSession', () => {
       });
       expect(result).instanceOf(DBSQLOperation);
     });
+
+    it('should use direct results', async () => {
+      const session = createSession();
+      const result = await session.getFunctions({
+        catalogName: 'catalog',
+        schemaName: 'schema',
+        functionName: 'avg',
+        maxRows: 10,
+      });
+      expect(result).instanceOf(DBSQLOperation);
+    });
   });
 
   describe('getPrimaryKeys', () => {
@@ -140,6 +211,17 @@ describe('DBSQLSession', () => {
         catalogName: 'catalog',
         schemaName: 'schema',
         tableName: 't1',
+      });
+      expect(result).instanceOf(DBSQLOperation);
+    });
+
+    it('should use direct results', async () => {
+      const session = createSession();
+      const result = await session.getPrimaryKeys({
+        catalogName: 'catalog',
+        schemaName: 'schema',
+        tableName: 't1',
+        maxRows: 10,
       });
       expect(result).instanceOf(DBSQLOperation);
     });
@@ -155,6 +237,20 @@ describe('DBSQLSession', () => {
         foreignCatalogName: 'foreignCatalogName',
         foreignSchemaName: 'foreignSchemaName',
         foreignTableName: 'foreignTableName',
+      });
+      expect(result).instanceOf(DBSQLOperation);
+    });
+
+    it('should use direct results', async () => {
+      const session = createSession();
+      const result = await session.getCrossReference({
+        parentCatalogName: 'parentCatalogName',
+        parentSchemaName: 'parentSchemaName',
+        parentTableName: 'parentTableName',
+        foreignCatalogName: 'foreignCatalogName',
+        foreignSchemaName: 'foreignSchemaName',
+        foreignTableName: 'foreignTableName',
+        maxRows: 10,
       });
       expect(result).instanceOf(DBSQLOperation);
     });

--- a/tests/unit/DBSQLSession.test.js
+++ b/tests/unit/DBSQLSession.test.js
@@ -22,8 +22,9 @@ const testMethod = (methodName, parameters, delegationToken) => {
 };
 
 describe('DBSQLSession', () => {
-  it('getInfo', () => {
-    return testMethod('getInfo', [1]).then((result) => {
+  describe('getInfo', () => {
+    it('should run operation', async () => {
+      const result = await testMethod('getInfo', [1]);
       expect(result).instanceOf(InfoValue);
     });
   });
@@ -43,126 +44,146 @@ describe('DBSQLSession', () => {
     });
   });
 
-  it('getTypeInfo', () => {
-    return testMethod('getTypeInfo', []).then((result) => {
+  describe('getTypeInfo', () => {
+    it('should run operation', async () => {
+      const result = await testMethod('getTypeInfo', []);
       expect(result).instanceOf(DBSQLOperation);
     });
   });
-  it('getCatalogs', () => {
-    return testMethod('getCatalogs', []).then((result) => {
+
+  describe('getCatalogs', () => {
+    it('should run operation', async () => {
+      const result = await testMethod('getCatalogs', []);
       expect(result).instanceOf(DBSQLOperation);
     });
   });
-  it('getSchemas', () => {
-    return testMethod('getSchemas', [
-      {
-        catalogName: 'catalog',
-        schemaName: 'schema',
-      },
-    ]).then((result) => {
+
+  describe('getSchemas', () => {
+    it('should run operation', async () => {
+      const result = await testMethod('getSchemas', [
+        {
+          catalogName: 'catalog',
+          schemaName: 'schema',
+        },
+      ]);
       expect(result).instanceOf(DBSQLOperation);
     });
   });
-  it('getTables', () => {
-    return testMethod('getTables', [
-      {
-        catalogName: 'catalog',
-        schemaName: 'default',
-        tableName: 't1',
-        tableTypes: ['external'],
-      },
-    ]).then((result) => {
+
+  describe('getTables', () => {
+    it('should run operation', async () => {
+      const result = await testMethod('getTables', [
+        {
+          catalogName: 'catalog',
+          schemaName: 'default',
+          tableName: 't1',
+          tableTypes: ['external'],
+        },
+      ]);
       expect(result).instanceOf(DBSQLOperation);
     });
   });
-  it('getTableTypes', () => {
-    return testMethod('getTableTypes', []).then((result) => {
+
+  describe('getTableTypes', () => {
+    it('should run operation', async () => {
+      const result = await testMethod('getTableTypes', []);
       expect(result).instanceOf(DBSQLOperation);
     });
   });
-  it('getColumns', () => {
-    return testMethod('getColumns', [
-      {
-        catalogName: 'catalog',
-        schemaName: 'schema',
-        tableName: 'table',
-        columnName: 'column',
-      },
-    ]).then((result) => {
+
+  describe('getColumns', () => {
+    it('should run operation', async () => {
+      const result = await testMethod('getColumns', [
+        {
+          catalogName: 'catalog',
+          schemaName: 'schema',
+          tableName: 'table',
+          columnName: 'column',
+        },
+      ]);
       expect(result).instanceOf(DBSQLOperation);
     });
   });
-  it('getFunctions', () => {
-    return testMethod('getFunctions', [
-      {
-        catalogName: 'catalog',
-        schemaName: 'schema',
-        functionName: 'avg',
-      },
-    ]).then((result) => {
+
+  describe('getFunctions', () => {
+    it('should run operation', async () => {
+      const result = await testMethod('getFunctions', [
+        {
+          catalogName: 'catalog',
+          schemaName: 'schema',
+          functionName: 'avg',
+        },
+      ]);
       expect(result).instanceOf(DBSQLOperation);
     });
   });
-  it('getPrimaryKeys', () => {
-    return testMethod('getPrimaryKeys', [
-      {
-        catalogName: 'catalog',
-        schemaName: 'schema',
-        tableName: 't1',
-      },
-    ]).then((result) => {
+
+  describe('getPrimaryKeys', () => {
+    it('should run operation', async () => {
+      const result = await testMethod('getPrimaryKeys', [
+        {
+          catalogName: 'catalog',
+          schemaName: 'schema',
+          tableName: 't1',
+        },
+      ]);
       expect(result).instanceOf(DBSQLOperation);
     });
   });
-  it('getCrossReference', () => {
-    return testMethod('getCrossReference', [
-      {
-        parentCatalogName: 'parentCatalogName',
-        parentSchemaName: 'parentSchemaName',
-        parentTableName: 'parentTableName',
-        foreignCatalogName: 'foreignCatalogName',
-        foreignSchemaName: 'foreignSchemaName',
-        foreignTableName: 'foreignTableName',
-      },
-    ]).then((result) => {
+
+  describe('getCrossReference', () => {
+    it('should run operation', async () => {
+      const result = await testMethod('getCrossReference', [
+        {
+          parentCatalogName: 'parentCatalogName',
+          parentSchemaName: 'parentSchemaName',
+          parentTableName: 'parentTableName',
+          foreignCatalogName: 'foreignCatalogName',
+          foreignSchemaName: 'foreignSchemaName',
+          foreignTableName: 'foreignTableName',
+        },
+      ]);
       expect(result).instanceOf(DBSQLOperation);
     });
   });
-  it('getDelegationToken', () => {
-    return testMethod('getDelegationToken', ['owner', 'renewer'], 'token')
-      .then((result) => {
-        expect(result).to.be.eq('token');
-      })
-      .then(() => {
-        return testMethod('getDelegationToken', ['owner', 'renewer']);
-      })
-      .then((result) => {
-        expect(result).to.be.eq('');
-      });
-  });
-  it('renewDelegationToken', () => {
-    return testMethod('renewDelegationToken', ['token']).then((result) => {
-      expect(result).instanceOf(Status);
+
+  describe('getDelegationToken', () => {
+    it('should run operation', async () => {
+      const result1 = await testMethod('getDelegationToken', ['owner', 'renewer'], 'token');
+      expect(result1).to.be.eq('token');
+
+      const result2 = await testMethod('getDelegationToken', ['owner', 'renewer']);
+      expect(result2).to.be.eq('');
     });
   });
-  it('cancelDelegationToken', () => {
-    return testMethod('cancelDelegationToken', ['token']).then((result) => {
+
+  describe('renewDelegationToken', () => {
+    it('should run operation', async () => {
+      const result = await testMethod('renewDelegationToken', ['token']);
       expect(result).instanceOf(Status);
     });
   });
 
-  it('close', () => {
-    const driver = {
-      closeSession: () =>
-        Promise.resolve({
-          status: {
-            statusCode: 0,
-          },
-        }),
-    };
-    const session = new DBSQLSession(driver, { sessionId: 'id' });
+  describe('cancelDelegationToken', () => {
+    it('should run operation', async () => {
+      const result = await testMethod('cancelDelegationToken', ['token']);
+      expect(result).instanceOf(Status);
+    });
+  });
 
-    return session.close().then((result) => {
+  describe('close', () => {
+    it('should run operation', async () => {
+      const driver = {
+        closeSession: () =>
+          Promise.resolve({
+            status: {
+              statusCode: 0,
+            },
+          }),
+      };
+      const session = new DBSQLSession(driver, { sessionId: 'id' });
+
+      const result = await session.close();
       expect(result).instanceOf(Status);
     });
   });


### PR DESCRIPTION
databricks/databricks-sql-nodejs#51 follow-up

Enable Direct results support for all operations that could use it.

In databricks/databricks-sql-nodejs#51, direct results support was implemented in IDBSQLOperation class, and ability to use it (through option `maxRows`) was added to IDBSQLSession.executeStatement.

This PR adds the same `maxRows` option to other methods of IDBSQLSession which allows to use direct results feature with them as well. _Note:_ not all the methods of IDBSQLSession support direct results; option was added only where it was possible.

Easier to review commit by commit:

- https://github.com/databricks/databricks-sql-nodejs/pull/63/commits/4d358fc7a8b09c4eb9b41400ea64229dae2a9dba contains actual changes
- next few commits are tests refactoring
- https://github.com/databricks/databricks-sql-nodejs/pull/63/commits/2ffeb0827f226cba0e3d45f933990fd32cb159a4 adds new tests