### PR TITLE
[REGRESSION] Prepend slash to path if needed

### DIFF
--- a/lib/DBSQLClient.ts
+++ b/lib/DBSQLClient.ts
@@ -21,6 +21,13 @@ import PlainHttpAuthentication from './connection/auth/PlainHttpAuthentication';
 import IDBSQLLogger, { LogLevel } from './contracts/IDBSQLLogger';
 import DBSQLLogger from './DBSQLLogger';
 
+function prependSlash(str: string): string {
+  if (str.length > 0 && str.charAt(0) !== '/') {
+    return `/${str}`;
+  }
+  return str;
+}
+
 function getInitialNamespaceOptions(catalogName?: string, schemaName?: string) {
   if (!catalogName && !schemaName) {
     return {};
@@ -61,11 +68,12 @@ export default class DBSQLClient extends EventEmitter implements IDBSQLClient {
   }
 
   private getConnectionOptions(options: ConnectionOptions): IConnectionOptions {
-    const { host, port, token, clientId, ...otherOptions } = options;
+    const { host, port, path, token, clientId, ...otherOptions } = options;
     return {
       host,
       port: port || 443,
       options: {
+        path: prependSlash(path),
         https: true,
         ...otherOptions,
       },

--- a/tests/unit/DBSQLClient.test.js
+++ b/tests/unit/DBSQLClient.test.js
@@ -31,6 +31,42 @@ describe('DBSQLClient.connect', () => {
     token: 'dapi********************************',
   };
 
+  it('should prepend "/" to path if it is missing', async () => {
+    const client = new DBSQLClient();
+    client.thrift = {
+      createClient() {},
+    };
+    const connectionProvider = ConnectionProviderMock();
+
+    const path = 'example/path';
+
+    client.connectionProvider = connectionProvider;
+    await client.connect({
+      ...options,
+      path,
+    });
+
+    expect(connectionProvider.options.options.path).to.equal(`/${path}`);
+  });
+
+  it('should not prepend "/" to path if it is already available', async () => {
+    const client = new DBSQLClient();
+    client.thrift = {
+      createClient() {},
+    };
+    const connectionProvider = ConnectionProviderMock();
+
+    const path = '/example/path';
+
+    client.connectionProvider = connectionProvider;
+    await client.connect({
+      ...options,
+      path,
+    });
+
+    expect(connectionProvider.options.options.path).to.equal(path);
+  });
+
   it('should set nosasl authenticator by default', async () => {
     const client = new DBSQLClient();
     const connectionProvider = ConnectionProviderMock();


### PR DESCRIPTION
Re-implement databricks/databricks-sql-nodejs#27 which was accidentally removed in databricks/databricks-sql-nodejs#40

Why it happened: because of missing tests for that feature (now added)