### PR TITLE
Make auth provider configurable

### DIFF
--- a/lib/DBSQLClient.ts
+++ b/lib/DBSQLClient.ts
@@ -84,18 +84,21 @@ export default class DBSQLClient extends EventEmitter implements IDBSQLClient {
    * Connects DBSQLClient to endpoint
    * @public
    * @param options - host, path, and token are required
+   * @param authProvider - Optional custom authentication provider
    * @returns Session object that can be used to execute statements
    * @example
    * const session = client.connect({host, path, token});
    */
-  async connect(options: ConnectionOptions): Promise<IDBSQLClient> {
-    this.authProvider = new PlainHttpAuthentication({
-      username: 'token',
-      password: options.token,
-      headers: {
-        'User-Agent': buildUserAgentString(options.clientId),
-      },
-    });
+  async connect(options: ConnectionOptions, authProvider?: IAuthentication): Promise<IDBSQLClient> {
+    this.authProvider =
+      authProvider ||
+      new PlainHttpAuthentication({
+        username: 'token',
+        password: options.token,
+        headers: {
+          'User-Agent': buildUserAgentString(options.clientId),
+        },
+      });
 
     this.connection = await this.connectionProvider.connect(this.getConnectionOptions(options), this.authProvider);
 


### PR DESCRIPTION
For the SQLTools driver for Databricks I want to leverage the auth provider from the VSCode extension. I need to be able to provide a customer auth provider because my tokens expire and I need a way to update them dynamically.

See https://github.com/databricks/sqltools-databricks-driver/pull/60