### PR TITLE
CI: run unit tests on multiple Nodejs versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,8 @@ jobs:
     strategy:
       matrix:
         # only LTS versions starting from the lowest we support
-        node-version: ['14', '16', '18', '20']
+        # TODO: Include Nodejs@14
+        node-version: ['16', '18', '20']
     env:
       cache-name: cache-node-modules
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,20 +32,27 @@ jobs:
 
   unit-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # only LTS versions starting from the lowest we support
+        node-version: ['14', '16', '18', '20']
     env:
       cache-name: cache-node-modules
 
     steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
       - uses: actions/checkout@v3
       - name: Cache node modules
         uses: actions/cache@v3
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-${{ matrix.node-version }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+            ${{ runner.os }}-${{ matrix.node-version }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-${{ matrix.node-version }}-build-
+            ${{ runner.os }}-${{ matrix.node-version }}-
       - name: Run unit tests
         run: |
           npm ci

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,7 @@ jobs:
         node-version: ['16', '18', '20']
     env:
       cache-name: cache-node-modules
+      NYC_REPORT_DIR: coverage_unit_node${{ matrix.node-version }}
 
     steps:
       - uses: actions/setup-node@v4
@@ -58,12 +59,12 @@ jobs:
         run: |
           npm ci
           npm run test
-      - run: tar -cvf coverage_unit.tar coverage_unit
+      - run: tar -cvf ${{ env.NYC_REPORT_DIR }}.tar ${{ env.NYC_REPORT_DIR }}
       - name: Store coverage report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: coverage_unit
-          path: coverage_unit.tar
+          name: ${{ env.NYC_REPORT_DIR }}
+          path: ${{ env.NYC_REPORT_DIR }}.tar
           retention-days: 1
 
   e2e-test:
@@ -75,6 +76,7 @@ jobs:
       E2E_ACCESS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
       E2E_TABLE_SUFFIX: ${{github.sha}}
       cache-name: cache-node-modules
+      NYC_REPORT_DIR: coverage_e2e
 
     steps:
       - uses: actions/checkout@v3
@@ -91,12 +93,12 @@ jobs:
         run: |
           npm ci
           NODE_OPTIONS="--max-old-space-size=4096" npm run e2e
-      - run: tar -cvf coverage_e2e.tar coverage_e2e
+      - run: tar -cvf ${{ env.NYC_REPORT_DIR }}.tar ${{ env.NYC_REPORT_DIR }}
       - name: Store coverage report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: coverage_e2e
-          path: coverage_e2e.tar
+          name: ${{ env.NYC_REPORT_DIR }}
+          path: ${{ env.NYC_REPORT_DIR }}.tar
           retention-days: 1
 
   coverage:
@@ -116,14 +118,15 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: coverage_unit
-      - uses: actions/download-artifact@v3
-        with:
-          name: coverage_e2e
-      - run: tar -xvf coverage_unit.tar && rm coverage_unit.tar
-      - run: tar -xvf coverage_e2e.tar && rm coverage_e2e.tar
+          pattern: coverage_*
+          merge-multiple: true
+      - name: Unpack coverage reports
+        run: |
+          ls -1 coverage_*.tar | xargs -I '{}' -- tar -xvf '{}'
+          rm coverage_*.tar
+      - run: ls -la
       - name: Coverage
         uses: codecov/codecov-action@v3
         with:

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   },
   "scripts": {
     "prepare": "npm run build",
-    "e2e": "nyc --reporter=lcov --report-dir=coverage_e2e mocha --config tests/e2e/.mocharc.js",
-    "test": "nyc --reporter=lcov --report-dir=coverage_unit mocha  --config tests/unit/.mocharc.js",
+    "e2e": "nyc --reporter=lcov --report-dir=${NYC_REPORT_DIR:-coverage_e2e} mocha --config tests/e2e/.mocharc.js",
+    "test": "nyc --reporter=lcov --report-dir=${NYC_REPORT_DIR:-coverage_unit} mocha  --config tests/unit/.mocharc.js",
     "update-version": "node bin/update-version.js && prettier --write ./lib/version.ts",
     "build": "npm run update-version && tsc",
     "watch": "tsc -w",


### PR DESCRIPTION
Configure CI to run unit tests on different Nodejs versions.

E2e are a somewhat time and resource consuming, so for now they will be executed only once.

It should help with preventing compatibility issues in future (see databricks/databricks-sql-nodejs#219)