### PR TITLE
[PECO-932] OAuth M2M flow: fix token refresh flow

### DIFF
--- a/tests/unit/connection/auth/DatabricksOAuth/OAuthManager.test.js
+++ b/tests/unit/connection/auth/DatabricksOAuth/OAuthManager.test.js
@@ -170,7 +170,7 @@ class OAuthClientMock {
       expect(oauthClient.grant.called).to.be.true;
       expect(token).to.be.instanceOf(OAuthToken);
       expect(token.accessToken).to.be.equal(oauthClient.accessToken);
-      expect(token.refreshToken).to.be.equal(oauthClient.refreshToken);
+      expect(token.refreshToken).to.be.undefined;
     });
 
     it('should throw an error if cannot get access token', async () => {

--- a/tests/unit/connection/auth/DatabricksOAuth/OAuthManager.test.js
+++ b/tests/unit/connection/auth/DatabricksOAuth/OAuthManager.test.js
@@ -145,164 +145,278 @@ class OAuthClientMock {
       openidClientLib.Issuer.restore?.();
     });
 
-    it('should get access token (U2M)', async () => {
-      const { oauthManager, oauthClient } = prepareTestInstances({
-        logger: {
-          log: () => {},
-        },
-      });
+    describe('U2M flow', () => {
+      it('should get access token', async () => {
+        const { oauthManager, oauthClient } = prepareTestInstances({
+          logger: {
+            log: () => {},
+          },
+        });
 
-      const token = await oauthManager.getToken(['offline_access']);
-      expect(oauthClient.grant.called).to.be.true;
-      expect(token).to.be.instanceOf(OAuthToken);
-      expect(token.accessToken).to.be.equal(oauthClient.accessToken);
-      expect(token.refreshToken).to.be.equal(oauthClient.refreshToken);
-    });
-
-    it('should get access token (M2M)', async () => {
-      const { oauthManager, oauthClient } = prepareTestInstances({
-        // setup for M2M flow
-        clientId: 'test_client_id',
-        clientSecret: 'test_client_secret',
-      });
-
-      const token = await oauthManager.getToken([]);
-      expect(oauthClient.grant.called).to.be.true;
-      expect(token).to.be.instanceOf(OAuthToken);
-      expect(token.accessToken).to.be.equal(oauthClient.accessToken);
-      expect(token.refreshToken).to.be.undefined;
-    });
-
-    it('should throw an error if cannot get access token', async () => {
-      const { oauthManager, oauthClient } = prepareTestInstances();
-
-      // Make it return empty tokens
-      oauthClient.accessToken = undefined;
-      oauthClient.refreshToken = undefined;
-
-      try {
-        await oauthManager.getToken([]);
-        expect.fail('It should throw an error');
-      } catch (error) {
-        if (error instanceof AssertionError) {
-          throw error;
-        }
+        const token = await oauthManager.getToken(['offline_access']);
         expect(oauthClient.grant.called).to.be.true;
-        expect(error.message).to.contain('Failed to fetch access token');
-      }
-    });
-
-    it('should re-throw unhandled errors when getting access token', async () => {
-      const { oauthManager, oauthClient } = prepareTestInstances();
-
-      const testError = new Error('Test');
-      oauthClient.grantError = testError;
-
-      try {
-        await oauthManager.getToken([]);
-        expect.fail('It should throw an error');
-      } catch (error) {
-        if (error instanceof AssertionError) {
-          throw error;
-        }
-        expect(oauthClient.grant.called).to.be.true;
-        expect(error).to.be.equal(testError);
-      }
-    });
-
-    it('should not refresh valid token', async () => {
-      const { oauthManager, oauthClient } = prepareTestInstances();
-
-      const token = new OAuthToken(createValidAccessToken(), oauthClient.refreshToken);
-      expect(token.hasExpired).to.be.false;
-
-      const newToken = await oauthManager.refreshAccessToken(token);
-      expect(oauthClient.refresh.called).to.be.false;
-      expect(newToken).to.be.instanceOf(OAuthToken);
-      expect(newToken.accessToken).to.be.equal(token.accessToken);
-      expect(newToken.hasExpired).to.be.false;
-    });
-
-    it('should throw an error if no refresh token is available', async () => {
-      const { oauthManager, oauthClient } = prepareTestInstances({
-        logger: {
-          log: () => {},
-        },
+        expect(token).to.be.instanceOf(OAuthToken);
+        expect(token.accessToken).to.be.equal(oauthClient.accessToken);
+        expect(token.refreshToken).to.be.equal(oauthClient.refreshToken);
       });
 
-      try {
-        const token = new OAuthToken(createExpiredAccessToken());
-        expect(token.hasExpired).to.be.true;
+      it('should throw an error if cannot get access token', async () => {
+        const { oauthManager, oauthClient } = prepareTestInstances();
 
-        await oauthManager.refreshAccessToken(token);
-        expect.fail('It should throw an error');
-      } catch (error) {
-        if (error instanceof AssertionError) {
-          throw error;
+        // Make it return empty tokens
+        oauthClient.accessToken = undefined;
+        oauthClient.refreshToken = undefined;
+
+        try {
+          await oauthManager.getToken([]);
+          expect.fail('It should throw an error');
+        } catch (error) {
+          if (error instanceof AssertionError) {
+            throw error;
+          }
+          expect(oauthClient.grant.called).to.be.true;
+          expect(error.message).to.contain('Failed to fetch access token');
         }
+      });
+
+      it('should re-throw unhandled errors when getting access token', async () => {
+        const { oauthManager, oauthClient } = prepareTestInstances();
+
+        const testError = new Error('Test');
+        oauthClient.grantError = testError;
+
+        try {
+          await oauthManager.getToken([]);
+          expect.fail('It should throw an error');
+        } catch (error) {
+          if (error instanceof AssertionError) {
+            throw error;
+          }
+          expect(oauthClient.grant.called).to.be.true;
+          expect(error).to.be.equal(testError);
+        }
+      });
+
+      it('should not refresh valid token', async () => {
+        const { oauthManager, oauthClient } = prepareTestInstances();
+
+        const token = new OAuthToken(createValidAccessToken(), oauthClient.refreshToken);
+        expect(token.hasExpired).to.be.false;
+
+        const newToken = await oauthManager.refreshAccessToken(token);
         expect(oauthClient.refresh.called).to.be.false;
-        expect(error.message).to.contain('token expired');
-      }
-    });
-
-    it('should throw an error on invalid response', async () => {
-      const { oauthManager, oauthClient } = prepareTestInstances({
-        logger: {
-          log: () => {},
-        },
+        expect(newToken).to.be.instanceOf(OAuthToken);
+        expect(newToken.accessToken).to.be.equal(token.accessToken);
+        expect(newToken.hasExpired).to.be.false;
       });
 
-      oauthClient.refresh.restore();
-      sinon.stub(oauthClient, 'refresh').returns({});
+      it('should throw an error if no refresh token is available', async () => {
+        const { oauthManager, oauthClient } = prepareTestInstances({
+          logger: {
+            log: () => {},
+          },
+        });
 
-      try {
-        const token = new OAuthToken(createExpiredAccessToken(), oauthClient.refreshToken);
+        try {
+          const token = new OAuthToken(createExpiredAccessToken());
+          expect(token.hasExpired).to.be.true;
+
+          await oauthManager.refreshAccessToken(token);
+          expect.fail('It should throw an error');
+        } catch (error) {
+          if (error instanceof AssertionError) {
+            throw error;
+          }
+          expect(oauthClient.refresh.called).to.be.false;
+          expect(error.message).to.contain('token expired');
+        }
+      });
+
+      it('should throw an error for invalid token', async () => {
+        const { oauthManager, oauthClient } = prepareTestInstances({
+          logger: {
+            log: () => {},
+          },
+        });
+
+        try {
+          const token = new OAuthToken('invalid_access_token', 'invalid_refresh_token');
+          await oauthManager.refreshAccessToken(token);
+          expect.fail('It should throw an error');
+        } catch (error) {
+          if (error instanceof AssertionError) {
+            throw error;
+          }
+          expect(oauthClient.refresh.called).to.be.false;
+          // Random malformed string passed as access token will cause JSON parse errors
+          expect(error).to.be.instanceof(TypeError);
+        }
+      });
+
+      it('should refresh expired token', async () => {
+        const { oauthManager, oauthClient } = prepareTestInstances();
+
+        oauthClient.accessToken = createExpiredAccessToken();
+        const token = await oauthManager.getToken([]);
         expect(token.hasExpired).to.be.true;
 
-        await oauthManager.refreshAccessToken(token);
-        expect.fail('It should throw an error');
-      } catch (error) {
-        if (error instanceof AssertionError) {
-          throw error;
-        }
+        const newToken = await oauthManager.refreshAccessToken(token);
         expect(oauthClient.refresh.called).to.be.true;
-        expect(error.message).to.contain('invalid response');
-      }
-    });
-
-    it('should throw an error for invalid token', async () => {
-      const { oauthManager, oauthClient } = prepareTestInstances({
-        logger: {
-          log: () => {},
-        },
+        expect(newToken).to.be.instanceOf(OAuthToken);
+        expect(newToken.accessToken).to.be.not.equal(token.accessToken);
+        expect(newToken.hasExpired).to.be.false;
       });
 
-      try {
-        const token = new OAuthToken('invalid_access_token', 'invalid_refresh_token');
-        await oauthManager.refreshAccessToken(token);
-        expect.fail('It should throw an error');
-      } catch (error) {
-        if (error instanceof AssertionError) {
-          throw error;
+      it('should throw an error if cannot refresh token', async () => {
+        const { oauthManager, oauthClient } = prepareTestInstances({
+          logger: {
+            log: () => {},
+          },
+        });
+
+        oauthClient.refresh.restore();
+        sinon.stub(oauthClient, 'refresh').returns({});
+
+        try {
+          const token = new OAuthToken(createExpiredAccessToken(), oauthClient.refreshToken);
+          expect(token.hasExpired).to.be.true;
+
+          await oauthManager.refreshAccessToken(token);
+          expect.fail('It should throw an error');
+        } catch (error) {
+          if (error instanceof AssertionError) {
+            throw error;
+          }
+          expect(oauthClient.refresh.called).to.be.true;
+          expect(error.message).to.contain('invalid response');
         }
-        expect(oauthClient.refresh.called).to.be.false;
-        // Random malformed string passed as access token will cause JSON parse errors
-        expect(error).to.be.instanceof(TypeError);
-      }
+      });
     });
 
-    it('should refresh expired token', async () => {
-      const { oauthManager, oauthClient } = prepareTestInstances();
+    describe('M2M flow', () => {
+      it('should get access token', async () => {
+        const { oauthManager, oauthClient } = prepareTestInstances({
+          // setup for M2M flow
+          clientId: 'test_client_id',
+          clientSecret: 'test_client_secret',
+        });
 
-      oauthClient.accessToken = createExpiredAccessToken();
-      const token = await oauthManager.getToken([]);
-      expect(token.hasExpired).to.be.true;
+        const token = await oauthManager.getToken([]);
+        expect(oauthClient.grant.called).to.be.true;
+        expect(token).to.be.instanceOf(OAuthToken);
+        expect(token.accessToken).to.be.equal(oauthClient.accessToken);
+        expect(token.refreshToken).to.be.undefined;
+      });
 
-      const newToken = await oauthManager.refreshAccessToken(token);
-      expect(oauthClient.refresh.called).to.be.true;
-      expect(newToken).to.be.instanceOf(OAuthToken);
-      expect(newToken.accessToken).to.be.not.equal(token.accessToken);
-      expect(newToken.hasExpired).to.be.false;
+      it('should throw an error if cannot get access token', async () => {
+        const { oauthManager, oauthClient } = prepareTestInstances({
+          // setup for M2M flow
+          clientId: 'test_client_id',
+          clientSecret: 'test_client_secret',
+        });
+
+        // Make it return empty tokens
+        oauthClient.accessToken = undefined;
+        oauthClient.refreshToken = undefined;
+
+        try {
+          await oauthManager.getToken([]);
+          expect.fail('It should throw an error');
+        } catch (error) {
+          if (error instanceof AssertionError) {
+            throw error;
+          }
+          expect(oauthClient.grant.called).to.be.true;
+          expect(error.message).to.contain('Failed to fetch access token');
+        }
+      });
+
+      it('should re-throw unhandled errors when getting access token', async () => {
+        const { oauthManager, oauthClient } = prepareTestInstances({
+          // setup for M2M flow
+          clientId: 'test_client_id',
+          clientSecret: 'test_client_secret',
+        });
+
+        const testError = new Error('Test');
+        oauthClient.grantError = testError;
+
+        try {
+          await oauthManager.getToken([]);
+          expect.fail('It should throw an error');
+        } catch (error) {
+          if (error instanceof AssertionError) {
+            throw error;
+          }
+          expect(oauthClient.grant.called).to.be.true;
+          expect(error).to.be.equal(testError);
+        }
+      });
+
+      it('should not refresh valid token', async () => {
+        const { oauthManager, oauthClient } = prepareTestInstances({
+          // setup for M2M flow
+          clientId: 'test_client_id',
+          clientSecret: 'test_client_secret',
+        });
+
+        const token = new OAuthToken(createValidAccessToken());
+        expect(token.hasExpired).to.be.false;
+
+        const newToken = await oauthManager.refreshAccessToken(token);
+        expect(oauthClient.grant.called).to.be.false;
+        expect(oauthClient.refresh.called).to.be.false;
+        expect(newToken).to.be.instanceOf(OAuthToken);
+        expect(newToken.accessToken).to.be.equal(token.accessToken);
+        expect(newToken.hasExpired).to.be.false;
+      });
+
+      it('should refresh expired token', async () => {
+        const { oauthManager, oauthClient } = prepareTestInstances({
+          // setup for M2M flow
+          clientId: 'test_client_id',
+          clientSecret: 'test_client_secret',
+        });
+
+        oauthClient.accessToken = createExpiredAccessToken();
+        const token = await oauthManager.getToken([]);
+        expect(token.hasExpired).to.be.true;
+
+        oauthClient.accessToken = createValidAccessToken();
+        const newToken = await oauthManager.refreshAccessToken(token);
+        expect(oauthClient.grant.called).to.be.true;
+        expect(oauthClient.refresh.called).to.be.false;
+        expect(newToken).to.be.instanceOf(OAuthToken);
+        expect(newToken.accessToken).to.be.not.equal(token.accessToken);
+        expect(newToken.hasExpired).to.be.false;
+      });
+
+      it('should throw an error if cannot refresh token', async () => {
+        const { oauthManager, oauthClient } = prepareTestInstances({
+          // setup for M2M flow
+          clientId: 'test_client_id',
+          clientSecret: 'test_client_secret',
+        });
+
+        oauthClient.accessToken = createExpiredAccessToken();
+        const token = await oauthManager.getToken([]);
+        expect(token.hasExpired).to.be.true;
+
+        oauthClient.grant.restore();
+        sinon.stub(oauthClient, 'grant').returns({});
+
+        try {
+          await oauthManager.refreshAccessToken(token);
+          expect.fail('It should throw an error');
+        } catch (error) {
+          if (error instanceof AssertionError) {
+            throw error;
+          }
+          expect(oauthClient.grant.called).to.be.true;
+          expect(oauthClient.refresh.called).to.be.false;
+          expect(error.message).to.contain('Failed to fetch access token');
+        }
+      });
     });
   });
 });


### PR DESCRIPTION
In OAuth M2M flow, token refresh is not really supported. Instead, each time when access token expires, a new one should be acquired using client secret