### PR TITLE
Prepare release 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release History
 
+## 1.7.0
+
+- Fixed behavior of `maxRows` option of `IOperation.fetchChunk()`. Now it will return chunks
+  of requested size (databricks/databricks-sql-nodejs#200)
+- Improved CloudFetch memory usage and overall performance (databricks/databricks-sql-nodejs#204,
+  databricks/databricks-sql-nodejs#207, databricks/databricks-sql-nodejs#209)
+- Remove protocol version check when using query parameters (databricks/databricks-sql-nodejs#213)
+- Fix `IOperation.hasMoreRows()` behavior to avoid fetching data beyond the end of dataset.
+  Also, now it will work properly prior to fetching first chunk (databricks/databricks-sql-nodejs#205)
+
 ## 1.6.1
 
 - Make default logger singleton (databricks/databricks-sql-nodejs#199)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@databricks/sql",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@databricks/sql",
-      "version": "1.6.1",
+      "version": "1.7.0",
       "license": "Apache 2.0",
       "dependencies": {
         "apache-arrow": "^13.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks/sql",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Driver for connection to Databricks SQL via Thrift API.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
All the changes in this release are various fixes. But since they slightly change behavior of `IOperation.fetchChunk()` and `IOperation.hasMoreRows()` I ended up incrementing minor version number instead of build