### PR TITLE
Adding Databricks Azure tokens (Bearer token) support. (Issue #121)

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -2,19 +2,24 @@
 
 ## Table of Contents
 
-1. [Foreword](#foreword)
-2. [Example](#example) \
-   2.1. [Error handling](#error-handling)
-3. [DBSQLSession](#dbsqlsession)
-4. [DBSQLOperation](#dbsqloperation)
-5. [Status](#status)
-6. [Finalize](#finalize)
+- [Getting started](#getting-started)
+  - [Table of Contents](#table-of-contents)
+  - [Foreword](#foreword)
+  - [Example](#example)
+    - [Error handling](#error-handling)
+  - [DBSQLSession](#dbsqlsession)
+  - [DBSQLOperation](#dbsqloperation)
+    - [Example](#example-1)
+  - [Status](#status)
+  - [Finalize](#finalize)
 
 ## Foreword
 
 The library is written using TypeScript, so the best way to get to know how it works is to look through the code [lib/](/lib/), [tests/e2e](/tests/e2e/) and [examples](/examples).
 
 If you find any mistakes, misleading or some confusion feel free to create an issue or send a pull request.
+
+By default, the token is assumed to be a PAT token. If you are using AAD tokens, pass `useAADToken: true` in the connection options. To generate an AAD token, use the command line `az account get-access-token --resource 2ff814a6-3304-4ab8-85cb-cd0e6f879c1d` or use the MSAL authentication library.
 
 ## Example
 
@@ -28,6 +33,7 @@ client
     host: '...',
     path: '/sql/1.0/endpoints/****************',
     token: 'dapi********************************',
+    // useAADToken: true, // If token is an AAD token
   })
   .then(async (client) => {
     const session = await client.openSession();

--- a/examples/usage.js
+++ b/examples/usage.js
@@ -5,9 +5,12 @@ const client = new DBSQLClient();
 const host = '****.databricks.com';
 const path = '/sql/1.0/endpoints/****';
 const token = 'dapi********************************';
-
+const useAADToken = false;
+// For AAD tokens
+// const token = 'ey***********';
+// const useAADToken=true;
 client
-  .connect({ host, path, token })
+  .connect({ host, path, token, useAADToken })
   .then(async (client) => {
     const session = await client.openSession();
     const response = await session.getInfo(thrift.TCLIService_types.TGetInfoType.CLI_DBMS_VER);

--- a/lib/DBSQLClient.ts
+++ b/lib/DBSQLClient.ts
@@ -92,6 +92,7 @@ export default class DBSQLClient extends EventEmitter implements IDBSQLClient {
     this.authProvider = new PlainHttpAuthentication({
       username: 'token',
       password: options.token,
+      useAADToken: options.useAADToken,
       headers: {
         'User-Agent': buildUserAgentString(options.clientId),
       },

--- a/lib/connection/auth/PlainHttpAuthentication.ts
+++ b/lib/connection/auth/PlainHttpAuthentication.ts
@@ -4,6 +4,7 @@ import { AuthOptions } from '../types/AuthOptions';
 
 type HttpAuthOptions = AuthOptions & {
   headers?: object;
+  useAADToken?: boolean;
 };
 
 export default class PlainHttpAuthentication implements IAuthentication {
@@ -11,12 +12,15 @@ export default class PlainHttpAuthentication implements IAuthentication {
 
   private password: string;
 
+  private useAADToken: boolean;
+
   private headers: object;
 
   constructor(options: HttpAuthOptions) {
     this.username = options?.username || 'anonymous';
     this.password = options?.password !== undefined ? options?.password : 'anonymous';
     this.headers = options?.headers || {};
+    this.useAADToken = options?.useAADToken !== undefined ? options?.useAADToken : false;
   }
 
   authenticate(transport: ITransport): Promise<ITransport> {
@@ -29,6 +33,10 @@ export default class PlainHttpAuthentication implements IAuthentication {
   }
 
   private getToken(username: string, password: string): string {
-    return `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`;
+    if (this.useAADToken) {
+      return `Bearer ${password}`;
+    } else {
+      return `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`;
+    }
   }
 }

--- a/lib/contracts/IDBSQLClient.ts
+++ b/lib/contracts/IDBSQLClient.ts
@@ -11,6 +11,7 @@ export interface ConnectionOptions {
   path: string;
   token: string;
   clientId?: string;
+  useAADToken?: boolean;
 }
 
 export interface OpenSessionRequest {


### PR DESCRIPTION
Issue #121 : Support Azure AD Tokens instead of PAT tokens

PAT vs Azure AD tokens - PAT tokens are workspace specific and usually have a long expiry. Azure AD tokens expire within a few hours and the same token will work across all workspaces with SSO enabled. 

The NodeJS SQL driver was extended to support Azure AD tokens.

Description of change:
- Introduces useAADToken in connection options.
- When useAADToken=true, the PlainHTTPAuthentication class will send a Bearer authorization header with the Azure AD token, instead of the Basic authorization header when using a PAT token. 
- Unit tests extended for PlainHTTPAuthentication for Azure tokens.
- E2E tests extended to support AAD Tokens


Workaround:
To use AAD token - you can tweak (@databricks/sql 1.1.1) as follows to use Azure AD tokens.

```
const { DBSQLClient, auth } = require('@databricks/sql');
// Patch to Databricks SQL driver to send Azure AD token as Bearer token.
Reflect.defineProperty(auth.PlainHttpAuthentication.prototype, 'getToken', {
  value: function () {
    return `Bearer ${this.password}`
  }
})

// Use normally - replacing token with your AAD token.
```

Submitted by:
Divya van Mahajan <divyavanmahajan@users.noreply.github.com>

