### PR TITLE
Performance fixes

### DIFF
--- a/lib/DBSQLOperation/index.ts
+++ b/lib/DBSQLOperation/index.ts
@@ -147,6 +147,24 @@ export default class DBSQLOperation implements IOperation {
     const resultHandler = await this.getResultHandler();
     await this.failIfClosed();
 
+    // All the library code is Promise-based, however, since Promises are microtasks,
+    // enqueueing a lot of promises may block macrotasks execution for a while.
+    // Usually, there are no much microtasks scheduled, however, when fetching query
+    // results (especially CloudFetch ones) it's quite easy to block event loop for
+    // long enough to break a lot of things. For example, with CloudFetch, after first
+    // set of files are downloaded and being processed immediately one by one, event
+    // loop easily gets blocked for enough time to break connection pool. `http.Agent`
+    // stops receiving socket events, and marks all sockets invalid on the next attempt
+    // to use them. See these similar issues that helped to debug this particular case -
+    // https://github.com/nodejs/node/issues/47130 and https://github.com/node-fetch/node-fetch/issues/1735
+    // This simple fix allows to clean up a microtasks queue and allow Node to process
+    // macrotasks as well, allowing the normal operation of other code. Also, this
+    // fix is added to `fetchChunk` method because, unlike other methods, `fetchChunk` is
+    // a potential source of issues described above
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+
     const result = resultHandler.fetchNext({
       limit: options?.maxRows || defaultMaxRows,
       disableBuffering: options?.disableBuffering,

--- a/lib/connection/connections/HttpConnection.ts
+++ b/lib/connection/connections/HttpConnection.ts
@@ -48,9 +48,12 @@ export default class HttpConnection implements IConnectionProvider {
 
   private getAgentDefaultOptions(): http.AgentOptions {
     const clientConfig = this.context.getConfig();
+
+    const cloudFetchExtraSocketsCount = clientConfig.useCloudFetch ? clientConfig.cloudFetchConcurrentDownloads : 0;
+
     return {
       keepAlive: true,
-      maxSockets: 5,
+      maxSockets: 5 + cloudFetchExtraSocketsCount,
       keepAliveMsecs: 10000,
       timeout: this.options.socketTimeout ?? clientConfig.socketTimeout,
     };


### PR DESCRIPTION
This PR is related to databricks/databricks-sql-nodejs#204. After changes made in that PR, downloading CloudFetch results sometimes started to fail with `ECONNRESET: socket hang up` error. After debugging, I've found a root cause. Even though all the library code is Promise-based, since Promises are microtasks, enqueueing a lot of promises may block macrotasks execution for a while. Usually, there are no much microtasks scheduled. However, when fetching a CloudFetch results, after first set of files are downloaded and being processed immediately one by one (and chunk by chunk), event loop easily gets clogged for enough time to break connection pool. `http.Agent` stops receiving socket events, and marks all sockets invalid on the next attempt to use them. The fix allows to clean up a microtasks queue and allow Node to process macrotasks as well, allowing the normal operation of other code.

This change has almost no effect prior to databricks/databricks-sql-nodejs#204 changes, but after databricks/databricks-sql-nodejs#204 the difference is really noticeable (see screenshots under the spoilers). Memory consumption and sockets usage remains basically the same, but event loop now is executed much more evenly, without long delays (which is also reflected on CPU graph):

<details>
<summary>Before</summary>

![image](https://github.com/databricks/databricks-sql-nodejs/assets/12139186/8f2da67c-9486-42aa-b5ec-b2eb6a03a4b9)

</details>

<details>
<summary>After</summary>

![image](https://github.com/databricks/databricks-sql-nodejs/assets/12139186/23e458c5-0393-47b4-ac46-de82223daa6a)

</details>


Also, another (smaller) improvement is increasing connection pool when CloudFetch is enabled, which allows to download data a bit faster.