### PR TITLE
Fix E2E tests: session used after being closed

### DIFF
--- a/tests/e2e/arrow.test.js
+++ b/tests/e2e/arrow.test.js
@@ -58,10 +58,10 @@ describe('Arrow support', () => {
         await testBody(session);
       } catch (error) {
         logger(error);
-        await session.close();
         throw error;
       } finally {
         await deleteTable(session, tableName);
+        await session.close();
       }
     };
   }

--- a/tests/e2e/batched_fetch.test.js
+++ b/tests/e2e/batched_fetch.test.js
@@ -36,15 +36,23 @@ describe('Data fetching', () => {
 
   it('fetch chunks should return a max row set of chunkSize', async () => {
     const session = await openSession();
-    const operation = await session.executeStatement(query, { runAsync: true, maxRows: null });
-    let chunkedOp = await operation.fetchChunk({ maxRows: 10 }).catch((error) => logger(error));
-    expect(chunkedOp.length).to.be.equal(10);
+    try {
+      const operation = await session.executeStatement(query, { runAsync: true, maxRows: null });
+      let chunkedOp = await operation.fetchChunk({ maxRows: 10 }).catch((error) => logger(error));
+      expect(chunkedOp.length).to.be.equal(10);
+    } finally {
+      await session.close();
+    }
   });
 
   it('fetch all should fetch all records', async () => {
     const session = await openSession();
-    const operation = await session.executeStatement(query, { runAsync: true, maxRows: null });
-    let all = await operation.fetchAll();
-    expect(all.length).to.be.equal(1000);
+    try {
+      const operation = await session.executeStatement(query, { runAsync: true, maxRows: null });
+      let all = await operation.fetchAll();
+      expect(all.length).to.be.equal(1000);
+    } finally {
+      await session.close();
+    }
   });
 });

--- a/tests/e2e/data_types.test.js
+++ b/tests/e2e/data_types.test.js
@@ -189,14 +189,12 @@ describe('Data types', () => {
           dat: '2014-01-17',
         },
       ]);
-
-      await session.close();
     } catch (error) {
       logger(error);
-      await session.close();
       throw error;
     } finally {
       await execute(session, `DROP TABLE IF EXISTS ${table}`);
+      await session.close();
     }
   });
 
@@ -235,14 +233,12 @@ describe('Data types', () => {
           month_interval: '0-1',
         },
       ]);
-
-      await session.close();
     } catch (error) {
       logger(error);
-      await session.close();
       throw error;
     } finally {
       await execute(session, `DROP TABLE IF EXISTS ${table}`);
+      await session.close();
     }
   });
 
@@ -362,15 +358,13 @@ describe('Data types', () => {
           },
         },
       ]);
-
-      await session.close();
     } catch (error) {
       logger(error);
-      await session.close();
       throw error;
     } finally {
       await execute(session, `DROP TABLE IF EXISTS ${table}`);
       await execute(session, `DROP TABLE IF EXISTS ${helperTable}`);
+      await session.close();
     }
   });
 });


### PR DESCRIPTION
Until now it worked just by an accident: server doesn't immediately close session, but obviously it's not a correct usage of session