### PR TITLE
Use correct scopes for OAuth U2M and M2M flows

### DIFF
--- a/lib/DBSQLClient.ts
+++ b/lib/DBSQLClient.ts
@@ -17,7 +17,7 @@ import Status from './dto/Status';
 import HiveDriverError from './errors/HiveDriverError';
 import { buildUserAgentString, definedOrError } from './utils';
 import PlainHttpAuthentication from './connection/auth/PlainHttpAuthentication';
-import DatabricksOAuth from './connection/auth/DatabricksOAuth';
+import DatabricksOAuth, { OAuthFlow } from './connection/auth/DatabricksOAuth';
 import IDBSQLLogger, { LogLevel } from './contracts/IDBSQLLogger';
 import DBSQLLogger from './DBSQLLogger';
 import CloseableCollection from './utils/CloseableCollection';
@@ -125,6 +125,7 @@ export default class DBSQLClient extends EventEmitter implements IDBSQLClient, I
         });
       case 'databricks-oauth':
         return new DatabricksOAuth({
+          flow: options.oauthClientSecret === undefined ? OAuthFlow.U2M : OAuthFlow.M2M,
           host: options.host,
           persistence: options.persistence,
           azureTenantId: options.azureTenantId,

--- a/lib/connection/auth/DatabricksOAuth/OAuthScope.ts
+++ b/lib/connection/auth/DatabricksOAuth/OAuthScope.ts
@@ -1,6 +1,7 @@
 export enum OAuthScope {
   offlineAccess = 'offline_access',
   SQL = 'sql',
+  AllAPIs = 'all-apis',
 }
 
 export type OAuthScopes = Array<string>;

--- a/lib/connection/auth/DatabricksOAuth/OAuthScope.ts
+++ b/lib/connection/auth/DatabricksOAuth/OAuthScope.ts
@@ -1,7 +1,7 @@
 export enum OAuthScope {
   offlineAccess = 'offline_access',
   SQL = 'sql',
-  AllAPIs = 'all-apis',
+  allAPIs = 'all-apis',
 }
 
 export type OAuthScopes = Array<string>;

--- a/lib/connection/auth/DatabricksOAuth/OAuthToken.ts
+++ b/lib/connection/auth/DatabricksOAuth/OAuthToken.ts
@@ -1,13 +1,18 @@
+import { OAuthScopes } from './OAuthScope';
+
 export default class OAuthToken {
   private readonly _accessToken: string;
 
   private readonly _refreshToken?: string;
 
+  private readonly _scopes?: OAuthScopes;
+
   private _expirationTime?: number;
 
-  constructor(accessToken: string, refreshToken?: string) {
+  constructor(accessToken: string, refreshToken?: string, scopes?: OAuthScopes) {
     this._accessToken = accessToken;
     this._refreshToken = refreshToken;
+    this._scopes = scopes;
   }
 
   get accessToken(): string {
@@ -16,6 +21,10 @@ export default class OAuthToken {
 
   get refreshToken(): string | undefined {
     return this._refreshToken;
+  }
+
+  get scopes(): OAuthScopes | undefined {
+    return this._scopes;
   }
 
   get expirationTime(): number {

--- a/lib/connection/auth/DatabricksOAuth/index.ts
+++ b/lib/connection/auth/DatabricksOAuth/index.ts
@@ -1,9 +1,11 @@
 import { HeadersInit } from 'node-fetch';
 import IAuthentication from '../../contracts/IAuthentication';
 import OAuthPersistence, { OAuthPersistenceCache } from './OAuthPersistence';
-import OAuthManager, { OAuthManagerOptions } from './OAuthManager';
+import OAuthManager, { OAuthManagerOptions, OAuthFlow } from './OAuthManager';
 import { OAuthScopes, defaultOAuthScopes } from './OAuthScope';
 import IClientContext from '../../../contracts/IClientContext';
+
+export { OAuthFlow };
 
 interface DatabricksOAuthOptions extends OAuthManagerOptions {
   scopes?: OAuthScopes;

--- a/tests/unit/DBSQLClient.test.js
+++ b/tests/unit/DBSQLClient.test.js
@@ -344,6 +344,7 @@ describe('DBSQLClient.initAuthProvider', () => {
       authType: 'databricks-oauth',
       // host is used when creating OAuth manager, so make it look like a real AWS instance
       host: 'example.dev.databricks.com',
+      oauthClientSecret: 'test-secret',
     });
 
     expect(provider).to.be.instanceOf(DatabricksOAuth);

--- a/tests/unit/connection/auth/DatabricksOAuth/OAuthManager.test.js
+++ b/tests/unit/connection/auth/DatabricksOAuth/OAuthManager.test.js
@@ -5,6 +5,7 @@ const { DBSQLLogger, LogLevel } = require('../../../../../dist');
 const {
   DatabricksOAuthManager,
   AzureOAuthManager,
+  OAuthFlow,
 } = require('../../../../../dist/connection/auth/DatabricksOAuth/OAuthManager');
 const OAuthToken = require('../../../../../dist/connection/auth/DatabricksOAuth/OAuthToken').default;
 const AuthorizationCodeModule = require('../../../../../dist/connection/auth/DatabricksOAuth/AuthorizationCode');
@@ -156,7 +157,7 @@ class OAuthClientMock {
 
     describe('U2M flow', () => {
       it('should get access token', async () => {
-        const { oauthManager, oauthClient } = prepareTestInstances();
+        const { oauthManager, oauthClient } = prepareTestInstances({ flow: OAuthFlow.U2M });
 
         const token = await oauthManager.getToken(['offline_access']);
         expect(oauthClient.grant.called).to.be.true;
@@ -166,7 +167,7 @@ class OAuthClientMock {
       });
 
       it('should throw an error if cannot get access token', async () => {
-        const { oauthManager, oauthClient } = prepareTestInstances();
+        const { oauthManager, oauthClient } = prepareTestInstances({ flow: OAuthFlow.U2M });
 
         // Make it return empty tokens
         oauthClient.accessToken = undefined;
@@ -185,7 +186,7 @@ class OAuthClientMock {
       });
 
       it('should re-throw unhandled errors when getting access token', async () => {
-        const { oauthManager, oauthClient } = prepareTestInstances();
+        const { oauthManager, oauthClient } = prepareTestInstances({ flow: OAuthFlow.U2M });
 
         const testError = new Error('Test');
         oauthClient.grantError = testError;
@@ -203,7 +204,7 @@ class OAuthClientMock {
       });
 
       it('should not refresh valid token', async () => {
-        const { oauthManager, oauthClient } = prepareTestInstances();
+        const { oauthManager, oauthClient } = prepareTestInstances({ flow: OAuthFlow.U2M });
 
         const token = new OAuthToken(createValidAccessToken(), oauthClient.refreshToken);
         expect(token.hasExpired).to.be.false;
@@ -216,7 +217,7 @@ class OAuthClientMock {
       });
 
       it('should throw an error if no refresh token is available', async () => {
-        const { oauthManager, oauthClient } = prepareTestInstances();
+        const { oauthManager, oauthClient } = prepareTestInstances({ flow: OAuthFlow.U2M });
 
         try {
           const token = new OAuthToken(createExpiredAccessToken());
@@ -234,7 +235,7 @@ class OAuthClientMock {
       });
 
       it('should throw an error for invalid token', async () => {
-        const { oauthManager, oauthClient } = prepareTestInstances();
+        const { oauthManager, oauthClient } = prepareTestInstances({ flow: OAuthFlow.U2M });
 
         try {
           const token = new OAuthToken('invalid_access_token', 'invalid_refresh_token');
@@ -251,7 +252,7 @@ class OAuthClientMock {
       });
 
       it('should refresh expired token', async () => {
-        const { oauthManager, oauthClient } = prepareTestInstances();
+        const { oauthManager, oauthClient } = prepareTestInstances({ flow: OAuthFlow.U2M });
 
         oauthClient.accessToken = createExpiredAccessToken();
         const token = await oauthManager.getToken([]);
@@ -265,7 +266,7 @@ class OAuthClientMock {
       });
 
       it('should throw an error if cannot refresh token', async () => {
-        const { oauthManager, oauthClient } = prepareTestInstances();
+        const { oauthManager, oauthClient } = prepareTestInstances({ flow: OAuthFlow.U2M });
 
         oauthClient.refresh.restore();
         sinon.stub(oauthClient, 'refresh').returns({});
@@ -289,7 +290,7 @@ class OAuthClientMock {
     describe('M2M flow', () => {
       it('should get access token', async () => {
         const { oauthManager, oauthClient } = prepareTestInstances({
-          // setup for M2M flow
+          flow: OAuthFlow.M2M,
           clientId: 'test_client_id',
           clientSecret: 'test_client_secret',
         });
@@ -303,7 +304,7 @@ class OAuthClientMock {
 
       it('should throw an error if cannot get access token', async () => {
         const { oauthManager, oauthClient } = prepareTestInstances({
-          // setup for M2M flow
+          flow: OAuthFlow.M2M,
           clientId: 'test_client_id',
           clientSecret: 'test_client_secret',
         });
@@ -326,7 +327,7 @@ class OAuthClientMock {
 
       it('should re-throw unhandled errors when getting access token', async () => {
         const { oauthManager, oauthClient } = prepareTestInstances({
-          // setup for M2M flow
+          flow: OAuthFlow.M2M,
           clientId: 'test_client_id',
           clientSecret: 'test_client_secret',
         });
@@ -348,7 +349,7 @@ class OAuthClientMock {
 
       it('should not refresh valid token', async () => {
         const { oauthManager, oauthClient } = prepareTestInstances({
-          // setup for M2M flow
+          flow: OAuthFlow.M2M,
           clientId: 'test_client_id',
           clientSecret: 'test_client_secret',
         });
@@ -366,7 +367,7 @@ class OAuthClientMock {
 
       it('should refresh expired token', async () => {
         const { oauthManager, oauthClient } = prepareTestInstances({
-          // setup for M2M flow
+          flow: OAuthFlow.M2M,
           clientId: 'test_client_id',
           clientSecret: 'test_client_secret',
         });
@@ -386,7 +387,7 @@ class OAuthClientMock {
 
       it('should throw an error if cannot refresh token', async () => {
         const { oauthManager, oauthClient } = prepareTestInstances({
-          // setup for M2M flow
+          flow: OAuthFlow.M2M,
           clientId: 'test_client_id',
           clientSecret: 'test_client_secret',
         });

--- a/tests/unit/connection/auth/DatabricksOAuth/OAuthManager.test.js
+++ b/tests/unit/connection/auth/DatabricksOAuth/OAuthManager.test.js
@@ -8,6 +8,7 @@ const {
   OAuthFlow,
 } = require('../../../../../dist/connection/auth/DatabricksOAuth/OAuthManager');
 const OAuthToken = require('../../../../../dist/connection/auth/DatabricksOAuth/OAuthToken').default;
+const { OAuthScope, scopeDelimiter } = require('../../../../../dist/connection/auth/DatabricksOAuth/OAuthScope');
 const AuthorizationCodeModule = require('../../../../../dist/connection/auth/DatabricksOAuth/AuthorizationCode');
 
 const { createValidAccessToken, createExpiredAccessToken } = require('./utils');
@@ -17,9 +18,13 @@ const logger = new DBSQLLogger({ level: LogLevel.error });
 class AuthorizationCodeMock {
   constructor() {
     this.fetchResult = undefined;
+    this.expectedScope = undefined;
   }
 
-  async fetch() {
+  async fetch(scopes) {
+    if (this.expectedScope) {
+      expect(scopes.join(scopeDelimiter)).to.be.equal(this.expectedScope);
+    }
     return this.fetchResult;
   }
 }
@@ -35,6 +40,7 @@ class OAuthClientMock {
     this.clientOptions = {};
     this.expectedClientId = undefined;
     this.expectedClientSecret = undefined;
+    this.expectedScope = undefined;
 
     this.grantError = undefined;
     this.refreshError = undefined;
@@ -61,6 +67,9 @@ class OAuthClientMock {
     expect(params.code).to.be.equal(AuthorizationCodeMock.validCode.code);
     expect(params.code_verifier).to.be.equal(AuthorizationCodeMock.validCode.verifier);
     expect(params.redirect_uri).to.be.equal(AuthorizationCodeMock.validCode.redirectUri);
+    if (this.expectedScope) {
+      expect(params.scope).to.be.equal(this.expectedScope);
+    }
 
     return {
       access_token: this.accessToken,
@@ -76,7 +85,9 @@ class OAuthClientMock {
     }
 
     expect(params.grant_type).to.be.equal('client_credentials');
-    expect(params.scope).to.be.equal('all-apis');
+    if (this.expectedScope) {
+      expect(params.scope).to.be.equal(this.expectedScope);
+    }
 
     return {
       access_token: this.accessToken,
@@ -156,10 +167,23 @@ class OAuthClientMock {
     });
 
     describe('U2M flow', () => {
-      it('should get access token', async () => {
-        const { oauthManager, oauthClient } = prepareTestInstances({ flow: OAuthFlow.U2M });
+      function getExpectedScope(scopes) {
+        switch (OAuthManagerClass) {
+          case DatabricksOAuthManager:
+            return [...scopes].join(scopeDelimiter);
+          case AzureOAuthManager:
+            const tenantId = AzureOAuthManager.datatricksAzureApp;
+            return [`${tenantId}/user_impersonation`, ...scopes].join(scopeDelimiter);
+        }
+        return undefined;
+      }
 
-        const token = await oauthManager.getToken(['offline_access']);
+      it('should get access token', async () => {
+        const { oauthManager, oauthClient, authCode } = prepareTestInstances({ flow: OAuthFlow.U2M });
+        const requestedScopes = [OAuthScope.offlineAccess];
+        authCode.expectedScope = getExpectedScope(requestedScopes);
+
+        const token = await oauthManager.getToken(requestedScopes);
         expect(oauthClient.grant.called).to.be.true;
         expect(token).to.be.instanceOf(OAuthToken);
         expect(token.accessToken).to.be.equal(oauthClient.accessToken);
@@ -167,14 +191,16 @@ class OAuthClientMock {
       });
 
       it('should throw an error if cannot get access token', async () => {
-        const { oauthManager, oauthClient } = prepareTestInstances({ flow: OAuthFlow.U2M });
+        const { oauthManager, oauthClient, authCode } = prepareTestInstances({ flow: OAuthFlow.U2M });
+        const requestedScopes = [OAuthScope.offlineAccess];
+        authCode.expectedScope = getExpectedScope(requestedScopes);
 
         // Make it return empty tokens
         oauthClient.accessToken = undefined;
         oauthClient.refreshToken = undefined;
 
         try {
-          await oauthManager.getToken([]);
+          await oauthManager.getToken(requestedScopes);
           expect.fail('It should throw an error');
         } catch (error) {
           if (error instanceof AssertionError) {
@@ -186,13 +212,15 @@ class OAuthClientMock {
       });
 
       it('should re-throw unhandled errors when getting access token', async () => {
-        const { oauthManager, oauthClient } = prepareTestInstances({ flow: OAuthFlow.U2M });
+        const { oauthManager, oauthClient, authCode } = prepareTestInstances({ flow: OAuthFlow.U2M });
+        const requestedScopes = [];
+        authCode.expectedScope = getExpectedScope(requestedScopes);
 
         const testError = new Error('Test');
         oauthClient.grantError = testError;
 
         try {
-          await oauthManager.getToken([]);
+          await oauthManager.getToken(requestedScopes);
           expect.fail('It should throw an error');
         } catch (error) {
           if (error instanceof AssertionError) {
@@ -204,7 +232,8 @@ class OAuthClientMock {
       });
 
       it('should not refresh valid token', async () => {
-        const { oauthManager, oauthClient } = prepareTestInstances({ flow: OAuthFlow.U2M });
+        const { oauthManager, oauthClient, authCode } = prepareTestInstances({ flow: OAuthFlow.U2M });
+        authCode.expectedScope = getExpectedScope([]);
 
         const token = new OAuthToken(createValidAccessToken(), oauthClient.refreshToken);
         expect(token.hasExpired).to.be.false;
@@ -217,7 +246,8 @@ class OAuthClientMock {
       });
 
       it('should throw an error if no refresh token is available', async () => {
-        const { oauthManager, oauthClient } = prepareTestInstances({ flow: OAuthFlow.U2M });
+        const { oauthManager, oauthClient, authCode } = prepareTestInstances({ flow: OAuthFlow.U2M });
+        authCode.expectedScope = getExpectedScope([]);
 
         try {
           const token = new OAuthToken(createExpiredAccessToken());
@@ -235,7 +265,8 @@ class OAuthClientMock {
       });
 
       it('should throw an error for invalid token', async () => {
-        const { oauthManager, oauthClient } = prepareTestInstances({ flow: OAuthFlow.U2M });
+        const { oauthManager, oauthClient, authCode } = prepareTestInstances({ flow: OAuthFlow.U2M });
+        authCode.expectedScope = getExpectedScope([]);
 
         try {
           const token = new OAuthToken('invalid_access_token', 'invalid_refresh_token');
@@ -252,10 +283,12 @@ class OAuthClientMock {
       });
 
       it('should refresh expired token', async () => {
-        const { oauthManager, oauthClient } = prepareTestInstances({ flow: OAuthFlow.U2M });
+        const { oauthManager, oauthClient, authCode } = prepareTestInstances({ flow: OAuthFlow.U2M });
+        const requestedScopes = [OAuthScope.offlineAccess];
+        authCode.expectedScope = getExpectedScope(requestedScopes);
 
         oauthClient.accessToken = createExpiredAccessToken();
-        const token = await oauthManager.getToken([]);
+        const token = await oauthManager.getToken(requestedScopes);
         expect(token.hasExpired).to.be.true;
 
         const newToken = await oauthManager.refreshAccessToken(token);
@@ -266,7 +299,8 @@ class OAuthClientMock {
       });
 
       it('should throw an error if cannot refresh token', async () => {
-        const { oauthManager, oauthClient } = prepareTestInstances({ flow: OAuthFlow.U2M });
+        const { oauthManager, oauthClient, authCode } = prepareTestInstances({ flow: OAuthFlow.U2M });
+        authCode.expectedScope = getExpectedScope([]);
 
         oauthClient.refresh.restore();
         sinon.stub(oauthClient, 'refresh').returns({});
@@ -288,14 +322,27 @@ class OAuthClientMock {
     });
 
     describe('M2M flow', () => {
+      function getExpectedScope(scopes) {
+        switch (OAuthManagerClass) {
+          case DatabricksOAuthManager:
+            return [OAuthScope.allAPIs].join(scopeDelimiter);
+          case AzureOAuthManager:
+            const tenantId = AzureOAuthManager.datatricksAzureApp;
+            return [`${tenantId}/.default`, ...scopes].join(scopeDelimiter);
+        }
+        return undefined;
+      }
+
       it('should get access token', async () => {
         const { oauthManager, oauthClient } = prepareTestInstances({
           flow: OAuthFlow.M2M,
           clientId: 'test_client_id',
           clientSecret: 'test_client_secret',
         });
+        const requestedScopes = [OAuthScope.offlineAccess];
+        oauthClient.expectedScope = getExpectedScope(requestedScopes);
 
-        const token = await oauthManager.getToken([]);
+        const token = await oauthManager.getToken(requestedScopes);
         expect(oauthClient.grant.called).to.be.true;
         expect(token).to.be.instanceOf(OAuthToken);
         expect(token.accessToken).to.be.equal(oauthClient.accessToken);
@@ -308,13 +355,15 @@ class OAuthClientMock {
           clientId: 'test_client_id',
           clientSecret: 'test_client_secret',
         });
+        const requestedScopes = [OAuthScope.offlineAccess];
+        oauthClient.expectedScope = getExpectedScope(requestedScopes);
 
         // Make it return empty tokens
         oauthClient.accessToken = undefined;
         oauthClient.refreshToken = undefined;
 
         try {
-          await oauthManager.getToken([]);
+          await oauthManager.getToken(requestedScopes);
           expect.fail('It should throw an error');
         } catch (error) {
           if (error instanceof AssertionError) {
@@ -331,12 +380,14 @@ class OAuthClientMock {
           clientId: 'test_client_id',
           clientSecret: 'test_client_secret',
         });
+        const requestedScopes = [];
+        oauthClient.expectedScope = getExpectedScope(requestedScopes);
 
         const testError = new Error('Test');
         oauthClient.grantError = testError;
 
         try {
-          await oauthManager.getToken([]);
+          await oauthManager.getToken(requestedScopes);
           expect.fail('It should throw an error');
         } catch (error) {
           if (error instanceof AssertionError) {
@@ -353,6 +404,7 @@ class OAuthClientMock {
           clientId: 'test_client_id',
           clientSecret: 'test_client_secret',
         });
+        oauthClient.expectedScope = getExpectedScope([]);
 
         const token = new OAuthToken(createValidAccessToken());
         expect(token.hasExpired).to.be.false;
@@ -371,9 +423,11 @@ class OAuthClientMock {
           clientId: 'test_client_id',
           clientSecret: 'test_client_secret',
         });
+        const requestedScopes = [OAuthScope.offlineAccess];
+        oauthClient.expectedScope = getExpectedScope(requestedScopes);
 
         oauthClient.accessToken = createExpiredAccessToken();
-        const token = await oauthManager.getToken([]);
+        const token = await oauthManager.getToken(requestedScopes);
         expect(token.hasExpired).to.be.true;
 
         oauthClient.accessToken = createValidAccessToken();
@@ -391,9 +445,11 @@ class OAuthClientMock {
           clientId: 'test_client_id',
           clientSecret: 'test_client_secret',
         });
+        const requestedScopes = [OAuthScope.offlineAccess];
+        oauthClient.expectedScope = getExpectedScope(requestedScopes);
 
         oauthClient.accessToken = createExpiredAccessToken();
-        const token = await oauthManager.getToken([]);
+        const token = await oauthManager.getToken(requestedScopes);
         expect(token.hasExpired).to.be.true;
 
         oauthClient.grant.restore();

--- a/tests/unit/connection/auth/DatabricksOAuth/OAuthToken.test.js
+++ b/tests/unit/connection/auth/DatabricksOAuth/OAuthToken.test.js
@@ -7,6 +7,7 @@ describe('OAuthToken', () => {
   it('should be properly initialized', () => {
     const accessToken = 'access';
     const refreshToken = 'refresh';
+    const scopes = ['test'];
 
     const token1 = new OAuthToken(accessToken);
     expect(token1.accessToken).to.be.equal(accessToken);
@@ -14,6 +15,11 @@ describe('OAuthToken', () => {
     const token2 = new OAuthToken(accessToken, refreshToken);
     expect(token2.accessToken).to.be.equal(accessToken);
     expect(token2.refreshToken).to.be.equal(refreshToken);
+
+    const token3 = new OAuthToken(accessToken, refreshToken, scopes);
+    expect(token3.accessToken).to.be.equal(accessToken);
+    expect(token3.refreshToken).to.be.equal(refreshToken);
+    expect(token3.scopes).to.deep.equal(scopes);
   });
 
   it('should return valid expiration time', () => {


### PR DESCRIPTION
Fixes databricks/databricks-sql-nodejs#226

This PR also contains some preparation work/refactoring, and is easier to review commit by commit:

- explicitly define which flow to use (04011e451e8bd27844bc811327157acddc09a623). We still rely on presense of `clientSecret` option, but now this condition is moved all the way up to `DBSQLClient`. `OAuthManager` uses dedicated option to choose which flow to use
- when refreshing token, use the same scope as when getting the one (d587eb2a05b1409eb58967441dcc6ae3bb78f5db). U2M and M2M flows refresh token in a different way (M2M actually just obtains a new token). Previously we hard-coded scopes for M2M refresh, but, since Azure and In-House OAuth need different scopes, instead of adding one more hard-code we save token's scopes when obtaining one, and then use the same scope when "refreshing"
- fix Azure scopes for M2M flow (9f1c540b77965d4e30fb213c31c6f434af92a392)