### PR TITLE
Add polyfills to make `apache-arrow` work in Node@14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,8 +35,7 @@ jobs:
     strategy:
       matrix:
         # only LTS versions starting from the lowest we support
-        # TODO: Include Nodejs@14
-        node-version: ['16', '18', '20']
+        node-version: ['14', '16', '18', '20']
     env:
       cache-name: cache-node-modules
       NYC_REPORT_DIR: coverage_unit_node${{ matrix.node-version }}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,6 @@
+// Don't move this import - it should be placed before any other
+import './polyfills';
+
 import { Thrift } from 'thrift';
 import TCLIService from '../thrift/TCLIService';
 import TCLIService_types from '../thrift/TCLIService_types';

--- a/lib/polyfills.ts
+++ b/lib/polyfills.ts
@@ -1,3 +1,5 @@
+/* eslint-disable import/prefer-default-export */
+
 // `Array.at` / `TypedArray.at` is supported only since Nodejs@16.6.0
 // These methods are massively used by `apache-arrow@13`, but we have
 // to use this version because older ones contain some other nasty bugs
@@ -21,7 +23,7 @@ function toLength(value: unknown): number {
 }
 
 // https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.at
-function at<T>(this: Array<T>, index: number): T | undefined {
+export function at<T>(this: Array<T>, index: number): T | undefined {
   const length = toLength(this.length);
   const relativeIndex = toIntegerOrInfinity(index);
   const absoluteIndex = relativeIndex >= 0 ? relativeIndex : length + relativeIndex;

--- a/lib/polyfills.ts
+++ b/lib/polyfills.ts
@@ -1,0 +1,48 @@
+// `Array.at` / `TypedArray.at` is supported only since Nodejs@16.6.0
+// These methods are massively used by `apache-arrow@13`, but we have
+// to use this version because older ones contain some other nasty bugs
+
+// https://tc39.es/ecma262/multipage/abstract-operations.html#sec-tointegerorinfinity
+function toIntegerOrInfinity(value: unknown): number {
+  const result = Number(value);
+
+  // Return `0` for NaN; return `+Infinity` / `-Infinity` as is
+  if (!Number.isFinite(result)) {
+    return Number.isNaN(result) ? 0 : result;
+  }
+
+  return Math.trunc(result);
+}
+
+// https://tc39.es/ecma262/multipage/abstract-operations.html#sec-tolength
+function toLength(value: unknown): number {
+  const result = toIntegerOrInfinity(value);
+  return result > 0 ? Math.min(result, Number.MAX_SAFE_INTEGER) : 0;
+}
+
+// https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.at
+function at<T>(this: Array<T>, index: number): T | undefined {
+  const length = toLength(this.length);
+  const relativeIndex = toIntegerOrInfinity(index);
+  const absoluteIndex = relativeIndex >= 0 ? relativeIndex : length + relativeIndex;
+  return absoluteIndex >= 0 && absoluteIndex < length ? this[absoluteIndex] : undefined;
+}
+
+const ArrayConstructors = [
+  global.Array,
+  global.Int8Array,
+  global.Uint8Array,
+  global.Uint8ClampedArray,
+  global.Int16Array,
+  global.Uint16Array,
+  global.Int32Array,
+  global.Uint32Array,
+  global.Float32Array,
+  global.Float64Array,
+  global.BigInt64Array,
+  global.BigUint64Array,
+];
+
+ArrayConstructors.forEach((ArrayConstructor) => {
+  ArrayConstructor.prototype.at = ArrayConstructor.prototype.at ?? at;
+});

--- a/tests/e2e/arrow.test.js
+++ b/tests/e2e/arrow.test.js
@@ -48,10 +48,10 @@ async function deleteTable(session, tableName) {
 async function initializeTable(session, tableName) {
   await deleteTable(session, tableName);
 
-  const createTable = fixtures.createTableSql.replaceAll('${table_name}', tableName);
+  const createTable = fixtures.createTableSql.replace(/\$\{table_name\}/g, tableName);
   await execute(session, createTable);
 
-  const insertData = fixtures.insertDataSql.replaceAll('${table_name}', tableName);
+  const insertData = fixtures.insertDataSql.replace(/\$\{table_name\}/g, tableName);
   await execute(session, insertData);
 }
 

--- a/tests/unit/polyfills.test.js
+++ b/tests/unit/polyfills.test.js
@@ -1,0 +1,76 @@
+const { expect } = require('chai');
+const { at } = require('../../dist/polyfills');
+
+const defaultArrayMock = {
+  0: 'a',
+  1: 'b',
+  2: 'c',
+  3: 'd',
+  length: 4,
+  at,
+};
+
+describe('Array.at', () => {
+  it('should handle zero index', () => {
+    const obj = { ...defaultArrayMock };
+    expect(obj.at(0)).to.eq('a');
+    expect(obj.at(Number('+0'))).to.eq('a');
+    expect(obj.at(Number('-0'))).to.eq('a');
+  });
+
+  it('should handle positive index', () => {
+    const obj = { ...defaultArrayMock };
+    expect(obj.at(2)).to.eq('c');
+    expect(obj.at(2.2)).to.eq('c');
+    expect(obj.at(2.8)).to.eq('c');
+  });
+
+  it('should handle negative index', () => {
+    const obj = { ...defaultArrayMock };
+    expect(obj.at(-2)).to.eq('c');
+    expect(obj.at(-2.2)).to.eq('c');
+    expect(obj.at(-2.8)).to.eq('c');
+  });
+
+  it('should handle positive infinity index', () => {
+    const obj = { ...defaultArrayMock };
+    expect(obj.at(Number.POSITIVE_INFINITY)).to.be.undefined;
+  });
+
+  it('should handle negative infinity index', () => {
+    const obj = { ...defaultArrayMock };
+    expect(obj.at(Number.NEGATIVE_INFINITY)).to.be.undefined;
+  });
+
+  it('should handle non-numeric index', () => {
+    const obj = { ...defaultArrayMock };
+    expect(obj.at('2')).to.eq('c');
+  });
+
+  it('should handle NaN index', () => {
+    const obj = { ...defaultArrayMock };
+    expect(obj.at(Number.NaN)).to.eq('a');
+    expect(obj.at('invalid')).to.eq('a');
+  });
+
+  it('should handle index out of bounds', () => {
+    const obj = { ...defaultArrayMock };
+    expect(obj.at(10)).to.be.undefined;
+    expect(obj.at(-10)).to.be.undefined;
+  });
+
+  it('should handle zero length', () => {
+    const obj = { ...defaultArrayMock, length: 0 };
+    expect(obj.at(2)).to.be.undefined;
+  });
+
+  it('should handle negative length', () => {
+    const obj = { ...defaultArrayMock, length: -4 };
+    expect(obj.at(2)).to.be.undefined;
+  });
+
+  it('should handle non-numeric length', () => {
+    const obj = { ...defaultArrayMock, length: 'invalid' };
+    expect(obj.at(2)).to.be.undefined;
+  });
+});


### PR DESCRIPTION
After upgrading `apache-arrow` in databricks/databricks-sql-nodejs#180 (which was needed to fix databricks/databricks-sql-nodejs#150), this library stopped working in some Nodejs versions. Turns out that `apache-arrow@13` started to massively use `Array.at`/`TypedArray.at` methods which became available only in `Node@16.6.0`.

Even if we forget that `apache-arrow` declares a support for `Node@12` (at least in its `package.json` file), we had two options:

1. stop supporting older Nodejs versions;
2. add polyfills for missing methods.

I ended up implementing own polyfill with this reasoning:

1. we still have users that use Node 16 or even 14 (but for option 1 we'd have to declare support for even newer versions);
2. basically, only one method is currently needed (`Array.at`/`TypedArray.at` can use same implementation);
3. the needed method is really simple (so even using `core-js` would be absolute overkill). 