### PR TITLE
return null when timestamp value is null instead of epoch default ts

### DIFF
--- a/lib/result/ArrowResult.ts
+++ b/lib/result/ArrowResult.ts
@@ -101,7 +101,7 @@ export default class ArrowResult implements IOperationResult {
     }
 
     if (DataType.isTimestamp(valueType)) {
-      return new Date(value);
+      return value ? new Date(value) : null;
     }
 
     // Convert big number values to BigInt

--- a/lib/result/ArrowResult.ts
+++ b/lib/result/ArrowResult.ts
@@ -68,6 +68,10 @@ export default class ArrowResult implements IOperationResult {
   }
 
   private convertArrowTypes(value: any, valueType: DataType | undefined, fields: Array<ArrowSchemaField> = []): any {
+    if (value === null) {
+      return value;
+    }
+
     const fieldsMap: Record<string, ArrowSchemaField> = {};
     for (const field of fields) {
       fieldsMap[field.name] = field;
@@ -101,7 +105,7 @@ export default class ArrowResult implements IOperationResult {
     }
 
     if (DataType.isTimestamp(valueType)) {
-      return value ? new Date(value) : null;
+      return new Date(value);
     }
 
     // Convert big number values to BigInt


### PR DESCRIPTION
Right now ArrowResult returns default epoch timestamp `1970-01-01T00:00:00.000Z` when a data type timestamp returns a null value
https://github.com/databricks/databricks-sql-nodejs/blob/0a2bdb47df8fba59c27e981679703c02d04ec132/lib/result/ArrowResult.ts#L104
expected behavior is to return the null value 
