### PR TITLE
Allow configuration overrides in the connection options

### DIFF
--- a/lib/DBSQLClient.ts
+++ b/lib/DBSQLClient.ts
@@ -81,14 +81,12 @@ export default class DBSQLClient extends EventEmitter implements IDBSQLClient, I
   private getConnectionOptions(options: ConnectionOptions): IConnectionOptions {
     return {
       ...options,
-      host: options.host,
       port: options.port || 443,
       path: prependSlash(options.path || ''),
       https: true,
-      socketTimeout: options.socketTimeout,
-      proxy: options.proxy,
       headers: {
         'User-Agent': buildUserAgentString(options.clientId),
+        ...(options.headers || {})
       },
     };
   }

--- a/lib/connection/connections/HttpConnection.ts
+++ b/lib/connection/connections/HttpConnection.ts
@@ -61,7 +61,7 @@ export default class HttpConnection implements IConnectionProvider {
     const httpsAgentOptions: https.AgentOptions = {
       ...this.getAgentDefaultOptions(),
       minVersion: 'TLSv1.2',
-      rejectUnauthorized: false,
+      rejectUnauthorized: !!this.options.rejectUnauthorized,
       ca: this.options.ca,
       cert: this.options.cert,
       key: this.options.key,

--- a/lib/connection/contracts/IConnectionOptions.ts
+++ b/lib/connection/contracts/IConnectionOptions.ts
@@ -22,4 +22,5 @@ export default interface IConnectionOptions {
   ca?: Buffer | string;
   cert?: Buffer | string;
   key?: Buffer | string;
+  rejectUnauthorized?: boolean;
 }

--- a/lib/contracts/IDBSQLClient.ts
+++ b/lib/contracts/IDBSQLClient.ts
@@ -1,11 +1,14 @@
 import IDBSQLLogger from './IDBSQLLogger';
 import IDBSQLSession from './IDBSQLSession';
 import IAuthentication from '../connection/contracts/IAuthentication';
-import { ProxyOptions } from '../connection/contracts/IConnectionOptions';
+import IConnectionOptions, { ProxyOptions } from '../connection/contracts/IConnectionOptions';
 import OAuthPersistence from '../connection/auth/DatabricksOAuth/OAuthPersistence';
+import IConnectionProvider from '../connection/contracts/IConnectionProvider';
 
 export interface ClientOptions {
   logger?: IDBSQLLogger;
+
+  connectionProvider: new (o: IConnectionOptions) => IConnectionProvider;
 }
 
 type AuthOptions =
@@ -26,13 +29,8 @@ type AuthOptions =
     };
 
 export type ConnectionOptions = {
-  host: string;
-  port?: number;
-  path: string;
   clientId?: string;
-  socketTimeout?: number;
-  proxy?: ProxyOptions;
-} & AuthOptions;
+} & AuthOptions & IConnectionOptions;
 
 export interface OpenSessionRequest {
   initialCatalog?: string;


### PR DESCRIPTION
In the case that the user has extensions to the underlying HttpConnection instead of relying on supporting all use cases and features the consumer can simply provide a new subclass of IConnectionProvider (or subclass the existing HttpConnection) that will be used to generate new Thrift connections.

Summary of changes:
- Added an override property to the `ClientOptions` passed to the `DBSQLClient` to allow providing a new implementation of `IConnectionProvider`. This allows consumers to subclass `HttpConnection` and for the injected dependency to be used by the client to generate thrift connections. Specifically we have customers who have unique network configurations that we'd like to be able to customize the `http.Agent` implementation for. Extending `HttpConnection` to provide a new agent would be the best way for us to do that.
- Forward all options through the `getConnectionOptions` method. This will set any that are not present but also allows for unique TLS options to be used by any `IConnectionProvider` if they are needed.
- Add `rejectUnauthorized` as a possible option on the connection when using https.
- Make the `ConnectionOptions` implement `IConnectionOptions`
- Mocha recommends not using arrow functions as they capture `this` at the declaration site rather than using the runtime `this`. Mocha relies on that context and recommends not using arrow functions: https://mochajs.org/#arrow-functions
