### PR TITLE
Fix: proxy agent unintentionally overwrites protocol in URL

### DIFF
--- a/lib/connection/connections/HttpConnection.ts
+++ b/lib/connection/connections/HttpConnection.ts
@@ -82,14 +82,11 @@ export default class HttpConnection implements IConnectionProvider {
       : '';
     const proxyUrl = `${proxyOptions.protocol}://${proxyAuth}${proxyOptions.host}:${proxyOptions.port}`;
 
-    const proxyProtocol = `${proxyOptions.protocol}:`;
-
     return new ProxyAgent({
       ...this.getAgentDefaultOptions(),
       getProxyForUrl: () => proxyUrl,
       httpsAgent: this.createHttpsAgent(),
       httpAgent: this.createHttpAgent(),
-      protocol: proxyProtocol,
     });
   }
 

--- a/tests/e2e/proxy.test.js
+++ b/tests/e2e/proxy.test.js
@@ -50,6 +50,17 @@ describe('Proxy', () => {
     const proxy = new HttpProxyMock(`https://${config.host}`, 9090);
     try {
       const client = new DBSQLClient();
+
+      // Our proxy mock is HTTP -> HTTPS, but DBSQLClient is hard-coded to use HTTPS.
+      // Here we override default behavior to make DBSQLClient work with HTTP proxy
+      const originalGetConnectionOptions = client.getConnectionOptions;
+      client.getConnectionOptions = (...args) => {
+        const result = originalGetConnectionOptions.apply(client, args);
+        result.https = false;
+        result.port = 80;
+        return result;
+      };
+
       const clientConfig = client.getConfig();
       sinon.stub(client, 'getConfig').returns(clientConfig);
 


### PR DESCRIPTION
Fixes databricks/databricks-sql-nodejs#237

A proxy agent was configured to use a protocol of proxy itself as a protocol for proxy target. In some cases this causes an unintentional modification of target URLs - see https://github.com/databricks/databricks-sql-nodejs/issues/237#issuecomment-2037248591

I don't actually remember why I used that option, maybe I didn't fully understood its impact.