### PR TITLE
[PECO-1015] Changed error message to tell users which version of DBR will support parameterized queries.

### DIFF
--- a/lib/DBSQLSession.ts
+++ b/lib/DBSQLSession.ts
@@ -105,7 +105,7 @@ function getQueryParameters(
   ) {
     throw new Thrift.TProtocolException(
       Thrift.TProtocolExceptionType.BAD_VERSION,
-      'Server version does not support parameterized queries',
+      'Parameterized operations are not supported by this server. Support will begin with server version DBR 14.1'
     );
   }
 

--- a/lib/DBSQLSession.ts
+++ b/lib/DBSQLSession.ts
@@ -105,7 +105,7 @@ function getQueryParameters(
   ) {
     throw new Thrift.TProtocolException(
       Thrift.TProtocolExceptionType.BAD_VERSION,
-      'Parameterized operations are not supported by this server. Support will begin with server version DBR 14.1'
+      'Parameterized operations are not supported by this server. Support will begin with server version DBR 14.1',
     );
   }
 


### PR DESCRIPTION
It's unclear to some users why their server doesn't support params. I've added the soonest version of DBR that should support them to the error message.