### PR TITLE
Make default logger singleton

### DIFF
--- a/lib/DBSQLClient.ts
+++ b/lib/DBSQLClient.ts
@@ -44,6 +44,8 @@ function getInitialNamespaceOptions(catalogName?: string, schemaName?: string) {
 }
 
 export default class DBSQLClient extends EventEmitter implements IDBSQLClient, IClientContext {
+  private static defaultLogger?: IDBSQLLogger;
+
   private connectionProvider?: IConnectionProvider;
 
   private authProvider?: IAuthentication;
@@ -60,9 +62,16 @@ export default class DBSQLClient extends EventEmitter implements IDBSQLClient, I
 
   private sessions = new CloseableCollection<DBSQLSession>();
 
+  private static getDefaultLogger(): IDBSQLLogger {
+    if (!this.defaultLogger) {
+      this.defaultLogger = new DBSQLLogger();
+    }
+    return this.defaultLogger;
+  }
+
   constructor(options?: ClientOptions) {
     super();
-    this.logger = options?.logger || new DBSQLLogger();
+    this.logger = options?.logger ?? DBSQLClient.getDefaultLogger();
     this.logger.log(LogLevel.info, 'Created DBSQLClient');
   }
 


### PR DESCRIPTION
Fixes databricks/databricks-sql-nodejs#196

When no logger passed to `DBSQLClient`, the default one is created, a new instance per each client. Even though that default logger only prints to console, it still adds some error listeners to process object. And, as reported in databricks/databricks-sql-nodejs#196, if many `DBSQLClient`s created, there will be too many error listeners attached to process. Another possible issue is that since there are no destructors in JS, we cannot properly cleanup logger when client is no longer needed, and we have to rely on GC.

The proposed solution is to use a single default logger instance for all `DBSQLClient` instances. The default logger will be created on demand, so if user doesn't need it - they can pass their own logger to every `DBSQLClient` so default one will never be created.