### PR TITLE
Remove protocol version check for query parameters

### DIFF
--- a/lib/DBSQLSession.ts
+++ b/lib/DBSQLSession.ts
@@ -2,7 +2,6 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { stringify, NIL, parse } from 'uuid';
 import fetch, { HeadersInit } from 'node-fetch';
-import { Thrift } from 'thrift';
 import {
   TSessionHandle,
   TStatus,
@@ -10,7 +9,6 @@ import {
   TSparkDirectResults,
   TSparkArrowTypes,
   TSparkParameter,
-  TProtocolVersion,
 } from '../thrift/TCLIService_types';
 import { Int64 } from './hive/Types';
 import IDBSQLSession, {
@@ -96,16 +94,6 @@ function getQueryParameters(
 
   if (!namedParametersProvided && !ordinalParametersProvided) {
     return [];
-  }
-
-  if (
-    !sessionHandle.serverProtocolVersion ||
-    sessionHandle.serverProtocolVersion < TProtocolVersion.SPARK_CLI_SERVICE_PROTOCOL_V8
-  ) {
-    throw new Thrift.TProtocolException(
-      Thrift.TProtocolExceptionType.BAD_VERSION,
-      'Parameterized operations are not supported by this server. Support will begin with server version DBR 14.1',
-    );
   }
 
   const result: Array<TSparkParameter> = [];

--- a/tests/e2e/query_parameters.test.js
+++ b/tests/e2e/query_parameters.test.js
@@ -19,9 +19,8 @@ const openSession = async () => {
   });
 };
 
-// TODO: Temporarily disable those tests until we figure out issues with E2E test env
 describe('Query parameters', () => {
-  it.skip('should use named parameters', async () => {
+  it('should use named parameters', async () => {
     const session = await openSession();
     const operation = await session.executeStatement(
       `
@@ -72,7 +71,7 @@ describe('Query parameters', () => {
     ]);
   });
 
-  it.skip('should accept primitives as values for named parameters', async () => {
+  it('should accept primitives as values for named parameters', async () => {
     const session = await openSession();
     const operation = await session.executeStatement(
       `
@@ -117,7 +116,7 @@ describe('Query parameters', () => {
     ]);
   });
 
-  it.skip('should use ordinal parameters', async () => {
+  it('should use ordinal parameters', async () => {
     const session = await openSession();
     const operation = await session.executeStatement(
       `
@@ -168,7 +167,7 @@ describe('Query parameters', () => {
     ]);
   });
 
-  it.skip('should accept primitives as values for ordinal parameters', async () => {
+  it('should accept primitives as values for ordinal parameters', async () => {
     const session = await openSession();
     const operation = await session.executeStatement(
       `


### PR DESCRIPTION
We don't have any fallback logic for the case when native query parameters are not supported by server (like PySQL for example, which can fallback to inlining parameters), so this protocol version check is basically useless