### PR TITLE
Update `thrift` library patch and prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 1.x (Unreleased)
 
+## 1.2.1
+
+- Added Azure AD support (databricks/databricks-sql-nodejs#126)
+- Improved direct results handling (databricks/databricks-sql-nodejs#134)
+- Updated API endpoint references in docs and samples (databricks/databricks-sql-nodejs#137)
+- Code refactoring to improve maintainability
+
 ## 1.2.0
 
 - Added Apache Arrow support (databricks/databricks-sql-nodejs#94)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,12 @@
 {
   "name": "@databricks/sql",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@databricks/sql",
-      "version": "1.2.0",
-      "bundleDependencies": [
-        "thrift"
-      ],
+      "version": "1.2.1",
       "hasInstallScript": true,
       "license": "Apache 2.0",
       "dependencies": {
@@ -1304,8 +1301,7 @@
     "node_modules/async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
-      "inBundle": true
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
     "node_modules/axe-core": {
       "version": "4.4.3",
@@ -1359,8 +1355,7 @@
     "node_modules/browser-or-node": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/browser-or-node/-/browser-or-node-1.3.0.tgz",
-      "integrity": "sha512-0F2z/VSnLbmEeBcUrSuDH5l0HxTXdQQzLjkmBR4cYfvg1zJrKSlmIZFqyFR8oX0NrwPhy3c3HQ6i3OxMbew4Tg==",
-      "inBundle": true
+      "integrity": "sha512-0F2z/VSnLbmEeBcUrSuDH5l0HxTXdQQzLjkmBR4cYfvg1zJrKSlmIZFqyFR8oX0NrwPhy3c3HQ6i3OxMbew4Tg=="
     },
     "node_modules/browser-stdout": {
       "version": "1.3.1",
@@ -3417,7 +3412,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
       "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
-      "inBundle": true,
       "peerDependencies": {
         "ws": "*"
       }
@@ -3956,8 +3950,7 @@
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
-      "inBundle": true
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="
     },
     "node_modules/node-preload": {
       "version": "0.2.1",
@@ -4713,7 +4706,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
-      "inBundle": true,
       "engines": {
         "node": ">=0.6.0",
         "teleport": ">=0.2.0"
@@ -5300,7 +5292,6 @@
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/thrift/-/thrift-0.16.0.tgz",
       "integrity": "sha512-W8DpGyTPlIaK3f+e1XOCLxefaUWXtrOXAaVIDbfYhmVyriYeAKgsBVFNJUV1F9SQ2SPt2sG44AZQxSGwGj/3VA==",
-      "inBundle": true,
       "dependencies": {
         "browser-or-node": "^1.2.1",
         "isomorphic-ws": "^4.0.1",
@@ -5686,7 +5677,6 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.3.tgz",
       "integrity": "sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==",
-      "inBundle": true,
       "dependencies": {
         "async-limiter": "~1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -13,9 +13,8 @@
   },
   "scripts": {
     "postinstall": "patch-package",
-    "clean": "rm -rf dist",
-    "prepare": "npm run clean && npm run build && npm run internal:bundle-thrift",
-    "internal:bundle-thrift": "mkdir dist/node_modules && cp -R node_modules/thrift dist/node_modules/thrift",
+    "prepare": "npm run build",
+    "prepack": "mkdir dist/node_modules && cp -R node_modules/thrift dist/node_modules/thrift",
     "e2e": "nyc --reporter=lcov --report-dir=coverage_e2e mocha --config tests/e2e/.mocharc.js",
     "test": "nyc --reporter=lcov --report-dir=coverage_unit mocha  --config tests/unit/.mocharc.js",
     "update-version": "node bin/update-version.js && prettier --write ./lib/version.ts",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   },
   "scripts": {
     "postinstall": "patch-package",
-    "prepare": "npm run build",
+    "clean": "rm -rf dist",
+    "prepare": "npm run clean && npm run build && npm run internal:bundle-thrift",
+    "internal:bundle-thrift": "mkdir dist/node_modules && cp -R node_modules/thrift dist/node_modules/thrift",
     "e2e": "nyc --reporter=lcov --report-dir=coverage_e2e mocha --config tests/e2e/.mocharc.js",
     "test": "nyc --reporter=lcov --report-dir=coverage_unit mocha  --config tests/unit/.mocharc.js",
     "update-version": "node bin/update-version.js && prettier --write ./lib/version.ts",
@@ -77,8 +79,5 @@
     "thrift": "^0.16.0",
     "uuid": "^9.0.0",
     "winston": "^3.8.2"
-  },
-  "bundledDependencies": [
-    "thrift"
-  ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks/sql",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Driver for connection to Databricks SQL via Thrift API.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/patches/thrift+0.16.0.patch
+++ b/patches/thrift+0.16.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/thrift/lib/nodejs/lib/thrift/http_connection.js b/node_modules/thrift/lib/nodejs/lib/thrift/http_connection.js
-index 17e0d0c..d1ead4a 100644
+index 17e0d0c..9e90096 100644
 --- a/node_modules/thrift/lib/nodejs/lib/thrift/http_connection.js
 +++ b/node_modules/thrift/lib/nodejs/lib/thrift/http_connection.js
 @@ -106,7 +106,7 @@ var HttpConnection = exports.HttpConnection = function(options) {
@@ -34,7 +34,7 @@ index 17e0d0c..d1ead4a 100644
        }
      }
    }
-@@ -165,17 +166,15 @@ var HttpConnection = exports.HttpConnection = function(options) {
+@@ -165,17 +166,17 @@ var HttpConnection = exports.HttpConnection = function(options) {
  
    //Response handler
    //////////////////////////////////////////////////
@@ -46,6 +46,8 @@ index 17e0d0c..d1ead4a 100644
      if (response.statusCode !== 200) {
 -      this.emit("error", new THTTPException(response));
 +      handleError(new THTTPException(response));
++      response.destroy();
++      return;
      }
  
 -    response.on('error', function (e) {
@@ -55,7 +57,7 @@ index 17e0d0c..d1ead4a 100644
  
      // When running directly under node, chunk will be a buffer,
      // however, when running in a Browser (e.g. Browserify), chunk
-@@ -199,7 +198,9 @@ var HttpConnection = exports.HttpConnection = function(options) {
+@@ -199,7 +200,9 @@ var HttpConnection = exports.HttpConnection = function(options) {
        }
        //Get the receiver function for the transport and
        //  call it with the buffer
@@ -66,7 +68,7 @@ index 17e0d0c..d1ead4a 100644
      });
    };
  };
-@@ -212,18 +213,33 @@ util.inherits(HttpConnection, EventEmitter);
+@@ -212,18 +215,33 @@ util.inherits(HttpConnection, EventEmitter);
   * @event {error} the "error" event is raised upon request failure passing the
   *     Node.js error object to the listener.
   */


### PR DESCRIPTION
Update our patch for `thrift` dependency: immediately stop processing respone on HTTP error statuses (non-200), otherwise it leads to weird errors when trying to parse Thrift response body. Related to [ES-662981]

Update to the way we ship patched `thrift` dependency: Yarn 2 and upper does not respect `bundledPackages` field and completely ignores bundled dependencies. Instead, we copy patched `thrift` into `dist/node_modules` explicitly. It works because Nodejs looks in nested `node_modules` first, and only if package not found there - will attempt to go up the directory tree. Dependencies of `thrift` itself will still be located at their default locations since we still depend on `thrift` library and it will be installed as usual.

Also, with the changes mentioned above, we're going to release next library version, so all preparation steps are performed as well (update `package.json`, changdelog, etc.)

[ES-662981]: https://databricks.atlassian.net/browse/ES-662981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ