### PR TITLE
Allow piping user agent

### DIFF
--- a/lib/DBSQLClient.ts
+++ b/lib/DBSQLClient.ts
@@ -93,7 +93,7 @@ export default class DBSQLClient extends EventEmitter implements IDBSQLClient {
       username: 'token',
       password: options.token,
       headers: {
-        'User-Agent': buildUserAgentString(options.clientId),
+        'User-Agent': options.customUserAgent ? options.customUserAgent : buildUserAgentString(options.clientId),
       },
     });
 

--- a/lib/contracts/IDBSQLClient.ts
+++ b/lib/contracts/IDBSQLClient.ts
@@ -11,6 +11,7 @@ export interface ConnectionOptions {
   path: string;
   token: string;
   clientId?: string;
+  customUserAgent?: string;
 }
 
 export interface OpenSessionRequest {


### PR DESCRIPTION
Minor change; allows you to pass a custom user agent header. Requested by Fabian Jakobs for cases where we want to track internal products that are built on the databricks connector.
https://databricks.atlassian.net/browse/PECO-553