### PR TITLE
Update actions because currently used ones became deprecated

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,9 +12,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Cache node modules
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         env:
           cache-name: cache-node-modules
         with:
@@ -33,9 +33,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Cache node modules
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         env:
           cache-name: cache-node-modules
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 16
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm publish --access public


### PR DESCRIPTION
Currently used actions versions are going to be deprecated and should be updated (it's mostly related to Node12 deprecation in favor of Node16)

![image](https://user-images.githubusercontent.com/12139186/214304278-b0c2f257-8fdb-46c6-b5a3-bca3889bbbc9.png)

**Upd:** `tisonkun/actions-dco@1.1` still uses Node12 so there's still a warning for DCO check workflow (tisonkun/actions-dco#12), but ATM we cannot fix this one, so let's proceed with what's fixed so far.
