### PR TITLE
Fix coverage reporting in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,13 @@ jobs:
         run: |
           npm ci
           npm run test
+      - run: tar -cvf coverage_unit.tar coverage_unit
+      - name: Store coverage report
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage_unit
+          path: coverage_unit.tar
+          retention-days: 1
 
   e2e-test:
     runs-on: ubuntu-latest
@@ -76,6 +83,28 @@ jobs:
         run: |
           npm ci
           NODE_OPTIONS="--max-old-space-size=4096" npm run e2e
+      - run: tar -cvf coverage_e2e.tar coverage_e2e
+      - name: Store coverage report
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage_e2e
+          path: coverage_e2e.tar
+          retention-days: 1
+
+  coverage:
+    needs: [unit-test, e2e-test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: coverage_unit
+          path: coverage_unit.tar
+      - uses: actions/download-artifact@v3
+        with:
+          name: coverage_e2e
+          path: coverage_e2e.tar
+      - run: tar -xvf coverage_unit.tar coverage_unit
+      - run: tar -xvf coverage_e2e.tar coverage_e2e
       - name: Coverage
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,8 +101,8 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: coverage_e2e
-      - run: tar -xvf coverage_unit.tar
-      - run: tar -xvf coverage_e2e.tar
+      - run: tar -xvf coverage_unit.tar && rm coverage_unit.tar
+      - run: tar -xvf coverage_e2e.tar && rm coverage_e2e.tar
       - name: Coverage
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,13 +98,11 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: coverage_unit
-          path: coverage_unit.tar
       - uses: actions/download-artifact@v3
         with:
           name: coverage_e2e
-          path: coverage_e2e.tar
-      - run: tar -xvf coverage_unit.tar coverage_unit
-      - run: tar -xvf coverage_e2e.tar coverage_e2e
+      - run: tar -xvf coverage_unit.tar
+      - run: tar -xvf coverage_e2e.tar
       - name: Coverage
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,20 @@ jobs:
   coverage:
     needs: [unit-test, e2e-test]
     runs-on: ubuntu-latest
+    env:
+      cache-name: cache-node-modules
+
     steps:
+      - uses: actions/checkout@v3
+      - name: Cache node modules
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
       - uses: actions/download-artifact@v3
         with:
           name: coverage_unit


### PR DESCRIPTION
Follow up on databricks/databricks-sql-nodejs#172

Since we've split unit and e2e jobs, codecov stopped seing the full coverage report. So now we store coverage reports after unit and e2e jobs, and unpack them when running coverage job so it can process both

![](https://github.com/databricks/databricks-sql-nodejs/assets/12139186/98d4c681-4afa-4beb-89bf-1edc0011fe71)
