### PR TITLE
[PECO-1431] Support Databricks OAuth in Azure

### DIFF
--- a/lib/DBSQLClient.ts
+++ b/lib/DBSQLClient.ts
@@ -128,6 +128,7 @@ export default class DBSQLClient extends EventEmitter implements IDBSQLClient, I
           azureTenantId: options.azureTenantId,
           clientId: options.oauthClientId,
           clientSecret: options.oauthClientSecret,
+          useDatabricksOAuthInAzure: options.useDatabricksOAuthInAzure,
           context: this,
         });
       case 'custom':

--- a/lib/connection/auth/DatabricksOAuth/OAuthManager.ts
+++ b/lib/connection/auth/DatabricksOAuth/OAuthManager.ts
@@ -216,9 +216,7 @@ export default abstract class OAuthManager {
 export class DatabricksOAuthManager extends OAuthManager {
   public static azureDomains = ['.azuredatabricks.net', '.databricks.azure.us'];
 
-  public static domains = ['.cloud.databricks.com', '.dev.databricks.com', '.gcp.databricks.com'].concat(
-    this.azureDomains,
-  );
+  public static domains = ['.cloud.databricks.com', '.dev.databricks.com'].concat(this.azureDomains);
 
   public static defaultClientId = 'databricks-sql-connector';
 

--- a/lib/connection/auth/DatabricksOAuth/OAuthManager.ts
+++ b/lib/connection/auth/DatabricksOAuth/OAuthManager.ts
@@ -216,7 +216,9 @@ export default abstract class OAuthManager {
 export class DatabricksOAuthManager extends OAuthManager {
   public static azureDomains = ['.azuredatabricks.net', '.databricks.azure.us'];
 
-  public static domains = ['.cloud.databricks.com', '.dev.databricks.com','.gcp.databricks.com'].concat(this.azureDomains);
+  public static domains = ['.cloud.databricks.com', '.dev.databricks.com', '.gcp.databricks.com'].concat(
+    this.azureDomains,
+  );
 
   public static defaultClientId = 'databricks-sql-connector';
 

--- a/lib/connection/auth/DatabricksOAuth/OAuthManager.ts
+++ b/lib/connection/auth/DatabricksOAuth/OAuthManager.ts
@@ -192,20 +192,23 @@ export default abstract class OAuthManager {
 
     const awsDomains = ['.cloud.databricks.com', '.dev.databricks.com'];
     const isAWSDomain = awsDomains.some((domain) => host.endsWith(domain));
-
     if (isAWSDomain) {
       // eslint-disable-next-line @typescript-eslint/no-use-before-define
       return new DatabricksOAuthManager(options);
     }
 
-    const azureDomains = ['.azuredatabricks.net', '.databricks.azure.cn', '.databricks.azure.us'];
-    const isAzureDomain = azureDomains.some((domain) => host.endsWith(domain));
-
-    if (isAzureDomain) {
-      if (options.useDatabricksOAuthInAzure) {
+    if (options.useDatabricksOAuthInAzure) {
+      const domains = ['.azuredatabricks.net'];
+      const isSupportedDomain = domains.some((domain) => host.endsWith(domain));
+      if (isSupportedDomain) {
         // eslint-disable-next-line @typescript-eslint/no-use-before-define
         return new DatabricksOAuthManager(options);
       }
+    }
+
+    const azureDomains = ['.azuredatabricks.net', '.databricks.azure.us', '.databricks.azure.cn'];
+    const isAzureDomain = azureDomains.some((domain) => host.endsWith(domain));
+    if (isAzureDomain) {
       // eslint-disable-next-line @typescript-eslint/no-use-before-define
       return new AzureOAuthManager(options);
     }

--- a/lib/connection/auth/DatabricksOAuth/OAuthManager.ts
+++ b/lib/connection/auth/DatabricksOAuth/OAuthManager.ts
@@ -195,7 +195,7 @@ export default abstract class OAuthManager {
     const host = options.host.toLowerCase().replace('https://', '').split('/')[0];
 
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    const managers = [AWSOAuthManager, AzureOAuthManager];
+    const managers = [DatabricksOAuthManager, AzureOAuthManager];
 
     for (const OAuthManagerClass of managers) {
       for (const domain of OAuthManagerClass.domains) {
@@ -212,8 +212,8 @@ export default abstract class OAuthManager {
   }
 }
 
-  // Databricks InHouse OAuth Manager
-export class AWSOAuthManager extends OAuthManager {
+// Databricks InHouse OAuth Manager
+export class DatabricksOAuthManager extends OAuthManager {
   public static azureDomains = ['.azuredatabricks.net', '.databricks.azure.us'];
 
   public static domains = ['.cloud.databricks.com', '.dev.databricks.com'].concat(this.azureDomains);
@@ -223,7 +223,7 @@ export class AWSOAuthManager extends OAuthManager {
   public static defaultCallbackPorts = [8030];
 
   protected canUse(): boolean {
-    const isAzureDomain = AWSOAuthManager.azureDomains.some((domain) => this.options.host.endsWith(domain));
+    const isAzureDomain = DatabricksOAuthManager.azureDomains.some((domain) => this.options.host.endsWith(domain));
     return !isAzureDomain || !!this.options.useDatabricksOAuthInAzure;
   }
 
@@ -236,11 +236,11 @@ export class AWSOAuthManager extends OAuthManager {
   }
 
   protected getClientId(): string {
-    return this.options.clientId ?? AWSOAuthManager.defaultClientId;
+    return this.options.clientId ?? DatabricksOAuthManager.defaultClientId;
   }
 
   protected getCallbackPorts(): Array<number> {
-    return this.options.callbackPorts ?? AWSOAuthManager.defaultCallbackPorts;
+    return this.options.callbackPorts ?? DatabricksOAuthManager.defaultCallbackPorts;
   }
 }
 

--- a/lib/connection/auth/DatabricksOAuth/OAuthManager.ts
+++ b/lib/connection/auth/DatabricksOAuth/OAuthManager.ts
@@ -216,7 +216,7 @@ export default abstract class OAuthManager {
 export class DatabricksOAuthManager extends OAuthManager {
   public static azureDomains = ['.azuredatabricks.net', '.databricks.azure.us'];
 
-  public static domains = ['.cloud.databricks.com', '.dev.databricks.com'].concat(this.azureDomains);
+  public static domains = ['.cloud.databricks.com', '.dev.databricks.com','.gcp.databricks.com'].concat(this.azureDomains);
 
   public static defaultClientId = 'databricks-sql-connector';
 
@@ -246,9 +246,6 @@ export class DatabricksOAuthManager extends OAuthManager {
 
 export class AzureOAuthManager extends OAuthManager {
   public static domains = ['.azuredatabricks.net', '.databricks.azure.cn', '.databricks.azure.us'];
-
-  public static canBeUsed = (options: OAuthManagerOptions) =>
-    this.domains.some((domain) => options.host.endsWith(domain));
 
   public static defaultClientId = '96eecda7-19ea-49cc-abb5-240097d554f5';
 

--- a/lib/contracts/IDBSQLClient.ts
+++ b/lib/contracts/IDBSQLClient.ts
@@ -19,6 +19,7 @@ type AuthOptions =
       azureTenantId?: string;
       oauthClientId?: string;
       oauthClientSecret?: string;
+      useDatabricksOAuthInAzure?: boolean;
     }
   | {
       authType: 'custom';

--- a/tests/unit/DBSQLClient.test.js
+++ b/tests/unit/DBSQLClient.test.js
@@ -366,15 +366,29 @@ describe('DBSQLClient.initAuthProvider', () => {
   it('should use Databricks InHouse OAuth method (Azure)', () => {
     const client = new DBSQLClient();
 
-    const provider = client.initAuthProvider({
-      authType: 'databricks-oauth',
-      // host is used when creating OAuth manager, so make it look like a real Azure instance
-      host: 'example.databricks.azure.us',
-      useDatabricksOAuthInAzure: true,
-    });
+    case1: {
+      const provider = client.initAuthProvider({
+        authType: 'databricks-oauth',
+        // host is used when creating OAuth manager, so make it look like a real Azure instance
+        host: 'example.azuredatabricks.net',
+        useDatabricksOAuthInAzure: true,
+      });
 
-    expect(provider).to.be.instanceOf(DatabricksOAuth);
-    expect(provider.manager).to.be.instanceOf(DatabricksOAuthManager);
+      expect(provider).to.be.instanceOf(DatabricksOAuth);
+      expect(provider.manager).to.be.instanceOf(DatabricksOAuthManager);
+    }
+
+    case2: {
+      const provider = client.initAuthProvider({
+        authType: 'databricks-oauth',
+        // host is used when creating OAuth manager, so make it look like a real Azure instance
+        host: 'example.databricks.azure.us',
+        useDatabricksOAuthInAzure: true,
+      });
+
+      expect(provider).to.be.instanceOf(DatabricksOAuth);
+      expect(provider.manager).to.be.instanceOf(AzureOAuthManager);
+    }
   });
 
   it('should throw error when OAuth not supported for host', () => {

--- a/tests/unit/DBSQLClient.test.js
+++ b/tests/unit/DBSQLClient.test.js
@@ -5,9 +5,13 @@ const DBSQLSession = require('../../dist/DBSQLSession').default;
 
 const PlainHttpAuthentication = require('../../dist/connection/auth/PlainHttpAuthentication').default;
 const DatabricksOAuth = require('../../dist/connection/auth/DatabricksOAuth').default;
-const { AWSOAuthManager, AzureOAuthManager } = require('../../dist/connection/auth/DatabricksOAuth/OAuthManager');
+const {
+  DatabricksOAuthManager,
+  AzureOAuthManager,
+} = require('../../dist/connection/auth/DatabricksOAuth/OAuthManager');
 
 const HttpConnectionModule = require('../../dist/connection/connections/HttpConnection');
+
 const { default: HttpConnection } = HttpConnectionModule;
 
 class AuthProviderMock {
@@ -343,7 +347,7 @@ describe('DBSQLClient.initAuthProvider', () => {
     });
 
     expect(provider).to.be.instanceOf(DatabricksOAuth);
-    expect(provider.manager).to.be.instanceOf(AWSOAuthManager);
+    expect(provider.manager).to.be.instanceOf(DatabricksOAuthManager);
   });
 
   it('should use Databricks OAuth method (Azure)', () => {
@@ -366,11 +370,11 @@ describe('DBSQLClient.initAuthProvider', () => {
       authType: 'databricks-oauth',
       // host is used when creating OAuth manager, so make it look like a real Azure instance
       host: 'example.databricks.azure.us',
-      useDatabricksOAuthInAzure: true
+      useDatabricksOAuthInAzure: true,
     });
 
     expect(provider).to.be.instanceOf(DatabricksOAuth);
-    expect(provider.manager).to.be.instanceOf(AWSOAuthManager);
+    expect(provider.manager).to.be.instanceOf(DatabricksOAuthManager);
   });
 
   it('should throw error when OAuth not supported for host', () => {

--- a/tests/unit/DBSQLClient.test.js
+++ b/tests/unit/DBSQLClient.test.js
@@ -359,6 +359,20 @@ describe('DBSQLClient.initAuthProvider', () => {
     expect(provider.manager).to.be.instanceOf(AzureOAuthManager);
   });
 
+  it('should use Databricks InHouse OAuth method (Azure)', () => {
+    const client = new DBSQLClient();
+
+    const provider = client.initAuthProvider({
+      authType: 'databricks-oauth',
+      // host is used when creating OAuth manager, so make it look like a real Azure instance
+      host: 'example.databricks.azure.us',
+      useDatabricksOAuthInAzure: true
+    });
+
+    expect(provider).to.be.instanceOf(DatabricksOAuth);
+    expect(provider.manager).to.be.instanceOf(AWSOAuthManager);
+  });
+
   it('should throw error when OAuth not supported for host', () => {
     const client = new DBSQLClient();
 

--- a/tests/unit/connection/auth/DatabricksOAuth/OAuthManager.test.js
+++ b/tests/unit/connection/auth/DatabricksOAuth/OAuthManager.test.js
@@ -3,7 +3,7 @@ const sinon = require('sinon');
 const openidClientLib = require('openid-client');
 const { DBSQLLogger, LogLevel } = require('../../../../../dist');
 const {
-  AWSOAuthManager,
+  DatabricksOAuthManager,
   AzureOAuthManager,
 } = require('../../../../../dist/connection/auth/DatabricksOAuth/OAuthManager');
 const OAuthToken = require('../../../../../dist/connection/auth/DatabricksOAuth/OAuthToken').default;
@@ -110,7 +110,7 @@ class OAuthClientMock {
   }
 }
 
-[AWSOAuthManager, AzureOAuthManager].forEach((OAuthManagerClass) => {
+[DatabricksOAuthManager, AzureOAuthManager].forEach((OAuthManagerClass) => {
   function prepareTestInstances(options) {
     const oauthClient = new OAuthClientMock();
     sinon.stub(oauthClient, 'grant').callThrough();


### PR DESCRIPTION
Add optional property `useDatabricksOAuthInAzure` in the parameter `ConnectionOptions` of `DBSQLClient.connect`. 

If it is set as `true`, it will use Databricks native OAuth rather than Azure AD OAuth in both OAuth U2M and M2M flow. If it is not set or set as `false`, it will still use the existing Azure AD OAuth.

To use this in OAuth M2M flow, the `oauthClientId` and `oauthClientSecret` in the `ConnectionOptions` must be Databricks service principal client ID and secret which can be created by Databricks API or Databricks Account UI.