### PR TITLE
Fixed bug in Logger, cleaned up types

### DIFF
--- a/examples/logging.js
+++ b/examples/logging.js
@@ -3,7 +3,7 @@ const { DBSQLClient, DBSQLLogger, LogLevel } = require('../');
 
 // This logger will emit logs to console and log.txt
 //
-const logger = new DBSQLLogger('log.txt', LogLevel.info);
+const logger = new DBSQLLogger({ filepath: 'log.txt', level: LogLevel.info });
 
 const client = new DBSQLClient({ logger: logger });
 

--- a/lib/DBSQLLogger.ts
+++ b/lib/DBSQLLogger.ts
@@ -1,12 +1,15 @@
 import winston, { Logger } from 'winston';
-import IDBSQLLogger, { LogLevel } from './contracts/IDBSQLLogger';
+import IDBSQLLogger, { LoggerOptions, LogLevel } from './contracts/IDBSQLLogger';
 
 export default class DBSQLLogger implements IDBSQLLogger {
   logger: Logger;
 
-  transports: any;
+  transports: {
+    console: winston.transports.ConsoleTransportInstance;
+    file?: winston.transports.FileTransportInstance;
+  };
 
-  constructor(filepath?: string, level = LogLevel.info) {
+  constructor({ level = LogLevel.info, filepath }: LoggerOptions = {}) {
     this.transports = {
       console: new winston.transports.Console({ handleExceptions: true, level }),
     };
@@ -24,8 +27,9 @@ export default class DBSQLLogger implements IDBSQLLogger {
   }
 
   setLevel(level: LogLevel) {
-    for (const key of Object.keys(this.transports)) {
-      this.transports[key].level = level;
+    this.transports.console.level = level;
+    if (this.transports.file) {
+      this.transports.file.level = level;
     }
   }
 }

--- a/lib/contracts/IDBSQLLogger.ts
+++ b/lib/contracts/IDBSQLLogger.ts
@@ -1,3 +1,8 @@
+export interface LoggerOptions {
+  filepath?: string;
+  level?: LogLevel;
+}
+
 export default interface IDBSQLLogger {
   log(level: LogLevel, message: string): void;
 }

--- a/tests/unit/DBSQLOperation.test.js
+++ b/tests/unit/DBSQLOperation.test.js
@@ -9,7 +9,7 @@ const getResult = require('../../dist/DBSQLOperation/getResult').default;
 
 // Create logger that won't emit
 //
-const logger = new DBSQLLogger(LogLevel.error);
+const logger = new DBSQLLogger({ level: LogLevel.error });
 
 class OperationHandleMock {
   constructor(hasResultSet = true) {

--- a/tests/unit/DBSQLSession.test.js
+++ b/tests/unit/DBSQLSession.test.js
@@ -7,7 +7,7 @@ const DBSQLOperation = require('../../dist/DBSQLOperation').default;
 
 // Create logger that won't emit
 //
-const logger = new DBSQLLogger(LogLevel.error);
+const logger = new DBSQLLogger({ level: LogLevel.error });
 
 function createDriverMock(customMethodHandler) {
   customMethodHandler = customMethodHandler || ((methodName, value) => value);


### PR DESCRIPTION
To clarify, bug was that LogLevel was being cast to a string and interpreted as filepath (String is a superset of LogLevel).