### PR TITLE
fix(#244): Error When Freezing Array.prototype

### DIFF
--- a/lib/polyfills.ts
+++ b/lib/polyfills.ts
@@ -46,5 +46,8 @@ const ArrayConstructors = [
 ];
 
 ArrayConstructors.forEach((ArrayConstructor) => {
-  ArrayConstructor.prototype.at = ArrayConstructor.prototype.at ?? at;
+    if (!ArrayConstructor.prototype.at) {
+        var _a;
+        ArrayConstructor.prototype.at = (_a = ArrayConstructor.prototype.at) !== null && _a !== void 0 ? _a : at;
+    }
 });


### PR DESCRIPTION
In a particular file, the `Array.prototype` is being frozen which is causing compatibility issues. The issue arises when the `at` method is added to the `Array.prototype` after it has been frozen, resulting in an error.

Steps to reproduce:
1. Run the application.
2. Observe the error related to the `at` method.

Expected behavior:
The application should run without errors.

Actual behavior:
An error occurs when running the application due to the `Array.prototype` being frozen before the `at` method is added.

Proposed solution:
Modify the code to conditionally add the `at` method to the `Array.prototype` only if it doesn't already exist.