### PR TITLE
[PECO-348] Enable direct results by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - `DBSQLClient.openSession` now uses the latest protocol version by default
 - Direct results feature is now available for all IOperation methods which support it. To enable direct results feature,
   `maxRows` option should be used
+- Direct results became enabled by default. If `maxRows` is omitted - it will default to `100000`. To disable direct
+  results, set `maxRows` to `null`
 - `FunctionNameRequest` type renamed to `FunctionsRequest`
 - `IDBSQLConnectionOptions` type renamed to `ConnectionOptions`
 - `IFetchOptions` renamed to `FetchOptions`

--- a/lib/DBSQLOperation/index.ts
+++ b/lib/DBSQLOperation/index.ts
@@ -1,4 +1,4 @@
-import IOperation, { FetchOptions, GetSchemaOptions, FinishedOptions, defaultMaxRows } from '../contracts/IOperation';
+import IOperation, { FetchOptions, GetSchemaOptions, FinishedOptions } from '../contracts/IOperation';
 import HiveDriver from '../hive/HiveDriver';
 import {
   TGetOperationStatusResp,
@@ -13,6 +13,8 @@ import OperationStatusHelper from './OperationStatusHelper';
 import SchemaHelper from './SchemaHelper';
 import FetchResultsHelper from './FetchResultsHelper';
 import CompleteOperationHelper from './CompleteOperationHelper';
+
+const defaultMaxRows = 100000;
 
 export default class DBSQLOperation implements IOperation {
   private driver: HiveDriver;

--- a/lib/DBSQLSession.ts
+++ b/lib/DBSQLSession.ts
@@ -20,14 +20,16 @@ import StatusFactory from './factory/StatusFactory';
 import InfoValue from './dto/InfoValue';
 import { definedOrError } from './utils';
 
+const defaultMaxRows = 100000;
+
 interface OperationResponseShape {
   status: TStatus;
   operationHandle?: TOperationHandle;
   directResults?: TSparkDirectResults;
 }
 
-function getDirectResultsOptions(maxRows?: number) {
-  if (!maxRows) {
+function getDirectResultsOptions(maxRows: number | null = defaultMaxRows) {
+  if (maxRows === null) {
     return {};
   }
 

--- a/lib/contracts/IDBSQLSession.ts
+++ b/lib/contracts/IDBSQLSession.ts
@@ -6,24 +6,24 @@ import { Int64 } from '../hive/Types';
 export type ExecuteStatementOptions = {
   queryTimeout?: Int64;
   runAsync?: boolean;
-  maxRows?: number;
+  maxRows?: number | null;
 };
 
 export type TypeInfoRequest = {
   runAsync?: boolean;
-  maxRows?: number;
+  maxRows?: number | null;
 };
 
 export type CatalogsRequest = {
   runAsync?: boolean;
-  maxRows?: number;
+  maxRows?: number | null;
 };
 
 export type SchemasRequest = {
   catalogName?: string;
   schemaName?: string;
   runAsync?: boolean;
-  maxRows?: number;
+  maxRows?: number | null;
 };
 
 export type TablesRequest = {
@@ -32,12 +32,12 @@ export type TablesRequest = {
   tableName?: string;
   tableTypes?: Array<string>;
   runAsync?: boolean;
-  maxRows?: number;
+  maxRows?: number | null;
 };
 
 export type TableTypesRequest = {
   runAsync?: boolean;
-  maxRows?: number;
+  maxRows?: number | null;
 };
 
 export type ColumnsRequest = {
@@ -46,7 +46,7 @@ export type ColumnsRequest = {
   tableName?: string;
   columnName?: string;
   runAsync?: boolean;
-  maxRows?: number;
+  maxRows?: number | null;
 };
 
 export type FunctionsRequest = {
@@ -54,7 +54,7 @@ export type FunctionsRequest = {
   schemaName?: string;
   functionName: string;
   runAsync?: boolean;
-  maxRows?: number;
+  maxRows?: number | null;
 };
 
 export type PrimaryKeysRequest = {
@@ -62,7 +62,7 @@ export type PrimaryKeysRequest = {
   schemaName: string;
   tableName: string;
   runAsync?: boolean;
-  maxRows?: number;
+  maxRows?: number | null;
 };
 
 export type CrossReferenceRequest = {
@@ -73,7 +73,7 @@ export type CrossReferenceRequest = {
   foreignSchemaName: string;
   foreignTableName: string;
   runAsync?: boolean;
-  maxRows?: number;
+  maxRows?: number | null;
 };
 
 export default interface IDBSQLSession {

--- a/lib/contracts/IOperation.ts
+++ b/lib/contracts/IOperation.ts
@@ -20,8 +20,6 @@ export interface GetSchemaOptions extends WaitUntilReadyOptions {
   // no other options
 }
 
-export const defaultMaxRows = 100000;
-
 export default interface IOperation {
   /**
    * Fetch a portion of data

--- a/tests/e2e/batched_fetch.test.js
+++ b/tests/e2e/batched_fetch.test.js
@@ -27,14 +27,14 @@ describe('Data fetching', () => {
 
   it('fetch chunks should return a max row set of chunkSize', async () => {
     const session = await openSession();
-    const operation = await session.executeStatement(query, { runAsync: true });
+    const operation = await session.executeStatement(query, { runAsync: true, maxRows: null });
     let chunkedOp = await operation.fetchChunk({ maxRows: 10 }).catch((error) => logger(error));
     expect(chunkedOp.length).to.be.equal(10);
   });
 
   it('fetch all should fetch all records', async () => {
     const session = await openSession();
-    const operation = await session.executeStatement(query, { runAsync: true });
+    const operation = await session.executeStatement(query, { runAsync: true, maxRows: null });
     let all = await operation.fetchAll();
     expect(all.length).to.be.equal(1000);
   });

--- a/tests/unit/DBSQLSession.test.js
+++ b/tests/unit/DBSQLSession.test.js
@@ -58,6 +58,12 @@ describe('DBSQLSession', () => {
       const result = await session.executeStatement('SELECT * FROM table', { maxRows: 10 });
       expect(result).instanceOf(DBSQLOperation);
     });
+
+    it('should disable direct results', async () => {
+      const session = createSession();
+      const result = await session.executeStatement('SELECT * FROM table', { maxRows: null });
+      expect(result).instanceOf(DBSQLOperation);
+    });
   });
 
   describe('getTypeInfo', () => {
@@ -72,6 +78,12 @@ describe('DBSQLSession', () => {
       const result = await session.getTypeInfo({ maxRows: 10 });
       expect(result).instanceOf(DBSQLOperation);
     });
+
+    it('should disable direct results', async () => {
+      const session = createSession();
+      const result = await session.getTypeInfo({ maxRows: null });
+      expect(result).instanceOf(DBSQLOperation);
+    });
   });
 
   describe('getCatalogs', () => {
@@ -84,6 +96,12 @@ describe('DBSQLSession', () => {
     it('should use direct results', async () => {
       const session = createSession();
       const result = await session.getCatalogs({ maxRows: 10 });
+      expect(result).instanceOf(DBSQLOperation);
+    });
+
+    it('should disable direct results', async () => {
+      const session = createSession();
+      const result = await session.getCatalogs({ maxRows: null });
       expect(result).instanceOf(DBSQLOperation);
     });
   });
@@ -106,9 +124,13 @@ describe('DBSQLSession', () => {
 
     it('should use direct results', async () => {
       const session = createSession();
-      const result = await session.getSchemas({
-        maxRows: 10,
-      });
+      const result = await session.getSchemas({ maxRows: 10 });
+      expect(result).instanceOf(DBSQLOperation);
+    });
+
+    it('should disable direct results', async () => {
+      const session = createSession();
+      const result = await session.getSchemas({ maxRows: null });
       expect(result).instanceOf(DBSQLOperation);
     });
   });
@@ -133,9 +155,13 @@ describe('DBSQLSession', () => {
 
     it('should use direct results', async () => {
       const session = createSession();
-      const result = await session.getTables({
-        maxRows: 10,
-      });
+      const result = await session.getTables({ maxRows: 10 });
+      expect(result).instanceOf(DBSQLOperation);
+    });
+
+    it('should disable direct results', async () => {
+      const session = createSession();
+      const result = await session.getTables({ maxRows: null });
       expect(result).instanceOf(DBSQLOperation);
     });
   });
@@ -150,6 +176,12 @@ describe('DBSQLSession', () => {
     it('should use direct results', async () => {
       const session = createSession();
       const result = await session.getTableTypes({ maxRows: 10 });
+      expect(result).instanceOf(DBSQLOperation);
+    });
+
+    it('should disable direct results', async () => {
+      const session = createSession();
+      const result = await session.getTableTypes({ maxRows: null });
       expect(result).instanceOf(DBSQLOperation);
     });
   });
@@ -174,9 +206,13 @@ describe('DBSQLSession', () => {
 
     it('should use direct results', async () => {
       const session = createSession();
-      const result = await session.getColumns({
-        maxRows: 10,
-      });
+      const result = await session.getColumns({ maxRows: 10 });
+      expect(result).instanceOf(DBSQLOperation);
+    });
+
+    it('should disable direct results', async () => {
+      const session = createSession();
+      const result = await session.getColumns({ maxRows: null });
       expect(result).instanceOf(DBSQLOperation);
     });
   });
@@ -202,6 +238,17 @@ describe('DBSQLSession', () => {
       });
       expect(result).instanceOf(DBSQLOperation);
     });
+
+    it('should disable direct results', async () => {
+      const session = createSession();
+      const result = await session.getFunctions({
+        catalogName: 'catalog',
+        schemaName: 'schema',
+        functionName: 'avg',
+        maxRows: null,
+      });
+      expect(result).instanceOf(DBSQLOperation);
+    });
   });
 
   describe('getPrimaryKeys', () => {
@@ -222,6 +269,17 @@ describe('DBSQLSession', () => {
         schemaName: 'schema',
         tableName: 't1',
         maxRows: 10,
+      });
+      expect(result).instanceOf(DBSQLOperation);
+    });
+
+    it('should disable direct results', async () => {
+      const session = createSession();
+      const result = await session.getPrimaryKeys({
+        catalogName: 'catalog',
+        schemaName: 'schema',
+        tableName: 't1',
+        maxRows: null,
       });
       expect(result).instanceOf(DBSQLOperation);
     });
@@ -251,6 +309,20 @@ describe('DBSQLSession', () => {
         foreignSchemaName: 'foreignSchemaName',
         foreignTableName: 'foreignTableName',
         maxRows: 10,
+      });
+      expect(result).instanceOf(DBSQLOperation);
+    });
+
+    it('should disable direct results', async () => {
+      const session = createSession();
+      const result = await session.getCrossReference({
+        parentCatalogName: 'parentCatalogName',
+        parentSchemaName: 'parentSchemaName',
+        parentTableName: 'parentTableName',
+        foreignCatalogName: 'foreignCatalogName',
+        foreignSchemaName: 'foreignSchemaName',
+        foreignTableName: 'foreignTableName',
+        maxRows: null,
       });
       expect(result).instanceOf(DBSQLOperation);
     });


### PR DESCRIPTION
Previously user had to explicitly pass `maxRows` to use direct results feature. Now if `maxRows` is omitted, it will default to `100000 ` (same value we use for `fetchChunk`/`fetchAll` defaults), and to disable direct results `maxRows` should be explicitly set to `null` (e.g. for use with `runAsync`)