### PR TITLE
Remove limit for sockets per connection to fix "Premature close" error + prepare patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+## 1.7.1
+
+- Fix "Premature close" error which happened due to socket limit when intensively using library
+  (databricks/databricks-sql-nodejs#217)
+
 ## 1.7.0
 
 - Fixed behavior of `maxRows` option of `IOperation.fetchChunk()`. Now it will return chunks

--- a/lib/connection/connections/HttpConnection.ts
+++ b/lib/connection/connections/HttpConnection.ts
@@ -49,12 +49,10 @@ export default class HttpConnection implements IConnectionProvider {
   private getAgentDefaultOptions(): http.AgentOptions {
     const clientConfig = this.context.getConfig();
 
-    const cloudFetchExtraSocketsCount = clientConfig.useCloudFetch ? clientConfig.cloudFetchConcurrentDownloads : 0;
-
     return {
       keepAlive: true,
-      maxSockets: 5 + cloudFetchExtraSocketsCount,
       keepAliveMsecs: 10000,
+      maxSockets: Infinity, // no limit
       timeout: this.options.socketTimeout ?? clientConfig.socketTimeout,
     };
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@databricks/sql",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@databricks/sql",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "Apache 2.0",
       "dependencies": {
         "apache-arrow": "^13.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks/sql",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Driver for connection to Databricks SQL via Thrift API.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Fixes databricks/databricks-sql-nodejs#208