### PR TITLE
Query parameters: implement support for binding NULL parameters

### DIFF
--- a/lib/DBSQLParameter.ts
+++ b/lib/DBSQLParameter.ts
@@ -1,7 +1,7 @@
 import Int64 from 'node-int64';
 import { TSparkParameter, TSparkParameterValue } from '../thrift/TCLIService_types';
 
-export type DBSQLParameterValue = boolean | number | bigint | Int64 | Date | string;
+export type DBSQLParameterValue = undefined | null | boolean | number | bigint | Int64 | Date | string;
 
 export enum DBSQLParameterType {
   STRING = 'STRING',
@@ -35,6 +35,10 @@ export class DBSQLParameter {
   }
 
   public toSparkParameter(): TSparkParameter {
+    if (this.value === undefined || this.value === null) {
+      return new TSparkParameter(); // for NULL neither `type` nor `value` should be set
+    }
+
     if (typeof this.value === 'boolean') {
       return new TSparkParameter({
         type: this.type ?? DBSQLParameterType.BOOLEAN,

--- a/lib/DBSQLParameter.ts
+++ b/lib/DBSQLParameter.ts
@@ -4,6 +4,7 @@ import { TSparkParameter, TSparkParameterValue } from '../thrift/TCLIService_typ
 export type DBSQLParameterValue = undefined | null | boolean | number | bigint | Int64 | Date | string;
 
 export enum DBSQLParameterType {
+  VOID = 'VOID', // aka NULL
   STRING = 'STRING',
   DATE = 'DATE',
   TIMESTAMP = 'TIMESTAMP',
@@ -35,6 +36,12 @@ export class DBSQLParameter {
   }
 
   public toSparkParameter(): TSparkParameter {
+    // If VOID type was set explicitly - ignore value
+    if (this.type === DBSQLParameterType.VOID) {
+      return new TSparkParameter(); // for NULL neither `type` nor `value` should be set
+    }
+
+    // Infer NULL values
     if (this.value === undefined || this.value === null) {
       return new TSparkParameter(); // for NULL neither `type` nor `value` should be set
     }

--- a/tests/e2e/query_parameters.test.js
+++ b/tests/e2e/query_parameters.test.js
@@ -28,6 +28,7 @@ describe('Query parameters', () => {
         SELECT
           :p_null_1 AS col_null_1,
           :p_null_2 AS col_null_2,
+          :p_null_3 AS col_null_3,
           :p_bool AS col_bool,
           :p_int AS col_int,
           :p_double AS col_double,
@@ -41,6 +42,7 @@ describe('Query parameters', () => {
         namedParameters: {
           p_null_1: new DBSQLParameter({ value: undefined }),
           p_null_2: new DBSQLParameter({ value: null }),
+          p_null_3: new DBSQLParameter({ type: DBSQLParameterType.VOID, value: 'Test' }),
           p_bool: new DBSQLParameter({ value: true }),
           p_int: new DBSQLParameter({ value: 1234 }),
           p_double: new DBSQLParameter({ value: 3.14 }),
@@ -57,6 +59,7 @@ describe('Query parameters', () => {
       {
         col_null_1: null,
         col_null_2: null,
+        col_null_3: null,
         col_bool: true,
         col_int: 1234,
         col_double: 3.14,
@@ -121,6 +124,7 @@ describe('Query parameters', () => {
         SELECT
           ? AS col_null_1,
           ? AS col_null_2,
+          ? AS col_null_3,
           ? AS col_bool,
           ? AS col_int,
           ? AS col_double,
@@ -134,6 +138,7 @@ describe('Query parameters', () => {
         ordinalParameters: [
           new DBSQLParameter({ value: undefined }),
           new DBSQLParameter({ value: null }),
+          new DBSQLParameter({ type: DBSQLParameterType.VOID, value: 'Test' }),
           new DBSQLParameter({ value: true }),
           new DBSQLParameter({ value: 1234 }),
           new DBSQLParameter({ value: 3.14 }),
@@ -150,6 +155,7 @@ describe('Query parameters', () => {
       {
         col_null_1: null,
         col_null_2: null,
+        col_null_3: null,
         col_bool: true,
         col_int: 1234,
         col_double: 3.14,

--- a/tests/e2e/query_parameters.test.js
+++ b/tests/e2e/query_parameters.test.js
@@ -26,6 +26,8 @@ describe('Query parameters', () => {
     const operation = await session.executeStatement(
       `
         SELECT
+          :p_null_1 AS col_null_1,
+          :p_null_2 AS col_null_2,
           :p_bool AS col_bool,
           :p_int AS col_int,
           :p_double AS col_double,
@@ -37,6 +39,8 @@ describe('Query parameters', () => {
       `,
       {
         namedParameters: {
+          p_null_1: new DBSQLParameter({ value: undefined }),
+          p_null_2: new DBSQLParameter({ value: null }),
           p_bool: new DBSQLParameter({ value: true }),
           p_int: new DBSQLParameter({ value: 1234 }),
           p_double: new DBSQLParameter({ value: 3.14 }),
@@ -51,6 +55,8 @@ describe('Query parameters', () => {
     const result = await operation.fetchAll();
     expect(result).to.deep.equal([
       {
+        col_null_1: null,
+        col_null_2: null,
         col_bool: true,
         col_int: 1234,
         col_double: 3.14,
@@ -68,6 +74,8 @@ describe('Query parameters', () => {
     const operation = await session.executeStatement(
       `
         SELECT
+          :p_null_1 AS col_null_1,
+          :p_null_2 AS col_null_2,
           :p_bool AS col_bool,
           :p_int AS col_int,
           :p_double AS col_double,
@@ -78,6 +86,8 @@ describe('Query parameters', () => {
       `,
       {
         namedParameters: {
+          p_null_1: undefined,
+          p_null_2: null,
           p_bool: true,
           p_int: 1234,
           p_double: 3.14,
@@ -91,6 +101,8 @@ describe('Query parameters', () => {
     const result = await operation.fetchAll();
     expect(result).to.deep.equal([
       {
+        col_null_1: null,
+        col_null_2: null,
         col_bool: true,
         col_int: 1234,
         col_double: 3.14,
@@ -107,6 +119,8 @@ describe('Query parameters', () => {
     const operation = await session.executeStatement(
       `
         SELECT
+          ? AS col_null_1,
+          ? AS col_null_2,
           ? AS col_bool,
           ? AS col_int,
           ? AS col_double,
@@ -117,21 +131,25 @@ describe('Query parameters', () => {
           ? AS col_str
       `,
       {
-        namedParameters: {
-          p_bool: new DBSQLParameter({ value: true }),
-          p_int: new DBSQLParameter({ value: 1234 }),
-          p_double: new DBSQLParameter({ value: 3.14 }),
-          p_bigint_1: new DBSQLParameter({ value: BigInt(1234) }),
-          p_bigint_2: new DBSQLParameter({ value: new Int64(1234) }),
-          p_date: new DBSQLParameter({ value: new Date('2023-09-06T03:14:27.843Z'), type: DBSQLParameterType.DATE }),
-          p_timestamp: new DBSQLParameter({ value: new Date('2023-09-06T03:14:27.843Z') }),
-          p_str: new DBSQLParameter({ value: 'Hello' }),
-        },
+        ordinalParameters: [
+          new DBSQLParameter({ value: undefined }),
+          new DBSQLParameter({ value: null }),
+          new DBSQLParameter({ value: true }),
+          new DBSQLParameter({ value: 1234 }),
+          new DBSQLParameter({ value: 3.14 }),
+          new DBSQLParameter({ value: BigInt(1234) }),
+          new DBSQLParameter({ value: new Int64(1234) }),
+          new DBSQLParameter({ value: new Date('2023-09-06T03:14:27.843Z'), type: DBSQLParameterType.DATE }),
+          new DBSQLParameter({ value: new Date('2023-09-06T03:14:27.843Z') }),
+          new DBSQLParameter({ value: 'Hello' }),
+        ],
       },
     );
     const result = await operation.fetchAll();
     expect(result).to.deep.equal([
       {
+        col_null_1: null,
+        col_null_2: null,
         col_bool: true,
         col_int: 1234,
         col_double: 3.14,
@@ -149,6 +167,8 @@ describe('Query parameters', () => {
     const operation = await session.executeStatement(
       `
         SELECT
+          ? AS col_null_1,
+          ? AS col_null_2,
           ? AS col_bool,
           ? AS col_int,
           ? AS col_double,
@@ -159,6 +179,8 @@ describe('Query parameters', () => {
       `,
       {
         ordinalParameters: [
+          undefined,
+          null,
           true,
           1234,
           3.14,
@@ -172,6 +194,8 @@ describe('Query parameters', () => {
     const result = await operation.fetchAll();
     expect(result).to.deep.equal([
       {
+        col_null_1: null,
+        col_null_2: null,
         col_bool: true,
         col_int: 1234,
         col_double: 3.14,


### PR DESCRIPTION
This PR adds support for inferring NULL values passed to DBR as parameters. Both `null` and `undefined` could be used as `NULL` values. 

Related to databricks/databricks-sql-python#233