### PR TITLE
[PECO-1261] Improve CloudFetch downloading queue

### DIFF
--- a/tests/e2e/cloudfetch.test.js
+++ b/tests/e2e/cloudfetch.test.js
@@ -64,7 +64,7 @@ describe('CloudFetch', () => {
     // result handler should download 5 of them and schedule the rest
     expect(await cfResultHandler.hasMore()).to.be.false;
     expect(cfResultHandler.pendingLinks.length).to.be.equal(0);
-    expect(cfResultHandler.downloadedBatches.length).to.be.equal(0);
+    expect(cfResultHandler.downloadTasks.length).to.be.equal(0);
 
     sinon.spy(operation._data, 'fetchNext');
 
@@ -76,7 +76,7 @@ describe('CloudFetch', () => {
     expect(await cfResultHandler.hasMore()).to.be.true;
     // expected batches minus first 5 already fetched
     expect(cfResultHandler.pendingLinks.length).to.be.equal(resultLinksCount - cloudFetchConcurrentDownloads);
-    expect(cfResultHandler.downloadedBatches.length).to.be.equal(cloudFetchConcurrentDownloads - 1);
+    expect(cfResultHandler.downloadTasks.length).to.be.equal(cloudFetchConcurrentDownloads - 1);
 
     let fetchedRowCount = chunk.length;
     while (await operation.hasMoreRows()) {


### PR DESCRIPTION
[PECO-1261]

Previously, CloudFetch result handler enqueued batch of links and waited for all of them to be downloaded; the next batch of links was downloaded only when previous one was read by user.

Now, CloudFetch handler starts downloading links in background, and waits only for the one currently requested by user. More links are enqueued for downloading only on demand, if there are free slots in queue.

Profiler output (result set contains 8 links total, concurrent downloads set to 5). CPU and Event loop graphs clearly show that previously 5 links were fetched, then processed, and then remaining links were fetched and processed. After changes made in this PR, first links are scheduled, and data processing starts once the first one is available while other links continued downloading in background; remaining links are added to queue immediately when processed ones are procesed:

<details>
<summary>Before</summary>

![image](https://github.com/databricks/databricks-sql-nodejs/assets/12139186/873fc9e1-1a47-419d-bc56-e4390a333066)

</details>

<details>
<summary>After</summary>

![image](https://github.com/databricks/databricks-sql-nodejs/assets/12139186/de77f3f0-a043-4749-8e77-0e1f11f73b5d)

</details>



[PECO-1261]: https://databricks.atlassian.net/browse/PECO-1261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ