### PR TITLE
Fixed bug with spread operator crashing memory if chunk is too big

### DIFF
--- a/lib/DBSQLOperation/index.ts
+++ b/lib/DBSQLOperation/index.ts
@@ -13,7 +13,6 @@ import OperationStatusHelper from './OperationStatusHelper';
 import SchemaHelper from './SchemaHelper';
 import FetchResultsHelper from './FetchResultsHelper';
 import CompleteOperationHelper from './CompleteOperationHelper';
-import { it } from 'node:test';
 
 export default class DBSQLOperation implements IOperation {
   private driver: HiveDriver;

--- a/lib/DBSQLOperation/index.ts
+++ b/lib/DBSQLOperation/index.ts
@@ -13,6 +13,7 @@ import OperationStatusHelper from './OperationStatusHelper';
 import SchemaHelper from './SchemaHelper';
 import FetchResultsHelper from './FetchResultsHelper';
 import CompleteOperationHelper from './CompleteOperationHelper';
+import { it } from 'node:test';
 
 export default class DBSQLOperation implements IOperation {
   private driver: HiveDriver;
@@ -45,7 +46,9 @@ export default class DBSQLOperation implements IOperation {
     do {
       // eslint-disable-next-line no-await-in-loop
       const chunk = await this.fetchChunk(options);
-      data.push(...chunk);
+      for(let item of chunk) {
+        data.push(item);
+      }
     } while (await this.hasMoreRows()); // eslint-disable-line no-await-in-loop
     return data;
   }

--- a/lib/DBSQLOperation/index.ts
+++ b/lib/DBSQLOperation/index.ts
@@ -41,7 +41,7 @@ export default class DBSQLOperation implements IOperation {
   }
 
   async fetchAll(options?: IFetchOptions): Promise<Array<object>> {
-    const data: Array<object> = [];
+    const data: Array<Array<object>> = [];
     do {
       // eslint-disable-next-line no-await-in-loop
       const chunk = await this.fetchChunk(options);

--- a/lib/DBSQLOperation/index.ts
+++ b/lib/DBSQLOperation/index.ts
@@ -45,11 +45,10 @@ export default class DBSQLOperation implements IOperation {
     do {
       // eslint-disable-next-line no-await-in-loop
       const chunk = await this.fetchChunk(options);
-      for(let item of chunk) {
-        data.push(item);
-      }
+      data.push(chunk);
     } while (await this.hasMoreRows()); // eslint-disable-line no-await-in-loop
-    return data;
+
+    return data.flat();
   }
 
   async fetchChunk(options: IFetchOptions = defaultFetchOptions): Promise<Array<object>> {


### PR DESCRIPTION
We were using the spread operator improperly: it copies in all args of the array into the callstack, which will crash the callstack if the array is too big.