### PR TITLE
Fix polyfill

### DIFF
--- a/lib/polyfills.ts
+++ b/lib/polyfills.ts
@@ -46,7 +46,7 @@ const ArrayConstructors = [
 ];
 
 ArrayConstructors.forEach((ArrayConstructor) => {
-  if (!Object.prototype.hasOwnProperty.call(ArrayConstructor, 'at')) {
+  if (typeof ArrayConstructor.prototype.at !== 'function') {
     ArrayConstructor.prototype.at = at;
   }
 });


### PR DESCRIPTION
Change condition in polyfill. `hasOwnProperty` still returns `true` if property is available but its value is `undefined`. Also, the condition contained typo. Instead, explicitly check if `ArrayConstructor.prototype.at` is a function.