### PR TITLE
[PECO-1053] Update Node CI to use UC enabled provisioned workspaces

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    environment: azure-prod
     steps:
       - uses: actions/checkout@v3
       - name: Cache node modules

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Run e2e tests
         run: |
           npm ci
-          E2E_HOST=$E2E_HOST E2E_PATH=$E2E_PATH E2E_ACCESS_TOKEN=$E2E_ACCESS_TOKEN NODE_OPTIONS="--max-old-space-size=4096" npm run e2e
+          E2E_HOST={{env.E2E_HOST}} E2E_PATH={{env.E2E_PATH}}  E2E_ACCESS_TOKEN={{env.E2E_ACCESS_TOKEN}}  NODE_OPTIONS="--max-old-space-size=4096" npm run e2e
       - name: Coverage
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,8 +54,6 @@ jobs:
           E2E_HOST: ${{ secrets.DATABRICKS_HOST }}
           E2E_PATH: ${{ secrets.TEST_PECO_WAREHOUSE_HTTP_PATH }}
           E2E_ACCESS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
-          E2E_CATALOG: peco
-          E2E_DATABASE: client_libs_test
           E2E_TABLE_SUFFIX: ${{github.sha}}
         run: |
           npm ci

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Run e2e tests
         run: |
           npm ci
-          NODE_OPTIONS="--max-old-space-size=4096" npm run e2e
+          E2E_HOST=$E2E_HOST E2E_PATH=$E2E_PATH E2E_ACCESS_TOKEN=$E2E_ACCESS_TOKEN NODE_OPTIONS="--max-old-space-size=4096" npm run e2e
       - name: Coverage
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    environment: azure-prod
     steps:
       - uses: actions/checkout@v3
       - name: Cache node modules

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,8 +44,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: Cache node modules
         uses: actions/cache@v3
-        env:
-          cache-name: cache-node-modules
         with:
           path: ~/.npm
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
@@ -58,11 +56,6 @@ jobs:
           npm ci
           npm run test
       - name: Run e2e tests
-        env:
-          E2E_HOST: ${{ secrets.DATABRICKS_HOST }}
-          E2E_PATH: ${{ secrets.TEST_PECO_WAREHOUSE_HTTP_PATH }}
-          E2E_ACCESS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
-          E2E_TABLE_SUFFIX: ${{github.sha}}
         run: |
           npm ci
           NODE_OPTIONS="--max-old-space-size=4096" npm run e2e

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,10 +51,10 @@ jobs:
           npm run test
       - name: Run e2e tests
         env:
-          E2E_HOST: ${{secrets.E2E_HOST}}
-          E2E_PATH: ${{secrets.E2E_PATH}}
-          E2E_ACCESS_TOKEN: ${{secrets.E2E_ACCESS_TOKEN}}
-          E2E_CATALOG: hive_metastore
+          E2E_HOST: ${{ secrets.DATABRICKS_HOST }}
+          E2E_PATH: ${{ secrets.TEST_PECO_WAREHOUSE_HTTP_PATH }}
+          E2E_ACCESS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
+          E2E_CATALOG: peco
           E2E_DATABASE: client_libs_test
           E2E_TABLE_SUFFIX: ${{github.sha}}
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Run e2e tests
         run: |
           npm ci
-          E2E_HOST={{env.E2E_HOST}} E2E_PATH={{env.E2E_PATH}}  E2E_ACCESS_TOKEN={{env.E2E_ACCESS_TOKEN}}  NODE_OPTIONS="--max-old-space-size=4096" npm run e2e
+          E2E_HOST=${{env.E2E_HOST}} E2E_PATH=${{env.E2E_PATH}}  E2E_ACCESS_TOKEN=${{env.E2E_ACCESS_TOKEN}}  NODE_OPTIONS="--max-old-space-size=4096" npm run e2e
       - name: Coverage
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,28 @@ jobs:
           npm run prettier
           npm run lint
 
-  test:
+  unit-test:
+    runs-on: ubuntu-latest
+    env:
+      cache-name: cache-node-modules
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Cache node modules
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Run unit tests
+        run: |
+          npm ci
+          npm run test
+
+  e2e-test:
     runs-on: ubuntu-latest
     environment: azure-prod
     env:
@@ -51,14 +72,10 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-      - name: Run unit tests
-        run: |
-          npm ci
-          npm run test
       - name: Run e2e tests
         run: |
-          npm ci
-          E2E_HOST=${{env.E2E_HOST}} E2E_PATH=${{env.E2E_PATH}}  E2E_ACCESS_TOKEN=${{env.E2E_ACCESS_TOKEN}}  NODE_OPTIONS="--max-old-space-size=4096" npm run e2e
+          E2E_HOST=${{ env.E2E_HOST }} E2E_PATH=${{env.E2E_PATH}}  E2E_ACCESS_TOKEN=${{env.E2E_ACCESS_TOKEN}} npm ci
+          NODE_OPTIONS="--max-old-space-size=4096" npm run e2e
       - name: Coverage
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,13 @@ jobs:
   test:
     runs-on: ubuntu-latest
     environment: azure-prod
+    env:
+      E2E_HOST: ${{ secrets.DATABRICKS_HOST }}
+      E2E_PATH: ${{ secrets.TEST_PECO_WAREHOUSE_HTTP_PATH }}
+      E2E_ACCESS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
+      E2E_TABLE_SUFFIX: ${{github.sha}}
+      cache-name: cache-node-modules
+
     steps:
       - uses: actions/checkout@v3
       - name: Cache node modules

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,6 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    environment: azure-prod
     steps:
       - uses: actions/checkout@v3
       - name: Cache node modules
@@ -75,7 +74,7 @@ jobs:
             ${{ runner.os }}-
       - name: Run e2e tests
         run: |
-          E2E_HOST=${{ env.E2E_HOST }} E2E_PATH=${{env.E2E_PATH}}  E2E_ACCESS_TOKEN=${{env.E2E_ACCESS_TOKEN}} npm ci
+          npm ci
           NODE_OPTIONS="--max-old-space-size=4096" npm run e2e
       - name: Coverage
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
Currently e2e tests do not work with UC, but Ben has provisioned some new warehouses that we can use. We are trying to integrate these with our workflow.