### PR TITLE
Make sure that patch needed for improved error handling is applied when installing package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.x (Unreleased)
 
+## 1.1.1
+
+- Fix: patch needed for improved error handling wasn't applied when installing 1.1.0
+
 ## 1.1.0
 
 - Fix: now library will not attempt to parse column names and will use ones provided by server

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks/sql",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Driver for connection to Databricks SQL via Thrift API.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -76,5 +76,8 @@
     "thrift": "^0.16.0",
     "uuid": "^9.0.0",
     "winston": "^3.8.2"
-  }
+  },
+  "bundledDependencies": [
+    "thrift"
+  ]
 }


### PR DESCRIPTION
We patched `thrift` dependency in order to improve error handling mechanism. However, that patch wasn't applied when installing connector from NPM. This PR fixes it by publishing patched `thrift` with the library code, and later it will be installed as a local dependency for the connector.

[`bundleDependencies` docs](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#bundledependencies)

<details>

<summary>Example directory structure after installing `@databricks/sql` with this fix as a dependency</summary>

```
├─ package.json
├─ package-lock.json
└─ node_modules
   ├─ @databricks
   │  └─ sql
   │     ├─ dist
   │     │  ├─ ...
   │     └─ node_modules
   │        ├─ node-int64
   │        ├─ q
   │        └─ thrift    // <-- patched library - local for @databricks/sql
   │            └─ ...
   ├─ ...
   └─ thrift    // <-- original library, own dependency of this sample
      └─ ...
```

</details>