### PR TITLE
[PECO-217] DBSQLClient.openSession refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 0.1.x (Unreleased)
 
+- `DBSQLClient.openSession` now takes a limited set of options (`OpenSessionRequest` instead of Thrift's `TOpenSessionReq`)
+- `DBSQLClient.openSession` now uses the latest protocol version by default
+- Direct results feature is now available for all IOperation methods which support it. To enable direct results feature,
+  `maxRows` option should be used
+- `FunctionNameRequest` type renamed to `FunctionsRequest`
+- `IDBSQLConnectionOptions` type renamed to `ConnectionOptions`
+
 ## 0.1.8-beta.2 (2022-09-08)
 
 - Operations will wait for cluster to start instead of failing

--- a/lib/DBSQLClient.ts
+++ b/lib/DBSQLClient.ts
@@ -18,6 +18,19 @@ import HiveDriverError from './errors/HiveDriverError';
 import { buildUserAgentString, definedOrError } from './utils';
 import PlainHttpAuthentication from './connection/auth/PlainHttpAuthentication';
 
+function getInitialNamespaceOptions(catalogName?: string, schemaName?: string) {
+  if (!catalogName && !schemaName) {
+    return {};
+  }
+
+  return {
+    initialNamespace: {
+      catalogName,
+      schemaName,
+    },
+  };
+}
+
 export default class DBSQLClient extends EventEmitter implements IDBSQLClient {
   private client: TCLIService.Client | null;
 
@@ -102,6 +115,7 @@ export default class DBSQLClient extends EventEmitter implements IDBSQLClient {
         client_protocol: TProtocolVersion.SPARK_CLI_SERVICE_PROTOCOL_V6,
         configuration: request.configuration,
         connectionProperties: request.connectionProperties,
+        ...getInitialNamespaceOptions(request.initialCatalog, request.initialSchema),
       })
       .then((response) => {
         this.statusFactory.create(response.status);

--- a/lib/DBSQLClient.ts
+++ b/lib/DBSQLClient.ts
@@ -114,8 +114,6 @@ export default class DBSQLClient extends EventEmitter implements IDBSQLClient {
     return driver
       .openSession({
         client_protocol_i64: new Int64(TProtocolVersion.SPARK_CLI_SERVICE_PROTOCOL_V6),
-        configuration: request.configuration,
-        connectionProperties: request.connectionProperties,
         ...getInitialNamespaceOptions(request.initialCatalog, request.initialSchema),
       })
       .then((response) => {

--- a/lib/DBSQLClient.ts
+++ b/lib/DBSQLClient.ts
@@ -5,6 +5,7 @@ import TCLIService from '../thrift/TCLIService';
 import { TProtocolVersion } from '../thrift/TCLIService_types';
 import IDBSQLClient, { ConnectionOptions, OpenSessionRequest } from './contracts/IDBSQLClient';
 import HiveDriver from './hive/HiveDriver';
+import { Int64 } from './hive/Types';
 import DBSQLSession from './DBSQLSession';
 import IDBSQLSession from './contracts/IDBSQLSession';
 import IThriftConnection from './connection/contracts/IThriftConnection';
@@ -112,17 +113,14 @@ export default class DBSQLClient extends EventEmitter implements IDBSQLClient {
 
     return driver
       .openSession({
-        client_protocol: TProtocolVersion.SPARK_CLI_SERVICE_PROTOCOL_V6,
+        client_protocol_i64: new Int64(TProtocolVersion.SPARK_CLI_SERVICE_PROTOCOL_V6),
         configuration: request.configuration,
         connectionProperties: request.connectionProperties,
         ...getInitialNamespaceOptions(request.initialCatalog, request.initialSchema),
       })
       .then((response) => {
         this.statusFactory.create(response.status);
-
-        const session = new DBSQLSession(driver, definedOrError(response.sessionHandle));
-
-        return session;
+        return new DBSQLSession(driver, definedOrError(response.sessionHandle));
       });
   }
 

--- a/lib/contracts/IDBSQLClient.ts
+++ b/lib/contracts/IDBSQLClient.ts
@@ -1,7 +1,6 @@
-import { TOpenSessionReq } from '../../thrift/TCLIService_types';
 import IDBSQLSession from './IDBSQLSession';
 
-export interface IDBSQLConnectionOptions {
+export interface ConnectionOptions {
   host: string;
   port?: number;
   path: string;
@@ -9,10 +8,15 @@ export interface IDBSQLConnectionOptions {
   clientId?: string;
 }
 
-export default interface IDBSQLClient {
-  connect(options: IDBSQLConnectionOptions): Promise<IDBSQLClient>;
+export interface OpenSessionRequest {
+  configuration?: Record<string, string>;
+  connectionProperties?: Record<string, string>;
+}
 
-  openSession(request?: TOpenSessionReq): Promise<IDBSQLSession>;
+export default interface IDBSQLClient {
+  connect(options: ConnectionOptions): Promise<IDBSQLClient>;
+
+  openSession(request?: OpenSessionRequest): Promise<IDBSQLSession>;
 
   close(): Promise<void>;
 }

--- a/lib/contracts/IDBSQLClient.ts
+++ b/lib/contracts/IDBSQLClient.ts
@@ -9,6 +9,8 @@ export interface ConnectionOptions {
 }
 
 export interface OpenSessionRequest {
+  initialCatalog?: string;
+  initialSchema?: string;
   configuration?: Record<string, string>;
   connectionProperties?: Record<string, string>;
 }

--- a/lib/contracts/IDBSQLClient.ts
+++ b/lib/contracts/IDBSQLClient.ts
@@ -11,8 +11,6 @@ export interface ConnectionOptions {
 export interface OpenSessionRequest {
   initialCatalog?: string;
   initialSchema?: string;
-  configuration?: Record<string, string>;
-  connectionProperties?: Record<string, string>;
 }
 
 export default interface IDBSQLClient {

--- a/tests/e2e/batched_fetch.test.js
+++ b/tests/e2e/batched_fetch.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const config = require('./utils/config');
 const logger = require('./utils/logger')(config.logger);
-const { DBSQLClient, thrift } = require('../..');
+const { DBSQLClient } = require('../..');
 
 const openSession = async () => {
   const client = new DBSQLClient();
@@ -12,18 +12,10 @@ const openSession = async () => {
     token: config.token,
   });
 
-  const openSessionRequest = {};
-
-  if (config.database.length === 2) {
-    openSessionRequest.initialNamespace = {
-      catalogName: config.database[0],
-      schemaName: config.database[1],
-    };
-  }
-
-  const session = await connection.openSession(openSessionRequest);
-
-  return session;
+  return connection.openSession({
+    initialCatalog: config.database[0],
+    initialSchema: config.database[1],
+  });
 };
 
 describe('Data fetching', () => {

--- a/tests/e2e/data_types.test.js
+++ b/tests/e2e/data_types.test.js
@@ -1,9 +1,7 @@
 const { expect } = require('chai');
 const config = require('./utils/config');
 const logger = require('./utils/logger')(config.logger);
-const { DBSQLClient, thrift } = require('../..');
-
-const utils = DBSQLClient.utils;
+const { DBSQLClient } = require('../..');
 
 const openSession = async () => {
   const client = new DBSQLClient();
@@ -14,18 +12,10 @@ const openSession = async () => {
     token: config.token,
   });
 
-  const openSessionRequest = {};
-
-  if (config.database.length === 2) {
-    openSessionRequest.initialNamespace = {
-      catalogName: config.database[0],
-      schemaName: config.database[1],
-    };
-  }
-
-  const session = await connection.openSession(openSessionRequest);
-
-  return session;
+  return connection.openSession({
+    initialCatalog: config.database[0],
+    initialSchema: config.database[1],
+  });
 };
 
 const execute = async (session, statement) => {

--- a/tests/unit/DBSQLClient.test.js
+++ b/tests/unit/DBSQLClient.test.js
@@ -1,4 +1,5 @@
 const { expect } = require('chai');
+const sinon = require('sinon');
 const DBSQLClient = require('../../dist/DBSQLClient').default;
 const DBSQLSession = require('../../dist/DBSQLSession').default;
 const {
@@ -30,14 +31,16 @@ describe('DBSQLClient.connect', () => {
     token: 'dapi********************************',
   };
 
-  it('should set nosasl authenticator by default', () => {
+  it('should set nosasl authenticator by default', async () => {
     const client = new DBSQLClient();
     const connectionProvider = ConnectionProviderMock();
 
     client.connectionProvider = connectionProvider;
-    return client.connect(options).catch((error) => {
+    try {
+      await client.connect(options);
+    } catch {
       expect(connectionProvider.auth).instanceOf(PlainHttpAuthentication);
-    });
+    }
   });
 
   it('should handle network errors', (cb) => {
@@ -62,24 +65,19 @@ describe('DBSQLClient.connect', () => {
     });
   });
 
-  it('should use http connection by default', (cb) => {
+  it('should use http connection by default', async () => {
     const client = new DBSQLClient();
     client.thrift = {
       createClient() {},
     };
 
-    client
-      .connect(options)
-      .then(() => {
-        expect(client.connectionProvider).instanceOf(HttpConnection);
-        cb();
-      })
-      .catch(cb);
+    await client.connect(options);
+    expect(client.connectionProvider).instanceOf(HttpConnection);
   });
 });
 
 describe('DBSQLClient.openSession', () => {
-  it('should successfully open session', () => {
+  it('should successfully open session', async () => {
     const client = new DBSQLClient();
     client.client = {
       OpenSession(req, cb) {
@@ -91,12 +89,12 @@ describe('DBSQLClient.openSession', () => {
         return true;
       },
     };
-    return client.openSession().then((session) => {
-      expect(session).instanceOf(DBSQLSession);
-    });
+
+    const session = await client.openSession();
+    expect(session).instanceOf(DBSQLSession);
   });
 
-  it('should throw an exception when the connection is lost', (done) => {
+  it('should throw an exception when the connection is lost', async () => {
     const client = new DBSQLClient();
     client.connection = {
       isConnected() {
@@ -104,10 +102,12 @@ describe('DBSQLClient.openSession', () => {
       },
     };
 
-    client.openSession().catch((error) => {
+    try {
+      await client.openSession();
+      expect.fail('It should throw an error');
+    } catch (error) {
       expect(error.message).to.be.eq('DBSQLClient: connection is lost');
-      done();
-    });
+    }
   });
 });
 
@@ -119,47 +119,38 @@ describe('DBSQLClient.getClient', () => {
 });
 
 describe('DBSQLClient.close', () => {
-  it('should close the connection if it was initiated', (cb) => {
+  it('should close the connection if it was initiated', async () => {
     const client = new DBSQLClient();
-    let closed = false;
+    const closeConnectionStub = sinon.stub();
     client.connection = {
       getConnection: () => ({
-        end: () => {
-          closed = true;
-        },
+        end: closeConnectionStub,
       }),
     };
-    client
-      .close()
-      .then(() => {
-        expect(closed).to.be.true;
-        cb();
-      })
-      .catch(cb);
+
+    await client.close();
+    expect(closeConnectionStub.called).to.be.true;
+    // No additional asserts needed - it should just reach this point
   });
 
-  it('should do nothing if the connection does not exist', (cb) => {
+  it('should do nothing if the connection does not exist', async () => {
     const client = new DBSQLClient();
-    client
-      .close()
-      .then(() => {
-        expect(true).to.be.true;
-        cb();
-      })
-      .catch(cb);
+
+    await client.close();
+    // No additional asserts needed - it should just reach this point
   });
 
-  it('should do nothing if the connection exists but cannot be finished', (cb) => {
+  it('should do nothing if the connection exists but cannot be finished', async () => {
     const client = new DBSQLClient();
+    const closeConnectionStub = sinon.stub();
     client.connection = {
-      getConnection: () => ({}),
+      getConnection: () => ({
+        end: closeConnectionStub,
+      }),
     };
-    client
-      .close()
-      .then(() => {
-        expect(true).to.be.true;
-        cb();
-      })
-      .catch(cb);
+
+    await client.close();
+    expect(closeConnectionStub.called).to.be.true;
+    // No additional asserts needed - it should just reach this point
   });
 });


### PR DESCRIPTION
List of changes:

1. hide thrift details and expose only usable options (https://github.com/databricks/databricks-sql-nodejs/commit/0eb6634c81dee8614a7fbbd2ae1be0e78da5d7d5)
2. expose initial namespace config (https://github.com/databricks/databricks-sql-nodejs/commit/3b0b978980e0a4ebbd668c97778fdf42d4f2cc72)
3. use `client_protocol_i64` instead of `client_protocol` in order to enable Thrift protocol versions above `SPARK_CLI_SERVICE_PROTOCOL_V2` (https://github.com/databricks/databricks-sql-nodejs/commit/3b91837bed4394531d868c18245abdddb2d4d078)