### PR TITLE
Prepare release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Fix: now library will not attempt to parse column names and will use ones provided by server
   (databricks/databricks-sql-nodejs#84)
-- Better error handling: more errors could now be handled in appropriate `.catch()` handlers instead of being
+- Better error handling: more errors can now be handled in specific `.catch()` handlers instead of being
   emitted as a generic `error` event (databricks/databricks-sql-nodejs#99)
 - Fixed error logging bug (attempt to serialize circular structures) (databricks/databricks-sql-nodejs#89)
 - Fixed some minor bugs and regressions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 ## 1.x (Unreleased)
 
-- Fix(databricks/databricks-sql-nodejs#84): now library will not attempt to parse column names and
-  will use ones provided by server
+## 1.1.0
+
+- Fix: now library will not attempt to parse column names and will use ones provided by server
+  (databricks/databricks-sql-nodejs#84)
+- Better error handling: more errors could now be handled in appropriate `.catch()` handlers instead of being
+  emitted as a generic `error` event (databricks/databricks-sql-nodejs#99)
+- Fixed error logging bug (attempt to serialize circular structures) (databricks/databricks-sql-nodejs#89)
+- Fixed some minor bugs and regressions
 
 ## 1.0.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks/sql",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks/sql",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Driver for connection to Databricks SQL via Thrift API.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
We've fixed some annoying bugs (and a lot of people are waiting for these fixes), and improved error handling since 1.0.0. So it's time for a next release