### PR TITLE
Remove deprecated option `confOverlay`

### DIFF
--- a/lib/DBSQLSession.ts
+++ b/lib/DBSQLSession.ts
@@ -69,7 +69,6 @@ export default class DBSQLSession implements IDBSQLSession {
       .executeStatement({
         sessionHandle: this.sessionHandle,
         statement,
-        confOverlay: options.confOverlay,
         queryTimeout: options.queryTimeout,
         runAsync: options.runAsync || false,
         ...getDirectResultsOptions(options.maxRows),

--- a/lib/contracts/IDBSQLSession.ts
+++ b/lib/contracts/IDBSQLSession.ts
@@ -4,7 +4,6 @@ import InfoValue from '../dto/InfoValue';
 import { Int64 } from '../hive/Types';
 
 export type ExecuteStatementOptions = {
-  confOverlay?: Record<string, string>;
   queryTimeout?: Int64;
   runAsync?: boolean;
   maxRows?: number;


### PR DESCRIPTION
Part of [PECO-217]

Removing `TExecuteStatementReq.confOverlay` options as it is deprecated:

![image](https://user-images.githubusercontent.com/12139186/192265957-4e77ee17-16f9-4d6a-98af-69bf6a7f49ba.png)
