### PR TITLE
refactor(polyfills): do not raise a Assignment call unless needed.

### DIFF
--- a/lib/polyfills.ts
+++ b/lib/polyfills.ts
@@ -46,8 +46,7 @@ const ArrayConstructors = [
 ];
 
 ArrayConstructors.forEach((ArrayConstructor) => {
-  if (!Object.prototype.hasOwnProperty.call(ArrayConstructor, "at")) {
+  if (!Object.prototype.hasOwnProperty.call(ArrayConstructor, 'at')) {
     ArrayConstructor.prototype.at = at;
   }
 });
-

--- a/lib/polyfills.ts
+++ b/lib/polyfills.ts
@@ -46,5 +46,8 @@ const ArrayConstructors = [
 ];
 
 ArrayConstructors.forEach((ArrayConstructor) => {
-  ArrayConstructor.prototype.at = ArrayConstructor.prototype.at ?? at;
+  if (!Object.prototype.hasOwnProperty.call(ArrayConstructor, "at")) {
+    ArrayConstructor.prototype.at = at;
+  }
 });
+


### PR DESCRIPTION
I understand the need for the polyfill, but for various security reasons a few production projects `freeze` the ability to modify the constructors so this basically triggers an assignment even when it's not needed and the `freeze` cause a failure. 

Let me know if there's other considerations that you'd like to take for this