### PR TITLE
UC Volume ingestion: uniform behavior on SQL `REMOVE`

### DIFF
--- a/lib/DBSQLSession.ts
+++ b/lib/DBSQLSession.ts
@@ -280,11 +280,14 @@ export default class DBSQLSession implements IDBSQLSession {
     const agent = await connectionProvider.getAgent();
 
     const response = await fetch(presignedUrl, { method: 'DELETE', headers, agent });
-    // Looks that AWS and Azure have a different behavior of HTTP `DELETE` for non-existing files
-    // AWS assumes that - since file already doesn't exist - the goal is achieved, and returns HTTP 200
+    // Looks that AWS and Azure have a different behavior of HTTP `DELETE` for non-existing files.
+    // AWS assumes that - since file already doesn't exist - the goal is achieved, and returns HTTP 200.
     // Azure, on the other hand, is somewhat stricter and check if file exists before deleting it. And if
-    // file doesn't exist - Azure returns HTTP 404
-    if (!response.ok) {
+    // file doesn't exist - Azure returns HTTP 404.
+    //
+    // For us, it's totally okay if file didn't exist before removing. So when we get an HTTP 404 -
+    // just ignore it and report success. This way we can have a uniform library behavior for all clouds
+    if (!response.ok && response.status !== 404) {
       throw new StagingError(`HTTP error ${response.status} ${response.statusText}`);
     }
   }


### PR DESCRIPTION
Looks that AWS and Azure have a different behavior of HTTP `DELETE` for non-existing files.
AWS assumes that - since file already doesn't exist - the goal is achieved, and returns HTTP 200.
Azure, on the other hand, is somewhat stricter and check if file exists before deleting it. And if
file doesn't exist - Azure returns HTTP 404.

For us, it's totally okay if file didn't exist before removing. So when we get an HTTP 404 -
just ignore it and report success. This way we can have a uniform library behavior for all clouds