### PR TITLE
[PECO-1390] Configure Typescript for tests

### DIFF
--- a/nyc.config.js
+++ b/nyc.config.js
@@ -1,5 +1,9 @@
 'use strict';
 
 module.exports = {
+  require: ['ts-node/register'],
+  reporter: ['lcov'],
+  all: true,
+  include: ['lib/**'],
   exclude: ['thrift/**', 'tests/**'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,9 @@
         "winston": "^3.8.2"
       },
       "devDependencies": {
+        "@types/chai": "^4.3.14",
         "@types/lz4": "^0.6.4",
+        "@types/mocha": "^10.0.6",
         "@types/node": "^18.11.9",
         "@types/node-fetch": "^2.6.4",
         "@types/node-int64": "^0.4.29",
@@ -43,6 +45,7 @@
         "nyc": "^15.1.0",
         "prettier": "^2.8.4",
         "sinon": "^14.0.0",
+        "ts-node": "^10.9.2",
         "typescript": "^4.9.3"
       },
       "engines": {
@@ -591,6 +594,28 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@dabh/diagnostics": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
@@ -881,6 +906,36 @@
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
+    },
+    "node_modules/@types/chai": {
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.14.tgz",
+      "integrity": "sha512-Wj71sXE4Q4AkGdG9Tvq1u/fquNz9EdG4LIJMwVVII7ashjD/8cf8fyIfJAjRr6YcsXnSE8cOGQPq1gqeR8z+3w==",
+      "dev": true
+    },
     "node_modules/@types/command-line-args": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.0.tgz",
@@ -911,6 +966,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/mocha": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
+      "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "18.11.18",
@@ -1179,6 +1240,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
@@ -1310,6 +1380,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
+      "dev": true
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true
     },
     "node_modules/argparse": {
@@ -1927,6 +2003,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
       }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -4134,6 +4216,12 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -5765,6 +5853,58 @@
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
       "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -5957,6 +6097,12 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
     "node_modules/webidl-conversions": {
@@ -6197,6 +6343,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {
@@ -6633,6 +6788,27 @@
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
     },
+    "@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "dependencies": {
+        "@jridgewell/trace-mapping": {
+          "version": "0.3.9",
+          "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+          "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/resolve-uri": "^3.0.3",
+            "@jridgewell/sourcemap-codec": "^1.4.10"
+          }
+        }
+      }
+    },
     "@dabh/diagnostics": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
@@ -6870,6 +7046,36 @@
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="
     },
+    "@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
+    },
+    "@types/chai": {
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.14.tgz",
+      "integrity": "sha512-Wj71sXE4Q4AkGdG9Tvq1u/fquNz9EdG4LIJMwVVII7ashjD/8cf8fyIfJAjRr6YcsXnSE8cOGQPq1gqeR8z+3w==",
+      "dev": true
+    },
     "@types/command-line-args": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.0.tgz",
@@ -6900,6 +7106,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/mocha": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
+      "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
+      "dev": true
     },
     "@types/node": {
       "version": "18.11.18",
@@ -7071,6 +7283,12 @@
       "dev": true,
       "requires": {}
     },
+    "acorn-walk": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
+      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
+      "dev": true
+    },
     "agent-base": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
@@ -7173,6 +7391,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
+      "dev": true
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true
     },
     "argparse": {
@@ -7625,6 +7849,12 @@
       "version": "3.24.1",
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.24.1.tgz",
       "integrity": "sha512-r1nJk41QLLPyozHUUPmILCEMtMw24NG4oWK6RbsDdjzQgg9ZvrUsPBj1MnG0wXXp1DCDU6j+wUvEmBSrtRbLXg==",
+      "dev": true
+    },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
     "cross-spawn": {
@@ -9245,6 +9475,12 @@
         }
       }
     },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -10452,6 +10688,35 @@
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
       "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
+    "ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        }
+      }
+    },
     "tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -10587,6 +10852,12 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
+    },
+    "v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
     },
     "webidl-conversions": {
@@ -10779,6 +11050,12 @@
           "dev": true
         }
       }
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
   ],
   "license": "Apache 2.0",
   "devDependencies": {
+    "@types/chai": "^4.3.14",
     "@types/lz4": "^0.6.4",
+    "@types/mocha": "^10.0.6",
     "@types/node": "^18.11.9",
     "@types/node-fetch": "^2.6.4",
     "@types/node-int64": "^0.4.29",
@@ -69,6 +71,7 @@
     "nyc": "^15.1.0",
     "prettier": "^2.8.4",
     "sinon": "^14.0.0",
+    "ts-node": "^10.9.2",
     "typescript": "^4.9.3"
   },
   "dependencies": {

--- a/tests/e2e/arrow.test.js
+++ b/tests/e2e/arrow.test.js
@@ -2,10 +2,10 @@ const { expect } = require('chai');
 const sinon = require('sinon');
 const config = require('./utils/config');
 const logger = require('./utils/logger')(config.logger);
-const { DBSQLClient } = require('../..');
-const ArrowResultHandler = require('../../dist/result/ArrowResultHandler').default;
-const ArrowResultConverter = require('../../dist/result/ArrowResultConverter').default;
-const ResultSlicer = require('../../dist/result/ResultSlicer').default;
+const { DBSQLClient } = require('../../lib');
+const ArrowResultHandler = require('../../lib/result/ArrowResultHandler').default;
+const ArrowResultConverter = require('../../lib/result/ArrowResultConverter').default;
+const ResultSlicer = require('../../lib/result/ResultSlicer').default;
 
 const fixtures = require('../fixtures/compatibility');
 const { expected: expectedColumn } = require('../fixtures/compatibility/column');

--- a/tests/e2e/batched_fetch.test.js
+++ b/tests/e2e/batched_fetch.test.js
@@ -2,7 +2,7 @@ const { expect } = require('chai');
 const sinon = require('sinon');
 const config = require('./utils/config');
 const logger = require('./utils/logger')(config.logger);
-const { DBSQLClient } = require('../..');
+const { DBSQLClient } = require('../../lib');
 
 async function openSession(customConfig) {
   const client = new DBSQLClient();

--- a/tests/e2e/cloudfetch.test.js
+++ b/tests/e2e/cloudfetch.test.js
@@ -1,10 +1,10 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 const config = require('./utils/config');
-const { DBSQLClient } = require('../..');
-const CloudFetchResultHandler = require('../../dist/result/CloudFetchResultHandler').default;
-const ArrowResultConverter = require('../../dist/result/ArrowResultConverter').default;
-const ResultSlicer = require('../../dist/result/ResultSlicer').default;
+const { DBSQLClient } = require('../../lib');
+const CloudFetchResultHandler = require('../../lib/result/CloudFetchResultHandler').default;
+const ArrowResultConverter = require('../../lib/result/ArrowResultConverter').default;
+const ResultSlicer = require('../../lib/result/ResultSlicer').default;
 
 async function openSession(customConfig) {
   const client = new DBSQLClient();

--- a/tests/e2e/data_types.test.js
+++ b/tests/e2e/data_types.test.js
@@ -2,7 +2,7 @@ const { expect } = require('chai');
 const sinon = require('sinon');
 const config = require('./utils/config');
 const logger = require('./utils/logger')(config.logger);
-const { DBSQLClient } = require('../..');
+const { DBSQLClient } = require('../../lib');
 
 async function openSession(customConfig) {
   const client = new DBSQLClient();

--- a/tests/e2e/proxy.test.js
+++ b/tests/e2e/proxy.test.js
@@ -3,7 +3,7 @@ const sinon = require('sinon');
 const httpProxy = require('http-proxy');
 const https = require('https');
 const config = require('./utils/config');
-const { DBSQLClient } = require('../..');
+const { DBSQLClient } = require('../../lib');
 
 class HttpProxyMock {
   constructor(target, port) {

--- a/tests/e2e/query_parameters.test.js
+++ b/tests/e2e/query_parameters.test.js
@@ -1,8 +1,8 @@
 const { expect, AssertionError } = require('chai');
 const Int64 = require('node-int64');
 const config = require('./utils/config');
-const { DBSQLClient, DBSQLParameter, DBSQLParameterType } = require('../..');
-const ParameterError = require('../../dist/errors/ParameterError').default;
+const { DBSQLClient, DBSQLParameter, DBSQLParameterType } = require('../../lib');
+const ParameterError = require('../../lib/errors/ParameterError').default;
 
 const openSession = async () => {
   const client = new DBSQLClient();

--- a/tests/e2e/staging_ingestion.test.js
+++ b/tests/e2e/staging_ingestion.test.js
@@ -4,8 +4,8 @@ const path = require('path');
 const os = require('os');
 const uuid = require('uuid');
 const config = require('./utils/config');
-const { DBSQLClient } = require('../..');
-const StagingError = require('../../dist/errors/StagingError').default;
+const { DBSQLClient } = require('../../lib');
+const StagingError = require('../../lib/errors/StagingError').default;
 
 describe('Staging Test', () => {
   const catalog = config.database[0];

--- a/tests/e2e/timeouts.test.js
+++ b/tests/e2e/timeouts.test.js
@@ -1,7 +1,7 @@
 const { expect, AssertionError } = require('chai');
 const sinon = require('sinon');
 const config = require('./utils/config');
-const { DBSQLClient } = require('../..');
+const { DBSQLClient } = require('../../lib');
 
 async function openSession(socketTimeout, customConfig) {
   const client = new DBSQLClient();

--- a/tests/unit/DBSQLClient.test.js
+++ b/tests/unit/DBSQLClient.test.js
@@ -1,16 +1,13 @@
 const { expect, AssertionError } = require('chai');
 const sinon = require('sinon');
-const DBSQLClient = require('../../dist/DBSQLClient').default;
-const DBSQLSession = require('../../dist/DBSQLSession').default;
+const DBSQLClient = require('../../lib/DBSQLClient').default;
+const DBSQLSession = require('../../lib/DBSQLSession').default;
 
-const PlainHttpAuthentication = require('../../dist/connection/auth/PlainHttpAuthentication').default;
-const DatabricksOAuth = require('../../dist/connection/auth/DatabricksOAuth').default;
-const {
-  DatabricksOAuthManager,
-  AzureOAuthManager,
-} = require('../../dist/connection/auth/DatabricksOAuth/OAuthManager');
+const PlainHttpAuthentication = require('../../lib/connection/auth/PlainHttpAuthentication').default;
+const DatabricksOAuth = require('../../lib/connection/auth/DatabricksOAuth').default;
+const { DatabricksOAuthManager, AzureOAuthManager } = require('../../lib/connection/auth/DatabricksOAuth/OAuthManager');
 
-const HttpConnectionModule = require('../../dist/connection/connections/HttpConnection');
+const HttpConnectionModule = require('../../lib/connection/connections/HttpConnection');
 
 const { default: HttpConnection } = HttpConnectionModule;
 

--- a/tests/unit/DBSQLOperation.test.js
+++ b/tests/unit/DBSQLOperation.test.js
@@ -1,16 +1,16 @@
 const { expect, AssertionError } = require('chai');
 const sinon = require('sinon');
-const { DBSQLLogger, LogLevel } = require('../../dist');
+const { DBSQLLogger, LogLevel } = require('../../lib');
 const { TStatusCode, TOperationState, TTypeId, TSparkRowSetType } = require('../../thrift/TCLIService_types');
-const DBSQLOperation = require('../../dist/DBSQLOperation').default;
-const StatusError = require('../../dist/errors/StatusError').default;
-const OperationStateError = require('../../dist/errors/OperationStateError').default;
-const HiveDriverError = require('../../dist/errors/HiveDriverError').default;
-const JsonResultHandler = require('../../dist/result/JsonResultHandler').default;
-const ArrowResultConverter = require('../../dist/result/ArrowResultConverter').default;
-const ArrowResultHandler = require('../../dist/result/ArrowResultHandler').default;
-const CloudFetchResultHandler = require('../../dist/result/CloudFetchResultHandler').default;
-const ResultSlicer = require('../../dist/result/ResultSlicer').default;
+const DBSQLOperation = require('../../lib/DBSQLOperation').default;
+const StatusError = require('../../lib/errors/StatusError').default;
+const OperationStateError = require('../../lib/errors/OperationStateError').default;
+const HiveDriverError = require('../../lib/errors/HiveDriverError').default;
+const JsonResultHandler = require('../../lib/result/JsonResultHandler').default;
+const ArrowResultConverter = require('../../lib/result/ArrowResultConverter').default;
+const ArrowResultHandler = require('../../lib/result/ArrowResultHandler').default;
+const CloudFetchResultHandler = require('../../lib/result/CloudFetchResultHandler').default;
+const ResultSlicer = require('../../lib/result/ResultSlicer').default;
 
 class OperationHandleMock {
   constructor(hasResultSet = true) {

--- a/tests/unit/DBSQLParameter.test.js
+++ b/tests/unit/DBSQLParameter.test.js
@@ -2,7 +2,7 @@ const { expect } = require('chai');
 
 const Int64 = require('node-int64');
 const { TSparkParameterValue, TSparkParameter } = require('../../thrift/TCLIService_types');
-const { DBSQLParameter, DBSQLParameterType } = require('../../dist/DBSQLParameter');
+const { DBSQLParameter, DBSQLParameterType } = require('../../lib/DBSQLParameter');
 
 describe('DBSQLParameter', () => {
   it('should infer types correctly', () => {

--- a/tests/unit/DBSQLSession.test.js
+++ b/tests/unit/DBSQLSession.test.js
@@ -1,12 +1,12 @@
 const { expect, AssertionError } = require('chai');
-const { DBSQLLogger, LogLevel } = require('../../dist');
+const { DBSQLLogger, LogLevel } = require('../../lib');
 const sinon = require('sinon');
-const DBSQLSession = require('../../dist/DBSQLSession').default;
-const InfoValue = require('../../dist/dto/InfoValue').default;
-const Status = require('../../dist/dto/Status').default;
-const DBSQLOperation = require('../../dist/DBSQLOperation').default;
-const HiveDriver = require('../../dist/hive/HiveDriver').default;
-const DBSQLClient = require('../../dist/DBSQLClient').default;
+const DBSQLSession = require('../../lib/DBSQLSession').default;
+const InfoValue = require('../../lib/dto/InfoValue').default;
+const Status = require('../../lib/dto/Status').default;
+const DBSQLOperation = require('../../lib/DBSQLOperation').default;
+const HiveDriver = require('../../lib/hive/HiveDriver').default;
+const DBSQLClient = require('../../lib/DBSQLClient').default;
 
 // Create logger that won't emit
 //

--- a/tests/unit/connection/auth/DatabricksOAuth/AuthorizationCode.test.js
+++ b/tests/unit/connection/auth/DatabricksOAuth/AuthorizationCode.test.js
@@ -2,8 +2,8 @@ const { expect, AssertionError } = require('chai');
 const { EventEmitter } = require('events');
 const sinon = require('sinon');
 const http = require('http');
-const { DBSQLLogger, LogLevel } = require('../../../../../dist');
-const AuthorizationCode = require('../../../../../dist/connection/auth/DatabricksOAuth/AuthorizationCode').default;
+const { DBSQLLogger, LogLevel } = require('../../../../../lib');
+const AuthorizationCode = require('../../../../../lib/connection/auth/DatabricksOAuth/AuthorizationCode').default;
 
 const logger = new DBSQLLogger({ level: LogLevel.error });
 

--- a/tests/unit/connection/auth/DatabricksOAuth/OAuthManager.test.js
+++ b/tests/unit/connection/auth/DatabricksOAuth/OAuthManager.test.js
@@ -1,15 +1,15 @@
 const { expect, AssertionError } = require('chai');
 const sinon = require('sinon');
 const openidClientLib = require('openid-client');
-const { DBSQLLogger, LogLevel } = require('../../../../../dist');
+const { DBSQLLogger, LogLevel } = require('../../../../../lib');
 const {
   DatabricksOAuthManager,
   AzureOAuthManager,
   OAuthFlow,
-} = require('../../../../../dist/connection/auth/DatabricksOAuth/OAuthManager');
-const OAuthToken = require('../../../../../dist/connection/auth/DatabricksOAuth/OAuthToken').default;
-const { OAuthScope, scopeDelimiter } = require('../../../../../dist/connection/auth/DatabricksOAuth/OAuthScope');
-const AuthorizationCodeModule = require('../../../../../dist/connection/auth/DatabricksOAuth/AuthorizationCode');
+} = require('../../../../../lib/connection/auth/DatabricksOAuth/OAuthManager');
+const OAuthToken = require('../../../../../lib/connection/auth/DatabricksOAuth/OAuthToken').default;
+const { OAuthScope, scopeDelimiter } = require('../../../../../lib/connection/auth/DatabricksOAuth/OAuthScope');
+const AuthorizationCodeModule = require('../../../../../lib/connection/auth/DatabricksOAuth/AuthorizationCode');
 
 const { createValidAccessToken, createExpiredAccessToken } = require('./utils');
 

--- a/tests/unit/connection/auth/DatabricksOAuth/OAuthToken.test.js
+++ b/tests/unit/connection/auth/DatabricksOAuth/OAuthToken.test.js
@@ -1,5 +1,5 @@
 const { expect } = require('chai');
-const OAuthToken = require('../../../../../dist/connection/auth/DatabricksOAuth/OAuthToken').default;
+const OAuthToken = require('../../../../../lib/connection/auth/DatabricksOAuth/OAuthToken').default;
 
 const { createAccessToken } = require('./utils');
 

--- a/tests/unit/connection/auth/DatabricksOAuth/index.test.js
+++ b/tests/unit/connection/auth/DatabricksOAuth/index.test.js
@@ -1,8 +1,8 @@
 const { expect, AssertionError } = require('chai');
 const sinon = require('sinon');
-const DatabricksOAuth = require('../../../../../dist/connection/auth/DatabricksOAuth/index').default;
-const OAuthToken = require('../../../../../dist/connection/auth/DatabricksOAuth/OAuthToken').default;
-const OAuthManager = require('../../../../../dist/connection/auth/DatabricksOAuth/OAuthManager').default;
+const DatabricksOAuth = require('../../../../../lib/connection/auth/DatabricksOAuth/index').default;
+const OAuthToken = require('../../../../../lib/connection/auth/DatabricksOAuth/OAuthToken').default;
+const OAuthManager = require('../../../../../lib/connection/auth/DatabricksOAuth/OAuthManager').default;
 
 const { createValidAccessToken, createExpiredAccessToken } = require('./utils');
 

--- a/tests/unit/connection/auth/PlainHttpAuthentication.test.js
+++ b/tests/unit/connection/auth/PlainHttpAuthentication.test.js
@@ -1,5 +1,5 @@
 const { expect } = require('chai');
-const PlainHttpAuthentication = require('../../../../dist/connection/auth/PlainHttpAuthentication').default;
+const PlainHttpAuthentication = require('../../../../lib/connection/auth/PlainHttpAuthentication').default;
 
 describe('PlainHttpAuthentication', () => {
   it('username and password must be anonymous if nothing passed', () => {

--- a/tests/unit/connection/connections/HttpConnection.test.js
+++ b/tests/unit/connection/connections/HttpConnection.test.js
@@ -1,8 +1,8 @@
 const http = require('http');
 const { expect } = require('chai');
-const HttpConnection = require('../../../../dist/connection/connections/HttpConnection').default;
-const ThriftHttpConnection = require('../../../../dist/connection/connections/ThriftHttpConnection').default;
-const DBSQLClient = require('../../../../dist/DBSQLClient').default;
+const HttpConnection = require('../../../../lib/connection/connections/HttpConnection').default;
+const ThriftHttpConnection = require('../../../../lib/connection/connections/ThriftHttpConnection').default;
+const DBSQLClient = require('../../../../lib/DBSQLClient').default;
 
 describe('HttpConnection.connect', () => {
   it('should create Thrift connection', async () => {

--- a/tests/unit/connection/connections/HttpRetryPolicy.test.js
+++ b/tests/unit/connection/connections/HttpRetryPolicy.test.js
@@ -1,9 +1,9 @@
 const { expect, AssertionError } = require('chai');
 const sinon = require('sinon');
 const { Request, Response } = require('node-fetch');
-const HttpRetryPolicy = require('../../../../dist/connection/connections/HttpRetryPolicy').default;
-const { default: RetryError, RetryErrorCode } = require('../../../../dist/errors/RetryError');
-const DBSQLClient = require('../../../../dist/DBSQLClient').default;
+const HttpRetryPolicy = require('../../../../lib/connection/connections/HttpRetryPolicy').default;
+const { default: RetryError, RetryErrorCode } = require('../../../../lib/errors/RetryError');
+const DBSQLClient = require('../../../../lib/DBSQLClient').default;
 
 class ClientContextMock {
   constructor(configOverrides) {

--- a/tests/unit/connection/connections/NullRetryPolicy.test.js
+++ b/tests/unit/connection/connections/NullRetryPolicy.test.js
@@ -1,6 +1,6 @@
 const { expect, AssertionError } = require('chai');
 const sinon = require('sinon');
-const NullRetryPolicy = require('../../../../dist/connection/connections/NullRetryPolicy').default;
+const NullRetryPolicy = require('../../../../lib/connection/connections/NullRetryPolicy').default;
 
 describe('NullRetryPolicy', () => {
   it('should never allow retries', async () => {

--- a/tests/unit/dto/InfoValue.test.js
+++ b/tests/unit/dto/InfoValue.test.js
@@ -1,5 +1,5 @@
 const { expect } = require('chai');
-const InfoValue = require('../../../dist/dto/InfoValue').default;
+const InfoValue = require('../../../lib/dto/InfoValue').default;
 const NodeInt64 = require('node-int64');
 
 const createInfoValueMock = (value) =>

--- a/tests/unit/dto/Status.test.js
+++ b/tests/unit/dto/Status.test.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
-const { TCLIService_types } = require('../../../').thrift;
-const Status = require('../../../dist/dto/Status').default;
+const { TCLIService_types } = require('../../../lib').thrift;
+const Status = require('../../../lib/dto/Status').default;
 
 describe('StatusFactory', () => {
   it('should be success', () => {

--- a/tests/unit/hive/HiveDriver.test.js
+++ b/tests/unit/hive/HiveDriver.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
-const { TCLIService_types } = require('../../../').thrift;
-const HiveDriver = require('../../../dist/hive/HiveDriver').default;
+const { TCLIService_types } = require('../../../lib').thrift;
+const HiveDriver = require('../../../lib/hive/HiveDriver').default;
 
 const toTitleCase = (str) => str[0].toUpperCase() + str.slice(1);
 

--- a/tests/unit/hive/commands/BaseCommand.test.js
+++ b/tests/unit/hive/commands/BaseCommand.test.js
@@ -1,10 +1,10 @@
 const { expect, AssertionError } = require('chai');
 const { Request, Response } = require('node-fetch');
 const { Thrift } = require('thrift');
-const HiveDriverError = require('../../../../dist/errors/HiveDriverError').default;
-const BaseCommand = require('../../../../dist/hive/Commands/BaseCommand').default;
-const HttpRetryPolicy = require('../../../../dist/connection/connections/HttpRetryPolicy').default;
-const DBSQLClient = require('../../../../dist/DBSQLClient').default;
+const HiveDriverError = require('../../../../lib/errors/HiveDriverError').default;
+const BaseCommand = require('../../../../lib/hive/Commands/BaseCommand').default;
+const HttpRetryPolicy = require('../../../../lib/connection/connections/HttpRetryPolicy').default;
+const DBSQLClient = require('../../../../lib/DBSQLClient').default;
 
 class ThriftClientMock {
   constructor(context, methodHandler) {

--- a/tests/unit/hive/commands/CancelDelegationTokenCommand.test.js
+++ b/tests/unit/hive/commands/CancelDelegationTokenCommand.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 const TCLIService_types = require('../../../../thrift/TCLIService_types');
-const CancelDelegationTokenCommand = require('../../../../dist/hive/Commands/CancelDelegationTokenCommand').default;
+const CancelDelegationTokenCommand = require('../../../../lib/hive/Commands/CancelDelegationTokenCommand').default;
 
 const requestMock = {
   sessionHandle: {

--- a/tests/unit/hive/commands/CancelOperationCommand.test.js
+++ b/tests/unit/hive/commands/CancelOperationCommand.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 const TCLIService_types = require('../../../../thrift/TCLIService_types');
-const CancelOperationCommand = require('../../../../dist/hive/Commands/CancelOperationCommand').default;
+const CancelOperationCommand = require('../../../../lib/hive/Commands/CancelOperationCommand').default;
 
 const requestMock = {
   operationHandle: {

--- a/tests/unit/hive/commands/CloseOperationCommand.test.js
+++ b/tests/unit/hive/commands/CloseOperationCommand.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 const TCLIService_types = require('../../../../thrift/TCLIService_types');
-const CloseOperationCommand = require('../../../../dist/hive/Commands/CloseOperationCommand').default;
+const CloseOperationCommand = require('../../../../lib/hive/Commands/CloseOperationCommand').default;
 
 const requestMock = {
   operationHandle: {

--- a/tests/unit/hive/commands/CloseSessionCommand.test.js
+++ b/tests/unit/hive/commands/CloseSessionCommand.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 const TCLIService_types = require('../../../../thrift/TCLIService_types');
-const CloseSessionCommand = require('../../../../dist/hive/Commands/CloseSessionCommand').default;
+const CloseSessionCommand = require('../../../../lib/hive/Commands/CloseSessionCommand').default;
 
 const responseMock = {
   status: { statusCode: 0 },

--- a/tests/unit/hive/commands/ExecuteStatementCommand.test.js
+++ b/tests/unit/hive/commands/ExecuteStatementCommand.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 const TCLIService_types = require('../../../../thrift/TCLIService_types');
-const ExecuteStatementCommand = require('../../../../dist/hive/Commands/ExecuteStatementCommand').default;
+const ExecuteStatementCommand = require('../../../../lib/hive/Commands/ExecuteStatementCommand').default;
 
 const requestMock = {
   sessionHandle: {

--- a/tests/unit/hive/commands/FetchResultsCommand.test.js
+++ b/tests/unit/hive/commands/FetchResultsCommand.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 const TCLIService_types = require('../../../../thrift/TCLIService_types');
-const FetchResultsCommand = require('../../../../dist/hive/Commands/FetchResultsCommand').default;
+const FetchResultsCommand = require('../../../../lib/hive/Commands/FetchResultsCommand').default;
 
 const requestMock = {
   operationHandle: {

--- a/tests/unit/hive/commands/GetCatalogsCommand.test.js
+++ b/tests/unit/hive/commands/GetCatalogsCommand.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 const TCLIService_types = require('../../../../thrift/TCLIService_types');
-const GetCatalogsCommand = require('../../../../dist/hive/Commands/GetCatalogsCommand').default;
+const GetCatalogsCommand = require('../../../../lib/hive/Commands/GetCatalogsCommand').default;
 
 const requestMock = {
   sessionHandle: {

--- a/tests/unit/hive/commands/GetColumnsCommand.test.js
+++ b/tests/unit/hive/commands/GetColumnsCommand.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 const TCLIService_types = require('../../../../thrift/TCLIService_types');
-const GetColumnsCommand = require('../../../../dist/hive/Commands/GetColumnsCommand').default;
+const GetColumnsCommand = require('../../../../lib/hive/Commands/GetColumnsCommand').default;
 
 const requestMock = {
   sessionHandle: {

--- a/tests/unit/hive/commands/GetCrossReferenceCommand.test.js
+++ b/tests/unit/hive/commands/GetCrossReferenceCommand.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 const TCLIService_types = require('../../../../thrift/TCLIService_types');
-const GetCrossReferenceCommand = require('../../../../dist/hive/Commands/GetCrossReferenceCommand').default;
+const GetCrossReferenceCommand = require('../../../../lib/hive/Commands/GetCrossReferenceCommand').default;
 
 const requestMock = {
   sessionHandle: {

--- a/tests/unit/hive/commands/GetDelegationTokenCommand.test.js
+++ b/tests/unit/hive/commands/GetDelegationTokenCommand.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 const TCLIService_types = require('../../../../thrift/TCLIService_types');
-const GetDelegationTokenCommand = require('../../../../dist/hive/Commands/GetDelegationTokenCommand').default;
+const GetDelegationTokenCommand = require('../../../../lib/hive/Commands/GetDelegationTokenCommand').default;
 
 const requestMock = {
   sessionHandle: {

--- a/tests/unit/hive/commands/GetFunctionsCommand.test.js
+++ b/tests/unit/hive/commands/GetFunctionsCommand.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 const TCLIService_types = require('../../../../thrift/TCLIService_types');
-const GetFunctionsCommand = require('../../../../dist/hive/Commands/GetFunctionsCommand').default;
+const GetFunctionsCommand = require('../../../../lib/hive/Commands/GetFunctionsCommand').default;
 
 const requestMock = {
   sessionHandle: {

--- a/tests/unit/hive/commands/GetInfoCommand.test.js
+++ b/tests/unit/hive/commands/GetInfoCommand.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 const TCLIService_types = require('../../../../thrift/TCLIService_types');
-const GetInfoCommand = require('../../../../dist/hive/Commands/GetInfoCommand').default;
+const GetInfoCommand = require('../../../../lib/hive/Commands/GetInfoCommand').default;
 
 const requestMock = {
   sessionHandle: {

--- a/tests/unit/hive/commands/GetOperationStatusCommand.test.js
+++ b/tests/unit/hive/commands/GetOperationStatusCommand.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 const TCLIService_types = require('../../../../thrift/TCLIService_types');
-const GetOperationStatusCommand = require('../../../../dist/hive/Commands/GetOperationStatusCommand').default;
+const GetOperationStatusCommand = require('../../../../lib/hive/Commands/GetOperationStatusCommand').default;
 
 const requestMock = {
   operationHandle: {

--- a/tests/unit/hive/commands/GetPrimaryKeysCommand.test.js
+++ b/tests/unit/hive/commands/GetPrimaryKeysCommand.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 const TCLIService_types = require('../../../../thrift/TCLIService_types');
-const GetPrimaryKeysCommand = require('../../../../dist/hive/Commands/GetPrimaryKeysCommand').default;
+const GetPrimaryKeysCommand = require('../../../../lib/hive/Commands/GetPrimaryKeysCommand').default;
 
 const requestMock = {
   sessionHandle: {

--- a/tests/unit/hive/commands/GetResultSetMetadataCommand.test.js
+++ b/tests/unit/hive/commands/GetResultSetMetadataCommand.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 const TCLIService_types = require('../../../../thrift/TCLIService_types');
-const GetResultSetMetadataCommand = require('../../../../dist/hive/Commands/GetResultSetMetadataCommand').default;
+const GetResultSetMetadataCommand = require('../../../../lib/hive/Commands/GetResultSetMetadataCommand').default;
 
 const requestMock = {
   operationHandle: {

--- a/tests/unit/hive/commands/GetSchemasCommand.test.js
+++ b/tests/unit/hive/commands/GetSchemasCommand.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 const TCLIService_types = require('../../../../thrift/TCLIService_types');
-const GetSchemasCommand = require('../../../../dist/hive/Commands/GetSchemasCommand').default;
+const GetSchemasCommand = require('../../../../lib/hive/Commands/GetSchemasCommand').default;
 
 const requestMock = {
   sessionHandle: {

--- a/tests/unit/hive/commands/GetTableTypesCommand.test.js
+++ b/tests/unit/hive/commands/GetTableTypesCommand.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 const TCLIService_types = require('../../../../thrift/TCLIService_types');
-const GetTableTypesCommand = require('../../../../dist/hive/Commands/GetTableTypesCommand').default;
+const GetTableTypesCommand = require('../../../../lib/hive/Commands/GetTableTypesCommand').default;
 
 const requestMock = {
   sessionHandle: {

--- a/tests/unit/hive/commands/GetTablesCommand.test.js
+++ b/tests/unit/hive/commands/GetTablesCommand.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 const TCLIService_types = require('../../../../thrift/TCLIService_types');
-const GetTablesCommand = require('../../../../dist/hive/Commands/GetTablesCommand').default;
+const GetTablesCommand = require('../../../../lib/hive/Commands/GetTablesCommand').default;
 
 const requestMock = {
   sessionHandle: {

--- a/tests/unit/hive/commands/GetTypeInfoCommand.test.js
+++ b/tests/unit/hive/commands/GetTypeInfoCommand.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 const TCLIService_types = require('../../../../thrift/TCLIService_types');
-const GetTypeInfoCommand = require('../../../../dist/hive/Commands/GetTypeInfoCommand').default;
+const GetTypeInfoCommand = require('../../../../lib/hive/Commands/GetTypeInfoCommand').default;
 
 const requestMock = {
   sessionHandle: {

--- a/tests/unit/hive/commands/OpenSessionCommand.test.js
+++ b/tests/unit/hive/commands/OpenSessionCommand.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 const TCLIService_types = require('../../../../thrift/TCLIService_types');
-const OpenSessionCommand = require('../../../../dist/hive/Commands/OpenSessionCommand').default;
+const OpenSessionCommand = require('../../../../lib/hive/Commands/OpenSessionCommand').default;
 
 const CLIENT_PROTOCOL = 8;
 

--- a/tests/unit/hive/commands/RenewDelegationTokenCommand.test.js
+++ b/tests/unit/hive/commands/RenewDelegationTokenCommand.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 const TCLIService_types = require('../../../../thrift/TCLIService_types');
-const RenewDelegationTokenCommand = require('../../../../dist/hive/Commands/RenewDelegationTokenCommand').default;
+const RenewDelegationTokenCommand = require('../../../../lib/hive/Commands/RenewDelegationTokenCommand').default;
 
 const requestMock = {
   sessionHandle: {

--- a/tests/unit/polyfills.test.js
+++ b/tests/unit/polyfills.test.js
@@ -1,5 +1,5 @@
 const { expect } = require('chai');
-const { at } = require('../../dist/polyfills');
+const { at } = require('../../lib/polyfills');
 
 const defaultArrayMock = {
   0: 'a',

--- a/tests/unit/result/ArrowResultConverter.test.js
+++ b/tests/unit/result/ArrowResultConverter.test.js
@@ -2,7 +2,7 @@ const { expect } = require('chai');
 const fs = require('fs');
 const path = require('path');
 const { tableFromArrays, tableToIPC, Table } = require('apache-arrow');
-const ArrowResultConverter = require('../../../dist/result/ArrowResultConverter').default;
+const ArrowResultConverter = require('../../../lib/result/ArrowResultConverter').default;
 const ResultsProviderMock = require('./fixtures/ResultsProviderMock');
 
 function createSampleThriftSchema(columnName) {

--- a/tests/unit/result/ArrowResultHandler.test.js
+++ b/tests/unit/result/ArrowResultHandler.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const Int64 = require('node-int64');
 const LZ4 = require('lz4');
-const ArrowResultHandler = require('../../../dist/result/ArrowResultHandler').default;
+const ArrowResultHandler = require('../../../lib/result/ArrowResultHandler').default;
 const ResultsProviderMock = require('./fixtures/ResultsProviderMock');
 
 const sampleArrowSchema = Buffer.from([

--- a/tests/unit/result/CloudFetchResultHandler.test.js
+++ b/tests/unit/result/CloudFetchResultHandler.test.js
@@ -2,9 +2,9 @@ const { expect, AssertionError } = require('chai');
 const sinon = require('sinon');
 const Int64 = require('node-int64');
 const LZ4 = require('lz4');
-const CloudFetchResultHandler = require('../../../dist/result/CloudFetchResultHandler').default;
+const CloudFetchResultHandler = require('../../../lib/result/CloudFetchResultHandler').default;
 const ResultsProviderMock = require('./fixtures/ResultsProviderMock');
-const DBSQLClient = require('../../../dist/DBSQLClient').default;
+const DBSQLClient = require('../../../lib/DBSQLClient').default;
 
 const sampleArrowSchema = Buffer.from([
   255, 255, 255, 255, 208, 0, 0, 0, 16, 0, 0, 0, 0, 0, 10, 0, 14, 0, 6, 0, 13, 0, 8, 0, 10, 0, 0, 0, 0, 0, 4, 0, 16, 0,

--- a/tests/unit/result/JsonResultHandler.test.js
+++ b/tests/unit/result/JsonResultHandler.test.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
-const JsonResultHandler = require('../../../dist/result/JsonResultHandler').default;
-const { TCLIService_types } = require('../../../').thrift;
+const JsonResultHandler = require('../../../lib/result/JsonResultHandler').default;
+const { TCLIService_types } = require('../../../lib').thrift;
 const Int64 = require('node-int64');
 const ResultsProviderMock = require('./fixtures/ResultsProviderMock');
 

--- a/tests/unit/result/ResultSlicer.test.js
+++ b/tests/unit/result/ResultSlicer.test.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
-const ResultSlicer = require('../../../dist/result/ResultSlicer').default;
+const ResultSlicer = require('../../../lib/result/ResultSlicer').default;
 const ResultsProviderMock = require('./fixtures/ResultsProviderMock');
 
 describe('ResultSlicer', () => {

--- a/tests/unit/result/compatibility.test.js
+++ b/tests/unit/result/compatibility.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
-const ArrowResultHandler = require('../../../dist/result/ArrowResultHandler').default;
-const ArrowResultConverter = require('../../../dist/result/ArrowResultConverter').default;
-const JsonResultHandler = require('../../../dist/result/JsonResultHandler').default;
+const ArrowResultHandler = require('../../../lib/result/ArrowResultHandler').default;
+const ArrowResultConverter = require('../../../lib/result/ArrowResultConverter').default;
+const JsonResultHandler = require('../../../lib/result/JsonResultHandler').default;
 
 const { fixArrowResult } = require('../../fixtures/compatibility');
 const fixtureColumn = require('../../fixtures/compatibility/column');

--- a/tests/unit/result/utils.test.js
+++ b/tests/unit/result/utils.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const Int64 = require('node-int64');
-const { TCLIService_types } = require('../../../').thrift;
-const { getSchemaColumns, convertThriftValue } = require('../../../dist/result/utils');
+const { TCLIService_types } = require('../../../lib').thrift;
+const { getSchemaColumns, convertThriftValue } = require('../../../lib/result/utils');
 
 const { TTypeId } = TCLIService_types;
 

--- a/tests/unit/utils.test.js
+++ b/tests/unit/utils.test.js
@@ -1,7 +1,7 @@
 const { expect, AssertionError } = require('chai');
 
-const { buildUserAgentString, definedOrError, formatProgress, ProgressUpdateTransformer } = require('../../dist/utils');
-const CloseableCollection = require('../../dist/utils/CloseableCollection').default;
+const { buildUserAgentString, definedOrError, formatProgress, ProgressUpdateTransformer } = require('../../lib/utils');
+const CloseableCollection = require('../../lib/utils/CloseableCollection').default;
 
 describe('buildUserAgentString', () => {
   // It should follow https://www.rfc-editor.org/rfc/rfc7231#section-5.5.3 and


### PR DESCRIPTION
[PECO-1390]

- Configured `nyc` to run tests via `ts-node`;
- All imports in tests updated to use `/lib` instead of `/dist` so `nyc` can properly collect coverage data. A great side-effect of this - no longer need to build sources before runing tests;
- For now, all tests are still in `.js` files and still have to use `require`. Migrating all tests to TS would be a very massive change, so it will be done gradually in follow-up PRs.

After merging this PR, a slight (<1%) difference in code coverage may be caused by testing original sources vs. compiled+source maps, and using `ts-node` instead of regular `node`.

[PECO-1390]: https://databricks.atlassian.net/browse/PECO-1390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ