### PR TITLE
[PECO-1052] Added enum type class to DBSQLParameter class

### DIFF
--- a/lib/DBSQLParameter.ts
+++ b/lib/DBSQLParameter.ts
@@ -3,8 +3,24 @@ import { TSparkParameter, TSparkParameterValue } from '../thrift/TCLIService_typ
 
 export type DBSQLParameterValue = boolean | number | bigint | Int64 | Date | string;
 
+enum DBSQLParameterType {
+  STRING = "STRING",
+  DATE = "DATE",
+  TIMESTAMP = "TIMESTAMP",
+  FLOAT = "FLOAT",
+  DECIMAL = "DECIMAL",
+  DOUBLE = "DOUBLE",
+  INTEGER = "INTEGER",
+  BIGINT = "BIGINT",
+  SMALLINT = "SMALLINT",
+  TINYINT = "TINYINT",
+  BOOLEAN = "BOOLEAN",
+  INTERVALMONTH = "INTERVAL MONTH",
+  INTERVALDAY = "INTERVAL DAY"
+}
+
 interface DBSQLParameterOptions {
-  type?: string;
+  type?: DBSQLParameterType;
   value: DBSQLParameterValue;
 }
 
@@ -21,7 +37,7 @@ export default class DBSQLParameter {
   public toSparkParameter(): TSparkParameter {
     if (typeof this.value === 'boolean') {
       return new TSparkParameter({
-        type: this.type ?? 'BOOLEAN',
+        type: this.type ?? DBSQLParameterType.BOOLEAN,
         value: new TSparkParameterValue({
           stringValue: this.value ? 'TRUE' : 'FALSE',
         }),
@@ -30,7 +46,7 @@ export default class DBSQLParameter {
 
     if (typeof this.value === 'number') {
       return new TSparkParameter({
-        type: this.type ?? (Number.isInteger(this.value) ? 'INTEGER' : 'DOUBLE'),
+        type: this.type ?? (Number.isInteger(this.value) ? DBSQLParameterType.INTEGER : DBSQLParameterType.DOUBLE),
         value: new TSparkParameterValue({
           stringValue: Number(this.value).toString(),
         }),
@@ -39,7 +55,7 @@ export default class DBSQLParameter {
 
     if (this.value instanceof Int64 || typeof this.value === 'bigint') {
       return new TSparkParameter({
-        type: this.type ?? 'BIGINT',
+        type: this.type ?? DBSQLParameterType.BIGINT,
         value: new TSparkParameterValue({
           stringValue: this.value.toString(),
         }),
@@ -48,7 +64,7 @@ export default class DBSQLParameter {
 
     if (this.value instanceof Date) {
       return new TSparkParameter({
-        type: this.type ?? 'TIMESTAMP',
+        type: this.type ?? DBSQLParameterType.TIMESTAMP,
         value: new TSparkParameterValue({
           stringValue: this.value.toISOString(),
         }),
@@ -56,7 +72,7 @@ export default class DBSQLParameter {
     }
 
     return new TSparkParameter({
-      type: this.type ?? 'STRING',
+      type: this.type ?? DBSQLParameterType.STRING,
       value: new TSparkParameterValue({
         stringValue: this.value,
       }),

--- a/lib/DBSQLParameter.ts
+++ b/lib/DBSQLParameter.ts
@@ -3,20 +3,20 @@ import { TSparkParameter, TSparkParameterValue } from '../thrift/TCLIService_typ
 
 export type DBSQLParameterValue = boolean | number | bigint | Int64 | Date | string;
 
-enum DBSQLParameterType {
-  STRING = "STRING",
-  DATE = "DATE",
-  TIMESTAMP = "TIMESTAMP",
-  FLOAT = "FLOAT",
-  DECIMAL = "DECIMAL",
-  DOUBLE = "DOUBLE",
-  INTEGER = "INTEGER",
-  BIGINT = "BIGINT",
-  SMALLINT = "SMALLINT",
-  TINYINT = "TINYINT",
-  BOOLEAN = "BOOLEAN",
-  INTERVALMONTH = "INTERVAL MONTH",
-  INTERVALDAY = "INTERVAL DAY"
+export enum DBSQLParameterType {
+  STRING = 'STRING',
+  DATE = 'DATE',
+  TIMESTAMP = 'TIMESTAMP',
+  FLOAT = 'FLOAT',
+  DECIMAL = 'DECIMAL',
+  DOUBLE = 'DOUBLE',
+  INTEGER = 'INTEGER',
+  BIGINT = 'BIGINT',
+  SMALLINT = 'SMALLINT',
+  TINYINT = 'TINYINT',
+  BOOLEAN = 'BOOLEAN',
+  INTERVALMONTH = 'INTERVAL MONTH',
+  INTERVALDAY = 'INTERVAL DAY',
 }
 
 interface DBSQLParameterOptions {
@@ -24,7 +24,7 @@ interface DBSQLParameterOptions {
   value: DBSQLParameterValue;
 }
 
-export default class DBSQLParameter {
+export class DBSQLParameter {
   public readonly type?: string;
 
   public readonly value: DBSQLParameterValue;

--- a/lib/DBSQLSession.ts
+++ b/lib/DBSQLSession.ts
@@ -30,7 +30,7 @@ import CloseableCollection from './utils/CloseableCollection';
 import IDBSQLLogger, { LogLevel } from './contracts/IDBSQLLogger';
 import HiveDriverError from './errors/HiveDriverError';
 import globalConfig from './globalConfig';
-import DBSQLParameter, { DBSQLParameterValue } from './DBSQLParameter';
+import { DBSQLParameter, DBSQLParameterValue } from './DBSQLParameter';
 
 const defaultMaxRows = 100000;
 

--- a/lib/contracts/IDBSQLSession.ts
+++ b/lib/contracts/IDBSQLSession.ts
@@ -2,7 +2,7 @@ import IOperation from './IOperation';
 import Status from '../dto/Status';
 import InfoValue from '../dto/InfoValue';
 import { Int64 } from '../hive/Types';
-import DBSQLParameter, { DBSQLParameterValue } from '../DBSQLParameter';
+import { DBSQLParameter, DBSQLParameterValue } from '../DBSQLParameter';
 
 export type ExecuteStatementOptions = {
   queryTimeout?: Int64;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,7 +3,7 @@ import TCLIService from '../thrift/TCLIService';
 import TCLIService_types from '../thrift/TCLIService_types';
 import DBSQLClient from './DBSQLClient';
 import DBSQLSession from './DBSQLSession';
-import DBSQLParameter from './DBSQLParameter';
+import { DBSQLParameter } from './DBSQLParameter';
 import DBSQLLogger from './DBSQLLogger';
 import PlainHttpAuthentication from './connection/auth/PlainHttpAuthentication';
 import HttpConnection from './connection/connections/HttpConnection';

--- a/tests/unit/DBSQLParameter.test.js
+++ b/tests/unit/DBSQLParameter.test.js
@@ -2,28 +2,67 @@ const { expect } = require('chai');
 
 const Int64 = require('node-int64');
 const { TSparkParameterValue, TSparkParameter } = require('../../thrift/TCLIService_types');
-const { default: DBSQLParameter } = require('../../dist/DBSQLParameter');
+const { DBSQLParameter, DBSQLParameterType } = require('../../dist/DBSQLParameter');
 
 describe('DBSQLParameter', () => {
   it('should infer types correctly', () => {
     const cases = [
-      [false, new TSparkParameter({ type: 'BOOLEAN', value: new TSparkParameterValue({ stringValue: 'FALSE' }) })],
-      [true, new TSparkParameter({ type: 'BOOLEAN', value: new TSparkParameterValue({ stringValue: 'TRUE' }) })],
-      [123, new TSparkParameter({ type: 'INTEGER', value: new TSparkParameterValue({ stringValue: '123' }) })],
-      [3.14, new TSparkParameter({ type: 'DOUBLE', value: new TSparkParameterValue({ stringValue: '3.14' }) })],
-      [BigInt(1234), new TSparkParameter({ type: 'BIGINT', value: new TSparkParameterValue({ stringValue: '1234' }) })],
+      [
+        false,
+        new TSparkParameter({
+          type: DBSQLParameterType.BOOLEAN,
+          value: new TSparkParameterValue({ stringValue: 'FALSE' }),
+        }),
+      ],
+      [
+        true,
+        new TSparkParameter({
+          type: DBSQLParameterType.BOOLEAN,
+          value: new TSparkParameterValue({ stringValue: 'TRUE' }),
+        }),
+      ],
+      [
+        123,
+        new TSparkParameter({
+          type: DBSQLParameterType.INTEGER,
+          value: new TSparkParameterValue({ stringValue: '123' }),
+        }),
+      ],
+      [
+        3.14,
+        new TSparkParameter({
+          type: DBSQLParameterType.DOUBLE,
+          value: new TSparkParameterValue({ stringValue: '3.14' }),
+        }),
+      ],
+      [
+        BigInt(1234),
+        new TSparkParameter({
+          type: DBSQLParameterType.BIGINT,
+          value: new TSparkParameterValue({ stringValue: '1234' }),
+        }),
+      ],
       [
         new Int64(1234),
-        new TSparkParameter({ type: 'BIGINT', value: new TSparkParameterValue({ stringValue: '1234' }) }),
+        new TSparkParameter({
+          type: DBSQLParameterType.BIGINT,
+          value: new TSparkParameterValue({ stringValue: '1234' }),
+        }),
       ],
       [
         new Date('2023-09-06T03:14:27.843Z'),
         new TSparkParameter({
-          type: 'TIMESTAMP',
+          type: DBSQLParameterType.TIMESTAMP,
           value: new TSparkParameterValue({ stringValue: '2023-09-06T03:14:27.843Z' }),
         }),
       ],
-      ['Hello', new TSparkParameter({ type: 'STRING', value: new TSparkParameterValue({ stringValue: 'Hello' }) })],
+      [
+        'Hello',
+        new TSparkParameter({
+          type: DBSQLParameterType.STRING,
+          value: new TSparkParameterValue({ stringValue: 'Hello' }),
+        }),
+      ],
     ];
 
     for (const [value, expectedParam] of cases) {


### PR DESCRIPTION
It's unsafe to allow the user to pick any string. We should instead limit the types that they can set on parameters. We do this via an enum.