### PR TITLE
DBSQLOperation Refactoring (3 of 3)

### DIFF
--- a/lib/DBSQLOperation/index.ts
+++ b/lib/DBSQLOperation/index.ts
@@ -16,10 +16,10 @@ import {
   TOperationState,
 } from '../../thrift/TCLIService_types';
 import Status from '../dto/Status';
-import FetchResultsHelper from './FetchResultsHelper';
 import { LogLevel } from '../contracts/IDBSQLLogger';
 import OperationStateError, { OperationStateErrorCode } from '../errors/OperationStateError';
 import IOperationResult from '../result/IOperationResult';
+import RowSetProvider from '../result/RowSetProvider';
 import JsonResult from '../result/JsonResult';
 import ArrowResult from '../result/ArrowResult';
 import CloudFetchResult from '../result/CloudFetchResult';
@@ -50,7 +50,7 @@ export default class DBSQLOperation implements IOperation {
 
   public onClose?: () => void;
 
-  private readonly _data: FetchResultsHelper;
+  private readonly _data: RowSetProvider;
 
   private readonly closeOperation?: TCloseOperationResp;
 
@@ -82,7 +82,7 @@ export default class DBSQLOperation implements IOperation {
     }
 
     this.metadata = directResults?.resultSetMetadata;
-    this._data = new FetchResultsHelper(
+    this._data = new RowSetProvider(
       this.context,
       this.operationHandle,
       [directResults?.resultSet],
@@ -137,7 +137,7 @@ export default class DBSQLOperation implements IOperation {
 
     const [resultHandler, data] = await Promise.all([
       this.getResultHandler(),
-      this._data.fetch(options?.maxRows || defaultMaxRows),
+      this._data.fetchNext({ limit: options?.maxRows || defaultMaxRows }),
     ]);
 
     await this.failIfClosed();

--- a/lib/result/ArrowResultHandler.ts
+++ b/lib/result/ArrowResultHandler.ts
@@ -42,19 +42,16 @@ export default class ArrowResultHandler implements IResultsProvider<Array<any>> 
     this.arrowSchema = arrowSchema;
   }
 
-  async hasMore() {
+  public async hasMore() {
     return this.source.hasMore();
   }
 
-  async fetchNext(options: ResultsProviderFetchNextOptions) {
-    const data = await this.source.fetchNext(options);
-    return this.getValue(data ? [data] : []);
-  }
-
-  async getValue(data?: Array<TRowSet>) {
-    if (this.schema.length === 0 || !this.arrowSchema || !data) {
+  public async fetchNext(options: ResultsProviderFetchNextOptions) {
+    if (this.schema.length === 0 || !this.arrowSchema) {
       return [];
     }
+
+    const data = await this.source.fetchNext(options);
 
     const batches = await this.getBatches(data);
     if (batches.length === 0) {
@@ -65,15 +62,13 @@ export default class ArrowResultHandler implements IResultsProvider<Array<any>> 
     return this.getRows(table.schema, table.toArray());
   }
 
-  protected async getBatches(data: Array<TRowSet>): Promise<Array<Buffer>> {
+  protected async getBatches(rowSet?: TRowSet): Promise<Array<Buffer>> {
     const result: Array<Buffer> = [];
 
-    data.forEach((rowSet) => {
-      rowSet.arrowBatches?.forEach((arrowBatch) => {
-        if (arrowBatch.batch) {
-          result.push(arrowBatch.batch);
-        }
-      });
+    rowSet?.arrowBatches?.forEach((arrowBatch) => {
+      if (arrowBatch.batch) {
+        result.push(arrowBatch.batch);
+      }
     });
 
     return result;

--- a/lib/result/CloudFetchResultHandler.ts
+++ b/lib/result/CloudFetchResultHandler.ts
@@ -17,18 +17,16 @@ export default class CloudFetchResultHandler extends ArrowResultHandler {
     super(context, source, schema, Buffer.alloc(0));
   }
 
-  async hasMore() {
+  public async hasMore() {
     if (this.pendingLinks.length > 0 || this.downloadedBatches.length > 0) {
       return true;
     }
     return super.hasMore();
   }
 
-  protected async getBatches(data: Array<TRowSet>): Promise<Array<Buffer>> {
-    data.forEach((item) => {
-      item.resultLinks?.forEach((link) => {
-        this.pendingLinks.push(link);
-      });
+  protected async getBatches(data?: TRowSet): Promise<Array<Buffer>> {
+    data?.resultLinks?.forEach((link) => {
+      this.pendingLinks.push(link);
     });
 
     if (this.downloadedBatches.length === 0) {

--- a/lib/result/CloudFetchResultHandler.ts
+++ b/lib/result/CloudFetchResultHandler.ts
@@ -2,22 +2,26 @@ import { Buffer } from 'buffer';
 import fetch, { RequestInfo, RequestInit } from 'node-fetch';
 import { TRowSet, TSparkArrowResultLink, TTableSchema } from '../../thrift/TCLIService_types';
 import IClientContext from '../contracts/IClientContext';
-import ArrowResult from './ArrowResult';
+import IResultsProvider from './IResultsProvider';
+import ArrowResultHandler from './ArrowResultHandler';
 import globalConfig from '../globalConfig';
 
-export default class CloudFetchResult extends ArrowResult {
+export default class CloudFetchResultHandler extends ArrowResultHandler {
   private pendingLinks: Array<TSparkArrowResultLink> = [];
 
   private downloadedBatches: Array<Buffer> = [];
 
-  constructor(context: IClientContext, schema?: TTableSchema) {
+  constructor(context: IClientContext, source: IResultsProvider<TRowSet | undefined>, schema?: TTableSchema) {
     // Arrow schema returned in metadata is not needed for CloudFetch results:
     // each batch already contains schema and could be decoded as is
-    super(context, schema, Buffer.alloc(0));
+    super(context, source, schema, Buffer.alloc(0));
   }
 
-  async hasPendingData() {
-    return this.pendingLinks.length > 0 || this.downloadedBatches.length > 0;
+  async hasMore() {
+    if (this.pendingLinks.length > 0 || this.downloadedBatches.length > 0) {
+      return true;
+    }
+    return super.hasMore();
   }
 
   protected async getBatches(data: Array<TRowSet>): Promise<Array<Buffer>> {

--- a/lib/result/IOperationResult.ts
+++ b/lib/result/IOperationResult.ts
@@ -1,7 +1,0 @@
-import { TRowSet } from '../../thrift/TCLIService_types';
-
-export default interface IOperationResult {
-  getValue(data?: Array<TRowSet>): Promise<any>;
-
-  hasPendingData(): Promise<boolean>;
-}

--- a/lib/result/IResultsProvider.ts
+++ b/lib/result/IResultsProvider.ts
@@ -1,0 +1,9 @@
+export interface ResultsProviderFetchNextOptions {
+  limit: number;
+}
+
+export default interface IResultsProvider<T> {
+  fetchNext(options: ResultsProviderFetchNextOptions): Promise<T>;
+
+  hasMore(): Promise<boolean>;
+}

--- a/lib/result/JsonResultHandler.ts
+++ b/lib/result/JsonResultHandler.ts
@@ -17,26 +17,22 @@ export default class JsonResultHandler implements IResultsProvider<Array<any>> {
     this.schema = getSchemaColumns(schema);
   }
 
-  async hasMore() {
+  public async hasMore() {
     return this.source.hasMore();
   }
 
-  async fetchNext(options: ResultsProviderFetchNextOptions) {
-    const data = await this.source.fetchNext(options);
-    return this.getValue(data ? [data] : []);
-  }
-
-  async getValue(data?: Array<TRowSet>): Promise<Array<object>> {
-    if (this.schema.length === 0 || !data) {
+  public async fetchNext(options: ResultsProviderFetchNextOptions) {
+    if (this.schema.length === 0) {
       return [];
     }
 
-    return data.reduce((result: Array<any>, rowSet: TRowSet) => {
-      const columns = rowSet.columns || [];
-      const rows = this.getRows(columns, this.schema);
+    const data = await this.source.fetchNext(options);
+    if (!data) {
+      return [];
+    }
 
-      return result.concat(rows);
-    }, []);
+    const columns = data.columns || [];
+    return this.getRows(columns, this.schema);
   }
 
   private getRows(columns: Array<TColumn>, descriptors: Array<TColumnDesc>): Array<any> {

--- a/tests/e2e/arrow.test.js
+++ b/tests/e2e/arrow.test.js
@@ -2,7 +2,7 @@ const { expect } = require('chai');
 const config = require('./utils/config');
 const logger = require('./utils/logger')(config.logger);
 const { DBSQLClient } = require('../..');
-const ArrowResult = require('../../dist/result/ArrowResult').default;
+const ArrowResultHandler = require('../../dist/result/ArrowResultHandler').default;
 const globalConfig = require('../../dist/globalConfig').default;
 
 const fixtures = require('../fixtures/compatibility');
@@ -76,7 +76,7 @@ describe('Arrow support', () => {
       expect(result).to.deep.equal(expectedColumn);
 
       const resultHandler = await operation.getResultHandler();
-      expect(resultHandler).to.be.not.instanceof(ArrowResult);
+      expect(resultHandler).to.be.not.instanceof(ArrowResultHandler);
 
       await operation.close();
     }),
@@ -93,7 +93,7 @@ describe('Arrow support', () => {
       expect(fixArrowResult(result)).to.deep.equal(expectedArrow);
 
       const resultHandler = await operation.getResultHandler();
-      expect(resultHandler).to.be.instanceof(ArrowResult);
+      expect(resultHandler).to.be.instanceof(ArrowResultHandler);
 
       await operation.close();
     }),
@@ -110,7 +110,7 @@ describe('Arrow support', () => {
       expect(fixArrowResult(result)).to.deep.equal(expectedArrowNativeTypes);
 
       const resultHandler = await operation.getResultHandler();
-      expect(resultHandler).to.be.instanceof(ArrowResult);
+      expect(resultHandler).to.be.instanceof(ArrowResultHandler);
 
       await operation.close();
     }),
@@ -130,9 +130,9 @@ describe('Arrow support', () => {
 
     // We use some internals here to check that server returned response with multiple batches
     const resultHandler = await operation.getResultHandler();
-    expect(resultHandler).to.be.instanceof(ArrowResult);
+    expect(resultHandler).to.be.instanceof(ArrowResultHandler);
 
-    const rawData = await operation._data.fetch(rowsCount);
+    const rawData = await operation._data.fetchNext({ limit: rowsCount });
     // We don't know exact count of batches returned, it depends on server's configuration,
     // but with much enough rows there should be more than one result batch
     expect(rawData.arrowBatches?.length).to.be.gt(1);

--- a/tests/e2e/cloudfetch.test.js
+++ b/tests/e2e/cloudfetch.test.js
@@ -3,7 +3,7 @@ const sinon = require('sinon');
 const config = require('./utils/config');
 const logger = require('./utils/logger')(config.logger);
 const { DBSQLClient } = require('../..');
-const CloudFetchResult = require('../../dist/result/CloudFetchResult').default;
+const CloudFetchResultHandler = require('../../dist/result/CloudFetchResultHandler').default;
 const globalConfig = require('../../dist/globalConfig').default;
 
 const openSession = async () => {
@@ -57,24 +57,24 @@ describe('CloudFetch', () => {
 
     // Check if we're actually getting data via CloudFetch
     const resultHandler = await operation.getResultHandler();
-    expect(resultHandler).to.be.instanceOf(CloudFetchResult);
+    expect(resultHandler).to.be.instanceOf(CloudFetchResultHandler);
 
     // Fetch first chunk and check if result handler behaves properly.
     // With the count of rows we queried, there should be at least one row set,
     // containing 8 result links. After fetching the first chunk,
     // result handler should download 5 of them and schedule the rest
-    expect(await resultHandler.hasPendingData()).to.be.false;
+    expect(await resultHandler.hasMore()).to.be.false;
     expect(resultHandler.pendingLinks.length).to.be.equal(0);
     expect(resultHandler.downloadedBatches.length).to.be.equal(0);
 
-    sinon.spy(operation._data, 'fetch');
+    sinon.spy(operation._data, 'fetchNext');
 
     const chunk = await operation.fetchChunk({ maxRows: 100000 });
     // Count links returned from server
-    const resultSet = await operation._data.fetch.firstCall.returnValue;
+    const resultSet = await operation._data.fetchNext.firstCall.returnValue;
     const resultLinksCount = resultSet?.resultLinks?.length ?? 0;
 
-    expect(await resultHandler.hasPendingData()).to.be.true;
+    expect(await resultHandler.hasMore()).to.be.true;
     // expected batches minus first 5 already fetched
     expect(resultHandler.pendingLinks.length).to.be.equal(
       resultLinksCount - globalConfig.cloudFetchConcurrentDownloads,

--- a/tests/unit/DBSQLOperation.test.js
+++ b/tests/unit/DBSQLOperation.test.js
@@ -6,9 +6,9 @@ const DBSQLOperation = require('../../dist/DBSQLOperation').default;
 const StatusError = require('../../dist/errors/StatusError').default;
 const OperationStateError = require('../../dist/errors/OperationStateError').default;
 const HiveDriverError = require('../../dist/errors/HiveDriverError').default;
-const JsonResult = require('../../dist/result/JsonResult').default;
-const ArrowResult = require('../../dist/result/ArrowResult').default;
-const CloudFetchResult = require('../../dist/result/CloudFetchResult').default;
+const JsonResultHandler = require('../../dist/result/JsonResultHandler').default;
+const ArrowResultHandler = require('../../dist/result/ArrowResultHandler').default;
+const CloudFetchResultHandler = require('../../dist/result/CloudFetchResultHandler').default;
 
 class OperationHandleMock {
   constructor(hasResultSet = true) {
@@ -885,7 +885,7 @@ describe('DBSQLOperation', () => {
         const operation = new DBSQLOperation({ handle, context });
         const resultHandler = await operation.getResultHandler();
         expect(context.driver.getResultSetMetadata.called).to.be.true;
-        expect(resultHandler).to.be.instanceOf(JsonResult);
+        expect(resultHandler).to.be.instanceOf(JsonResultHandler);
       }
 
       arrowHandler: {
@@ -895,7 +895,7 @@ describe('DBSQLOperation', () => {
         const operation = new DBSQLOperation({ handle, context });
         const resultHandler = await operation.getResultHandler();
         expect(context.driver.getResultSetMetadata.called).to.be.true;
-        expect(resultHandler).to.be.instanceOf(ArrowResult);
+        expect(resultHandler).to.be.instanceOf(ArrowResultHandler);
       }
 
       cloudFetchHandler: {
@@ -905,7 +905,7 @@ describe('DBSQLOperation', () => {
         const operation = new DBSQLOperation({ handle, context });
         const resultHandler = await operation.getResultHandler();
         expect(context.driver.getResultSetMetadata.called).to.be.true;
-        expect(resultHandler).to.be.instanceOf(CloudFetchResult);
+        expect(resultHandler).to.be.instanceOf(CloudFetchResultHandler);
       }
     });
   });

--- a/tests/unit/result/ArrowResultHandler.test.js
+++ b/tests/unit/result/ArrowResultHandler.test.js
@@ -88,42 +88,60 @@ const rowSetAllNulls = {
 describe('ArrowResultHandler', () => {
   it('should not buffer any data', async () => {
     const context = {};
-    const rowSetProvider = new RowSetProviderMock();
+    const rowSetProvider = new RowSetProviderMock([sampleRowSet1]);
     const result = new ArrowResultHandler(context, rowSetProvider, sampleThriftSchema, sampleArrowSchema);
-    await result.getValue([sampleRowSet1]);
+    expect(await rowSetProvider.hasMore()).to.be.true;
+    expect(await result.hasMore()).to.be.true;
+
+    await result.fetchNext({ limit: 10000 });
+    expect(await rowSetProvider.hasMore()).to.be.false;
     expect(await result.hasMore()).to.be.false;
   });
 
   it('should convert data', async () => {
     const context = {};
-    const rowSetProvider = new RowSetProviderMock();
-    const result = new ArrowResultHandler(context, rowSetProvider, sampleThriftSchema, sampleArrowSchema);
-    expect(await result.getValue([sampleRowSet1])).to.be.deep.eq([]);
-    expect(await result.getValue([sampleRowSet2])).to.be.deep.eq([]);
-    expect(await result.getValue([sampleRowSet3])).to.be.deep.eq([]);
-    expect(await result.getValue([sampleRowSet4])).to.be.deep.eq([{ 1: 1 }]);
+
+    case1: {
+      const rowSetProvider = new RowSetProviderMock([sampleRowSet1]);
+      const result = new ArrowResultHandler(context, rowSetProvider, sampleThriftSchema, sampleArrowSchema);
+      expect(await result.fetchNext({ limit: 10000 })).to.be.deep.eq([]);
+    }
+    case2: {
+      const rowSetProvider = new RowSetProviderMock([sampleRowSet2]);
+      const result = new ArrowResultHandler(context, rowSetProvider, sampleThriftSchema, sampleArrowSchema);
+      expect(await result.fetchNext({ limit: 10000 })).to.be.deep.eq([]);
+    }
+    case3: {
+      const rowSetProvider = new RowSetProviderMock([sampleRowSet3]);
+      const result = new ArrowResultHandler(context, rowSetProvider, sampleThriftSchema, sampleArrowSchema);
+      expect(await result.fetchNext({ limit: 10000 })).to.be.deep.eq([]);
+    }
+    case4: {
+      const rowSetProvider = new RowSetProviderMock([sampleRowSet4]);
+      const result = new ArrowResultHandler(context, rowSetProvider, sampleThriftSchema, sampleArrowSchema);
+      expect(await result.fetchNext({ limit: 10000 })).to.be.deep.eq([{ 1: 1 }]);
+    }
   });
 
   it('should return empty array if no data to process', async () => {
     const context = {};
     const rowSetProvider = new RowSetProviderMock();
     const result = new ArrowResultHandler(context, rowSetProvider, sampleThriftSchema, sampleArrowSchema);
-    expect(await result.getValue()).to.be.deep.eq([]);
-    expect(await result.getValue([])).to.be.deep.eq([]);
+    expect(await result.fetchNext({ limit: 10000 })).to.be.deep.eq([]);
   });
 
   it('should return empty array if no schema available', async () => {
     const context = {};
-    const rowSetProvider = new RowSetProviderMock();
+    const rowSetProvider = new RowSetProviderMock([sampleRowSet4]);
     const result = new ArrowResultHandler(context, rowSetProvider);
-    expect(await result.getValue([sampleRowSet4])).to.be.deep.eq([]);
+    expect(await result.fetchNext({ limit: 10000 })).to.be.deep.eq([]);
   });
 
   it('should detect nulls', async () => {
     const context = {};
-    const rowSetProvider = new RowSetProviderMock();
+    const rowSetProvider = new RowSetProviderMock([rowSetAllNulls]);
     const result = new ArrowResultHandler(context, rowSetProvider, thriftSchemaAllNulls, arrowSchemaAllNulls);
-    expect(await result.getValue([rowSetAllNulls])).to.be.deep.eq([
+    expect(await result.fetchNext({ limit: 10000 })).to.be.deep.eq([
       {
         boolean_field: null,
 

--- a/tests/unit/result/ArrowResultHandler.test.js
+++ b/tests/unit/result/ArrowResultHandler.test.js
@@ -1,7 +1,8 @@
 const { expect } = require('chai');
 const fs = require('fs');
 const path = require('path');
-const ArrowResult = require('../../../dist/result/ArrowResult').default;
+const ArrowResultHandler = require('../../../dist/result/ArrowResultHandler').default;
+const RowSetProviderMock = require('./fixtures/RowSetProviderMock');
 
 const sampleThriftSchema = {
   columns: [
@@ -84,17 +85,19 @@ const rowSetAllNulls = {
   ],
 };
 
-describe('ArrowResult', () => {
+describe('ArrowResultHandler', () => {
   it('should not buffer any data', async () => {
     const context = {};
-    const result = new ArrowResult(context, sampleThriftSchema, sampleArrowSchema);
+    const rowSetProvider = new RowSetProviderMock();
+    const result = new ArrowResultHandler(context, rowSetProvider, sampleThriftSchema, sampleArrowSchema);
     await result.getValue([sampleRowSet1]);
-    expect(await result.hasPendingData()).to.be.false;
+    expect(await result.hasMore()).to.be.false;
   });
 
   it('should convert data', async () => {
     const context = {};
-    const result = new ArrowResult(context, sampleThriftSchema, sampleArrowSchema);
+    const rowSetProvider = new RowSetProviderMock();
+    const result = new ArrowResultHandler(context, rowSetProvider, sampleThriftSchema, sampleArrowSchema);
     expect(await result.getValue([sampleRowSet1])).to.be.deep.eq([]);
     expect(await result.getValue([sampleRowSet2])).to.be.deep.eq([]);
     expect(await result.getValue([sampleRowSet3])).to.be.deep.eq([]);
@@ -103,20 +106,23 @@ describe('ArrowResult', () => {
 
   it('should return empty array if no data to process', async () => {
     const context = {};
-    const result = new ArrowResult(context, sampleThriftSchema, sampleArrowSchema);
+    const rowSetProvider = new RowSetProviderMock();
+    const result = new ArrowResultHandler(context, rowSetProvider, sampleThriftSchema, sampleArrowSchema);
     expect(await result.getValue()).to.be.deep.eq([]);
     expect(await result.getValue([])).to.be.deep.eq([]);
   });
 
   it('should return empty array if no schema available', async () => {
     const context = {};
-    const result = new ArrowResult(context);
+    const rowSetProvider = new RowSetProviderMock();
+    const result = new ArrowResultHandler(context, rowSetProvider);
     expect(await result.getValue([sampleRowSet4])).to.be.deep.eq([]);
   });
 
   it('should detect nulls', async () => {
     const context = {};
-    const result = new ArrowResult(context, thriftSchemaAllNulls, arrowSchemaAllNulls);
+    const rowSetProvider = new RowSetProviderMock();
+    const result = new ArrowResultHandler(context, rowSetProvider, thriftSchemaAllNulls, arrowSchemaAllNulls);
     expect(await result.getValue([rowSetAllNulls])).to.be.deep.eq([
       {
         boolean_field: null,

--- a/tests/unit/result/JsonResultHandler.test.js
+++ b/tests/unit/result/JsonResultHandler.test.js
@@ -40,10 +40,14 @@ describe('JsonResultHandler', () => {
     ];
 
     const context = {};
-    const rowSetProvider = new RowSetProviderMock();
+    const rowSetProvider = new RowSetProviderMock(data);
 
     const result = new JsonResultHandler(context, rowSetProvider, schema);
-    await result.getValue(data);
+    expect(await rowSetProvider.hasMore()).to.be.true;
+    expect(await result.hasMore()).to.be.true;
+
+    await result.fetchNext({ limit: 10000 });
+    expect(await rowSetProvider.hasMore()).to.be.false;
     expect(await result.hasMore()).to.be.false;
   });
 
@@ -129,11 +133,11 @@ describe('JsonResultHandler', () => {
     ];
 
     const context = {};
-    const rowSetProvider = new RowSetProviderMock();
+    const rowSetProvider = new RowSetProviderMock(data);
 
     const result = new JsonResultHandler(context, rowSetProvider, schema);
 
-    expect(await result.getValue(data)).to.be.deep.eq([
+    expect(await result.fetchNext({ limit: 10000 })).to.be.deep.eq([
       {
         'table.str': 'a',
         'table.int64': 282578800148737,
@@ -202,11 +206,11 @@ describe('JsonResultHandler', () => {
     ];
 
     const context = {};
-    const rowSetProvider = new RowSetProviderMock();
+    const rowSetProvider = new RowSetProviderMock(data);
 
     const result = new JsonResultHandler(context, rowSetProvider, schema);
 
-    expect(await result.getValue(data)).to.be.deep.eq([
+    expect(await result.fetchNext({ limit: 10000 })).to.be.deep.eq([
       {
         'table.array': ['a', 'b'],
         'table.map': { key: 12 },
@@ -219,41 +223,6 @@ describe('JsonResultHandler', () => {
         'table.struct': { name: 'Jane', surname: 'Doe' },
         'table.union': '{1:"foo"}',
       },
-    ]);
-  });
-
-  it('should merge data items', async () => {
-    const schema = {
-      columns: [getColumnSchema('table.id', TCLIService_types.TTypeId.STRING_TYPE, 1)],
-    };
-    const data = [
-      {
-        columns: [
-          {
-            stringVal: { values: ['0', '1'] },
-          },
-        ],
-      },
-      {}, // it should also handle empty sets
-      {
-        columns: [
-          {
-            stringVal: { values: ['2', '3'] },
-          },
-        ],
-      },
-    ];
-
-    const context = {};
-    const rowSetProvider = new RowSetProviderMock();
-
-    const result = new JsonResultHandler(context, rowSetProvider, schema);
-
-    expect(await result.getValue(data)).to.be.deep.eq([
-      { 'table.id': '0' },
-      { 'table.id': '1' },
-      { 'table.id': '2' },
-      { 'table.id': '3' },
     ]);
   });
 
@@ -374,11 +343,11 @@ describe('JsonResultHandler', () => {
     ];
 
     const context = {};
-    const rowSetProvider = new RowSetProviderMock();
+    const rowSetProvider = new RowSetProviderMock(data);
 
     const result = new JsonResultHandler(context, rowSetProvider, schema);
 
-    expect(await result.getValue(data)).to.be.deep.eq([
+    expect(await result.fetchNext({ limit: 10000 })).to.be.deep.eq([
       {
         'table.str': null,
         'table.int64': null,
@@ -409,9 +378,7 @@ describe('JsonResultHandler', () => {
     const rowSetProvider = new RowSetProviderMock();
 
     const result = new JsonResultHandler(context, rowSetProvider, schema);
-
-    expect(await result.getValue()).to.be.deep.eq([]);
-    expect(await result.getValue([])).to.be.deep.eq([]);
+    expect(await result.fetchNext({ limit: 10000 })).to.be.deep.eq([]);
   });
 
   it('should return empty array if no schema available', async () => {
@@ -426,11 +393,11 @@ describe('JsonResultHandler', () => {
     ];
 
     const context = {};
-    const rowSetProvider = new RowSetProviderMock();
+    const rowSetProvider = new RowSetProviderMock(data);
 
     const result = new JsonResultHandler(context, rowSetProvider);
 
-    expect(await result.getValue(data)).to.be.deep.eq([]);
+    expect(await result.fetchNext({ limit: 10000 })).to.be.deep.eq([]);
   });
 
   it('should return raw data if types are not specified', async () => {
@@ -462,11 +429,11 @@ describe('JsonResultHandler', () => {
     ];
 
     const context = {};
-    const rowSetProvider = new RowSetProviderMock();
+    const rowSetProvider = new RowSetProviderMock(data);
 
     const result = new JsonResultHandler(context, rowSetProvider, schema);
 
-    expect(await result.getValue(data)).to.be.deep.eq([
+    expect(await result.fetchNext({ limit: 10000 })).to.be.deep.eq([
       {
         'table.array': '["a", "b"]',
         'table.map': '{ "key": 12 }',

--- a/tests/unit/result/JsonResultHandler.test.js
+++ b/tests/unit/result/JsonResultHandler.test.js
@@ -1,7 +1,8 @@
 const { expect } = require('chai');
-const JsonResult = require('../../../dist/result/JsonResult').default;
+const JsonResultHandler = require('../../../dist/result/JsonResultHandler').default;
 const { TCLIService_types } = require('../../../').thrift;
 const Int64 = require('node-int64');
+const RowSetProviderMock = require('./fixtures/RowSetProviderMock');
 
 const getColumnSchema = (columnName, type, position) => {
   if (type === undefined) {
@@ -27,7 +28,7 @@ const getColumnSchema = (columnName, type, position) => {
   };
 };
 
-describe('JsonResult', () => {
+describe('JsonResultHandler', () => {
   it('should not buffer any data', async () => {
     const schema = {
       columns: [getColumnSchema('table.id', TCLIService_types.TTypeId.STRING_TYPE, 1)],
@@ -39,10 +40,11 @@ describe('JsonResult', () => {
     ];
 
     const context = {};
+    const rowSetProvider = new RowSetProviderMock();
 
-    const result = new JsonResult(context, schema);
+    const result = new JsonResultHandler(context, rowSetProvider, schema);
     await result.getValue(data);
-    expect(await result.hasPendingData()).to.be.false;
+    expect(await result.hasMore()).to.be.false;
   });
 
   it('should convert schema with primitive types to json', async () => {
@@ -127,8 +129,9 @@ describe('JsonResult', () => {
     ];
 
     const context = {};
+    const rowSetProvider = new RowSetProviderMock();
 
-    const result = new JsonResult(context, schema);
+    const result = new JsonResultHandler(context, rowSetProvider, schema);
 
     expect(await result.getValue(data)).to.be.deep.eq([
       {
@@ -199,8 +202,9 @@ describe('JsonResult', () => {
     ];
 
     const context = {};
+    const rowSetProvider = new RowSetProviderMock();
 
-    const result = new JsonResult(context, schema);
+    const result = new JsonResultHandler(context, rowSetProvider, schema);
 
     expect(await result.getValue(data)).to.be.deep.eq([
       {
@@ -241,8 +245,9 @@ describe('JsonResult', () => {
     ];
 
     const context = {};
+    const rowSetProvider = new RowSetProviderMock();
 
-    const result = new JsonResult(context, schema);
+    const result = new JsonResultHandler(context, rowSetProvider, schema);
 
     expect(await result.getValue(data)).to.be.deep.eq([
       { 'table.id': '0' },
@@ -254,8 +259,9 @@ describe('JsonResult', () => {
 
   it('should detect nulls', () => {
     const context = {};
+    const rowSetProvider = new RowSetProviderMock();
 
-    const result = new JsonResult(context, null);
+    const result = new JsonResultHandler(context, rowSetProvider, null);
     const buf = Buffer.from([0x55, 0xaa, 0xc3]);
 
     [
@@ -368,8 +374,9 @@ describe('JsonResult', () => {
     ];
 
     const context = {};
+    const rowSetProvider = new RowSetProviderMock();
 
-    const result = new JsonResult(context, schema);
+    const result = new JsonResultHandler(context, rowSetProvider, schema);
 
     expect(await result.getValue(data)).to.be.deep.eq([
       {
@@ -399,8 +406,9 @@ describe('JsonResult', () => {
     };
 
     const context = {};
+    const rowSetProvider = new RowSetProviderMock();
 
-    const result = new JsonResult(context, schema);
+    const result = new JsonResultHandler(context, rowSetProvider, schema);
 
     expect(await result.getValue()).to.be.deep.eq([]);
     expect(await result.getValue([])).to.be.deep.eq([]);
@@ -418,8 +426,9 @@ describe('JsonResult', () => {
     ];
 
     const context = {};
+    const rowSetProvider = new RowSetProviderMock();
 
-    const result = new JsonResult(context);
+    const result = new JsonResultHandler(context, rowSetProvider);
 
     expect(await result.getValue(data)).to.be.deep.eq([]);
   });
@@ -453,8 +462,9 @@ describe('JsonResult', () => {
     ];
 
     const context = {};
+    const rowSetProvider = new RowSetProviderMock();
 
-    const result = new JsonResult(context, schema);
+    const result = new JsonResultHandler(context, rowSetProvider, schema);
 
     expect(await result.getValue(data)).to.be.deep.eq([
       {

--- a/tests/unit/result/compatibility.test.js
+++ b/tests/unit/result/compatibility.test.js
@@ -1,30 +1,35 @@
 const { expect } = require('chai');
-const ArrowResult = require('../../../dist/result/ArrowResult').default;
-const JsonResult = require('../../../dist/result/JsonResult').default;
+const ArrowResultHandler = require('../../../dist/result/ArrowResultHandler').default;
+const JsonResultHandler = require('../../../dist/result/JsonResultHandler').default;
 
 const { fixArrowResult } = require('../../fixtures/compatibility');
 const fixtureColumn = require('../../fixtures/compatibility/column');
 const fixtureArrow = require('../../fixtures/compatibility/arrow');
 const fixtureArrowNT = require('../../fixtures/compatibility/arrow_native_types');
 
+const RowSetProviderMock = require('./fixtures/RowSetProviderMock');
+
 describe('Result handlers compatibility tests', () => {
   it('colum-based data', async () => {
     const context = {};
-    const result = new JsonResult(context, fixtureColumn.schema);
+    const rowSetProvider = new RowSetProviderMock();
+    const result = new JsonResultHandler(context, rowSetProvider, fixtureColumn.schema);
     const rows = await result.getValue(fixtureColumn.rowSets);
     expect(rows).to.deep.equal(fixtureColumn.expected);
   });
 
   it('arrow-based data without native types', async () => {
     const context = {};
-    const result = new ArrowResult(context, fixtureArrow.schema, fixtureArrow.arrowSchema);
+    const rowSetProvider = new RowSetProviderMock();
+    const result = new ArrowResultHandler(context, rowSetProvider, fixtureArrow.schema, fixtureArrow.arrowSchema);
     const rows = await result.getValue(fixtureArrow.rowSets);
     expect(fixArrowResult(rows)).to.deep.equal(fixtureArrow.expected);
   });
 
   it('arrow-based data with native types', async () => {
     const context = {};
-    const result = new ArrowResult(context, fixtureArrowNT.schema, fixtureArrowNT.arrowSchema);
+    const rowSetProvider = new RowSetProviderMock();
+    const result = new ArrowResultHandler(context, rowSetProvider, fixtureArrowNT.schema, fixtureArrowNT.arrowSchema);
     const rows = await result.getValue(fixtureArrowNT.rowSets);
     expect(fixArrowResult(rows)).to.deep.equal(fixtureArrowNT.expected);
   });

--- a/tests/unit/result/compatibility.test.js
+++ b/tests/unit/result/compatibility.test.js
@@ -12,25 +12,25 @@ const RowSetProviderMock = require('./fixtures/RowSetProviderMock');
 describe('Result handlers compatibility tests', () => {
   it('colum-based data', async () => {
     const context = {};
-    const rowSetProvider = new RowSetProviderMock();
+    const rowSetProvider = new RowSetProviderMock(fixtureColumn.rowSets);
     const result = new JsonResultHandler(context, rowSetProvider, fixtureColumn.schema);
-    const rows = await result.getValue(fixtureColumn.rowSets);
+    const rows = await result.fetchNext({ limit: 10000 });
     expect(rows).to.deep.equal(fixtureColumn.expected);
   });
 
   it('arrow-based data without native types', async () => {
     const context = {};
-    const rowSetProvider = new RowSetProviderMock();
+    const rowSetProvider = new RowSetProviderMock(fixtureArrow.rowSets);
     const result = new ArrowResultHandler(context, rowSetProvider, fixtureArrow.schema, fixtureArrow.arrowSchema);
-    const rows = await result.getValue(fixtureArrow.rowSets);
+    const rows = await result.fetchNext({ limit: 10000 });
     expect(fixArrowResult(rows)).to.deep.equal(fixtureArrow.expected);
   });
 
   it('arrow-based data with native types', async () => {
     const context = {};
-    const rowSetProvider = new RowSetProviderMock();
+    const rowSetProvider = new RowSetProviderMock(fixtureArrowNT.rowSets);
     const result = new ArrowResultHandler(context, rowSetProvider, fixtureArrowNT.schema, fixtureArrowNT.arrowSchema);
-    const rows = await result.getValue(fixtureArrowNT.rowSets);
+    const rows = await result.fetchNext({ limit: 10000 });
     expect(fixArrowResult(rows)).to.deep.equal(fixtureArrowNT.expected);
   });
 });

--- a/tests/unit/result/fixtures/RowSetProviderMock.js
+++ b/tests/unit/result/fixtures/RowSetProviderMock.js
@@ -1,10 +1,14 @@
 class RowSetProviderMock {
+  constructor(rowSets) {
+    this.rowSets = Array.isArray(rowSets) ? [...rowSets] : [];
+  }
+
   async hasMore() {
-    return false;
+    return this.rowSets.length > 0;
   }
 
   async fetchNext() {
-    return undefined;
+    return this.rowSets.shift();
   }
 }
 

--- a/tests/unit/result/fixtures/RowSetProviderMock.js
+++ b/tests/unit/result/fixtures/RowSetProviderMock.js
@@ -1,0 +1,11 @@
+class RowSetProviderMock {
+  async hasMore() {
+    return false;
+  }
+
+  async fetchNext() {
+    return undefined;
+  }
+}
+
+module.exports = RowSetProviderMock;


### PR DESCRIPTION
Continuation of databricks/databricks-sql-nodejs#163 and databricks/databricks-sql-nodejs#185

Modify `FetchResultsHelper` and result handlers so they have unified interface and allow chaining. The idea is to form a sort of pipeline that will fetch operation results and then process it on each step. Currently it's just fetching and preparing (converting to array of rows), but later we'll add an additional step to ensure that chunk size matches `maxRows`, or steps that may convert data to different representation (or return raw data)