### PR TITLE
[PECO-217] Expose runAsync option for operations that support it

### DIFF
--- a/lib/DBSQLSession.ts
+++ b/lib/DBSQLSession.ts
@@ -69,9 +69,9 @@ export default class DBSQLSession implements IDBSQLSession {
       .executeStatement({
         sessionHandle: this.sessionHandle,
         statement,
-        runAsync: options.runAsync || false,
         confOverlay: options.confOverlay,
         queryTimeout: options.queryTimeout,
+        runAsync: options.runAsync || false,
         ...getDirectResultsOptions(options.maxRows),
       })
       .then((response) => this.createOperation(response));
@@ -81,6 +81,7 @@ export default class DBSQLSession implements IDBSQLSession {
     return this.driver
       .getTypeInfo({
         sessionHandle: this.sessionHandle,
+        runAsync: request.runAsync || false,
         ...getDirectResultsOptions(request.maxRows),
       })
       .then((response) => this.createOperation(response));
@@ -90,6 +91,7 @@ export default class DBSQLSession implements IDBSQLSession {
     return this.driver
       .getCatalogs({
         sessionHandle: this.sessionHandle,
+        runAsync: request.runAsync || false,
         ...getDirectResultsOptions(request.maxRows),
       })
       .then((response) => this.createOperation(response));
@@ -101,6 +103,7 @@ export default class DBSQLSession implements IDBSQLSession {
         sessionHandle: this.sessionHandle,
         catalogName: request.catalogName,
         schemaName: request.schemaName,
+        runAsync: request.runAsync || false,
         ...getDirectResultsOptions(request.maxRows),
       })
       .then((response) => this.createOperation(response));
@@ -114,6 +117,7 @@ export default class DBSQLSession implements IDBSQLSession {
         schemaName: request.schemaName,
         tableName: request.tableName,
         tableTypes: request.tableTypes,
+        runAsync: request.runAsync || false,
         ...getDirectResultsOptions(request.maxRows),
       })
       .then((response) => this.createOperation(response));
@@ -123,6 +127,7 @@ export default class DBSQLSession implements IDBSQLSession {
     return this.driver
       .getTableTypes({
         sessionHandle: this.sessionHandle,
+        runAsync: request.runAsync || false,
         ...getDirectResultsOptions(request.maxRows),
       })
       .then((response) => this.createOperation(response));
@@ -136,6 +141,7 @@ export default class DBSQLSession implements IDBSQLSession {
         schemaName: request.schemaName,
         tableName: request.tableName,
         columnName: request.columnName,
+        runAsync: request.runAsync || false,
         ...getDirectResultsOptions(request.maxRows),
       })
       .then((response) => this.createOperation(response));
@@ -148,6 +154,7 @@ export default class DBSQLSession implements IDBSQLSession {
         catalogName: request.catalogName,
         schemaName: request.schemaName,
         functionName: request.functionName,
+        runAsync: request.runAsync || false,
         ...getDirectResultsOptions(request.maxRows),
       })
       .then((response) => this.createOperation(response));
@@ -160,6 +167,7 @@ export default class DBSQLSession implements IDBSQLSession {
         catalogName: request.catalogName,
         schemaName: request.schemaName,
         tableName: request.tableName,
+        runAsync: request.runAsync || false,
         ...getDirectResultsOptions(request.maxRows),
       })
       .then((response) => this.createOperation(response));
@@ -175,6 +183,7 @@ export default class DBSQLSession implements IDBSQLSession {
         foreignCatalogName: request.foreignCatalogName,
         foreignSchemaName: request.foreignSchemaName,
         foreignTableName: request.foreignTableName,
+        runAsync: request.runAsync || false,
         ...getDirectResultsOptions(request.maxRows),
       })
       .then((response) => this.createOperation(response));

--- a/lib/contracts/IDBSQLSession.ts
+++ b/lib/contracts/IDBSQLSession.ts
@@ -4,23 +4,26 @@ import InfoValue from '../dto/InfoValue';
 import { Int64 } from '../hive/Types';
 
 export type ExecuteStatementOptions = {
-  runAsync?: boolean;
   confOverlay?: Record<string, string>;
   queryTimeout?: Int64;
+  runAsync?: boolean;
   maxRows?: number;
 };
 
 export type TypeInfoRequest = {
+  runAsync?: boolean;
   maxRows?: number;
 };
 
 export type CatalogsRequest = {
+  runAsync?: boolean;
   maxRows?: number;
 };
 
 export type SchemasRequest = {
   catalogName?: string;
   schemaName?: string;
+  runAsync?: boolean;
   maxRows?: number;
 };
 
@@ -29,10 +32,12 @@ export type TablesRequest = {
   schemaName?: string;
   tableName?: string;
   tableTypes?: Array<string>;
+  runAsync?: boolean;
   maxRows?: number;
 };
 
 export type TableTypesRequest = {
+  runAsync?: boolean;
   maxRows?: number;
 };
 
@@ -41,6 +46,7 @@ export type ColumnsRequest = {
   schemaName?: string;
   tableName?: string;
   columnName?: string;
+  runAsync?: boolean;
   maxRows?: number;
 };
 
@@ -48,6 +54,7 @@ export type FunctionsRequest = {
   catalogName?: string;
   schemaName?: string;
   functionName: string;
+  runAsync?: boolean;
   maxRows?: number;
 };
 
@@ -55,6 +62,7 @@ export type PrimaryKeysRequest = {
   catalogName?: string;
   schemaName: string;
   tableName: string;
+  runAsync?: boolean;
   maxRows?: number;
 };
 
@@ -65,6 +73,7 @@ export type CrossReferenceRequest = {
   foreignCatalogName: string;
   foreignSchemaName: string;
   foreignTableName: string;
+  runAsync?: boolean;
   maxRows?: number;
 };
 


### PR DESCRIPTION
Previously only `executeStatement` supported this option. But I think it may be useful to have it for other operations as well (e.g. `getTables` or `getColumns` may return quite a lot of records, so it may be handy to be able to run them asynchronously).