### PR TITLE
Fix mistake in test

### DIFF
--- a/tests/unit/utils.test.js
+++ b/tests/unit/utils.test.js
@@ -18,13 +18,13 @@ describe('buildUserAgentString', () => {
     // Prefix: 'NodejsDatabricksSqlConnector/'
     // Version: three period-separated digits and optional suffix
     const re =
-      /^(?<productName>NodejsDatabricksSqlConnector)\/(?<productVersion>\d+\.\d+\.\d+(-[^(]+)?)\((?<comment>[^)]+)\)$/i;
+      /^(?<productName>NodejsDatabricksSqlConnector)\/(?<productVersion>\d+\.\d+\.\d+(-[^(]+)?)\s*\((?<comment>[^)]+)\)$/i;
     const match = re.exec(ua);
     expect(match).to.not.be.eq(null);
 
     const { comment } = match.groups;
 
-    expect(comment.split(';').length).to.be.gte(2); // at least Node ans OS version should be there
+    expect(comment.split(';').length).to.be.gte(2); // at least Node and OS version should be there
 
     if (clientId) {
       expect(comment.trim()).to.satisfy((s) => s.startsWith(`${clientId};`));


### PR DESCRIPTION
User agent string has a whitespace between version and comment part. While library version had a suffix - that whitespace was captured into it. But after we tagged non-beta version - it started to fail. The solution is to explicitly "eat" that whitespace