### PR TITLE
[PECO-745] Default request timeout

### DIFF
--- a/lib/connection/connections/HttpConnection.ts
+++ b/lib/connection/connections/HttpConnection.ts
@@ -1,12 +1,13 @@
 import thrift from 'thrift';
 import https from 'https';
-
 import http, { IncomingMessage } from 'http';
+
 import IThriftConnection from '../contracts/IThriftConnection';
 import IConnectionProvider from '../contracts/IConnectionProvider';
 import IConnectionOptions, { Options } from '../contracts/IConnectionOptions';
 import IAuthentication from '../contracts/IAuthentication';
 import HttpTransport from '../transports/HttpTransport';
+import globalConfig from '../../globalConfig';
 
 type NodeOptions = {
   ca?: Buffer | string;
@@ -25,6 +26,7 @@ export default class HttpConnection implements IConnectionProvider, IThriftConne
       keepAlive: true,
       maxSockets: 5,
       keepAliveMsecs: 10000,
+      timeout: globalConfig.httpRequestTimeout,
     };
 
     const agent = options.options?.https
@@ -39,6 +41,7 @@ export default class HttpConnection implements IConnectionProvider, IThriftConne
         agent,
         ...this.getNodeOptions(options.options || {}),
         ...(options.options?.nodeOptions || {}),
+        timeout: globalConfig.httpRequestTimeout,
       },
     });
 

--- a/lib/connection/connections/HttpConnection.ts
+++ b/lib/connection/connections/HttpConnection.ts
@@ -26,7 +26,7 @@ export default class HttpConnection implements IConnectionProvider, IThriftConne
       keepAlive: true,
       maxSockets: 5,
       keepAliveMsecs: 10000,
-      timeout: globalConfig.httpRequestTimeout,
+      timeout: options.options?.socketTimeout ?? globalConfig.socketTimeout,
     };
 
     const agent = options.options?.https
@@ -41,7 +41,7 @@ export default class HttpConnection implements IConnectionProvider, IThriftConne
         agent,
         ...this.getNodeOptions(options.options || {}),
         ...(options.options?.nodeOptions || {}),
-        timeout: globalConfig.httpRequestTimeout,
+        timeout: options.options?.socketTimeout ?? globalConfig.socketTimeout,
       },
     });
 

--- a/lib/connection/contracts/IConnectionOptions.ts
+++ b/lib/connection/contracts/IConnectionOptions.ts
@@ -1,4 +1,5 @@
 export type Options = {
+  socketTimeout?: number;
   username?: string;
   password?: string;
   ssl?: boolean;

--- a/lib/contracts/IDBSQLClient.ts
+++ b/lib/contracts/IDBSQLClient.ts
@@ -11,6 +11,7 @@ export interface ConnectionOptions {
   path: string;
   token: string;
   clientId?: string;
+  socketTimeout?: number;
 }
 
 export interface OpenSessionRequest {

--- a/lib/globalConfig.ts
+++ b/lib/globalConfig.ts
@@ -1,7 +1,7 @@
 interface GlobalConfig {
   arrowEnabled?: boolean;
   useArrowNativeTypes?: boolean;
-  httpRequestTimeout: number;
+  socketTimeout: number;
 
   retryMaxAttempts: number;
   retriesTimeout: number; // in milliseconds
@@ -12,7 +12,7 @@ interface GlobalConfig {
 export default {
   arrowEnabled: true,
   useArrowNativeTypes: true,
-  httpRequestTimeout: 15 * 60 * 1000, // 15 minutes
+  socketTimeout: 15 * 60 * 1000, // 15 minutes
 
   retryMaxAttempts: 30,
   retriesTimeout: 900 * 1000,

--- a/lib/globalConfig.ts
+++ b/lib/globalConfig.ts
@@ -1,6 +1,7 @@
 interface GlobalConfig {
   arrowEnabled?: boolean;
   useArrowNativeTypes?: boolean;
+  httpRequestTimeout: number;
 
   retryMaxAttempts: number;
   retriesTimeout: number; // in milliseconds
@@ -11,6 +12,7 @@ interface GlobalConfig {
 export default {
   arrowEnabled: true,
   useArrowNativeTypes: true,
+  httpRequestTimeout: 15 * 60 * 1000, // 15 minutes
 
   retryMaxAttempts: 30,
   retriesTimeout: 900 * 1000,

--- a/patches/thrift+0.16.0.patch
+++ b/patches/thrift+0.16.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/thrift/lib/nodejs/lib/thrift/http_connection.js b/node_modules/thrift/lib/nodejs/lib/thrift/http_connection.js
-index 17e0d0c..f7764af 100644
+index 17e0d0c..96cbcf1 100644
 --- a/node_modules/thrift/lib/nodejs/lib/thrift/http_connection.js
 +++ b/node_modules/thrift/lib/nodejs/lib/thrift/http_connection.js
 @@ -106,7 +106,7 @@ var HttpConnection = exports.HttpConnection = function(options) {
@@ -106,7 +106,7 @@ index 17e0d0c..f7764af 100644
 +  req.on('timeout', () => {
 +    // Ignore all subsequent errors on this request
 +    req.off('error', handleError);
-+    req.on('error', () => console.log());
++    req.on('error', () => {});
 +    // Emit a single error and destroy request
 +    handleError(new thrift.TApplicationException(thrift.TApplicationExceptionType.PROTOCOL_ERROR, 'Request timed out'));
 +    req.destroy();

--- a/patches/thrift+0.16.0.patch
+++ b/patches/thrift+0.16.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/thrift/lib/nodejs/lib/thrift/http_connection.js b/node_modules/thrift/lib/nodejs/lib/thrift/http_connection.js
-index 17e0d0c..9e90096 100644
+index 17e0d0c..f7764af 100644
 --- a/node_modules/thrift/lib/nodejs/lib/thrift/http_connection.js
 +++ b/node_modules/thrift/lib/nodejs/lib/thrift/http_connection.js
 @@ -106,7 +106,7 @@ var HttpConnection = exports.HttpConnection = function(options) {
@@ -68,7 +68,7 @@ index 17e0d0c..9e90096 100644
      });
    };
  };
-@@ -212,18 +215,33 @@ util.inherits(HttpConnection, EventEmitter);
+@@ -212,18 +215,41 @@ util.inherits(HttpConnection, EventEmitter);
   * @event {error} the "error" event is raised upon request failure passing the
   *     Node.js error object to the listener.
   */
@@ -101,9 +101,16 @@ index 17e0d0c..9e90096 100644
 -      http.request(opts, self.responseCallback);
 -  req.on('error', function(err) {
 -    self.emit("error", err);
--  });
 +      https.request(opts, responseCallback) :
 +      http.request(opts, responseCallback);
++  req.on('timeout', () => {
++    // Ignore all subsequent errors on this request
++    req.off('error', handleError);
++    req.on('error', () => console.log());
++    // Emit a single error and destroy request
++    handleError(new thrift.TApplicationException(thrift.TApplicationExceptionType.PROTOCOL_ERROR, 'Request timed out'));
++    req.destroy();
+   });
 +  req.on('error', handleError);
    req.write(data);
    req.end();

--- a/tests/e2e/timeouts.test.js
+++ b/tests/e2e/timeouts.test.js
@@ -1,0 +1,59 @@
+const { expect, AssertionError } = require('chai');
+const config = require('./utils/config');
+const { DBSQLClient } = require('../..');
+const globalConfig = require('../../dist/globalConfig').default;
+
+const openSession = async (socketTimeout) => {
+  const client = new DBSQLClient();
+
+  const connection = await client.connect({
+    host: config.host,
+    path: config.path,
+    token: config.token,
+    socketTimeout,
+  });
+
+  return connection.openSession({
+    initialCatalog: config.database[0],
+    initialSchema: config.database[1],
+  });
+};
+
+describe('Data fetching', () => {
+  const query = `
+    SELECT *
+    FROM range(0, 100000) AS t1
+    LEFT JOIN (SELECT 1) AS t2
+    ORDER BY RANDOM() ASC
+  `;
+
+  const socketTimeout = 1; // minimum value to make sure any request will time out
+
+  it('should use default socket timeout', async () => {
+    const savedTimeout = globalConfig.socketTimeout;
+    globalConfig.socketTimeout = socketTimeout;
+    try {
+      await openSession();
+      expect.fail('It should throw an error');
+    } catch (error) {
+      if (error instanceof AssertionError) {
+        throw error;
+      }
+      expect(error.message).to.be.eq('Request timed out');
+    } finally {
+      globalConfig.socketTimeout = savedTimeout;
+    }
+  });
+
+  it('should use socket timeout from options', async () => {
+    try {
+      await await openSession(socketTimeout);
+      expect.fail('It should throw an error');
+    } catch (error) {
+      if (error instanceof AssertionError) {
+        throw error;
+      }
+      expect(error.message).to.be.eq('Request timed out');
+    }
+  });
+});

--- a/tests/unit/connection/connections/HttpConnection.test.js
+++ b/tests/unit/connection/connections/HttpConnection.test.js
@@ -162,7 +162,7 @@ describe('HttpConnection.connect', () => {
       .then(() => {
         resultConnection.responseCallback({ headers: {} });
         expect(resultConnection.executed).to.be.true;
-        expect(Object.keys(connection.thrift.options.nodeOptions)).to.be.deep.eq(['agent']);
+        expect(Object.keys(connection.thrift.options.nodeOptions)).to.be.deep.eq(['agent', 'timeout']);
       });
   });
 


### PR DESCRIPTION
Currently, for all Thrift requests timeouts are not set not handled.As per PECO-742, a single request should not block indefinitely.

- [x] Set default timeout to 15 minutes and abort timed out requests
- [x] Expose timeout option to user
- [x] Tests