### PR TITLE
[PECO-2049] Add custom auth headers into cloud fetch request

### DIFF
--- a/lib/result/CloudFetchResultHandler.ts
+++ b/lib/result/CloudFetchResultHandler.ts
@@ -73,7 +73,7 @@ export default class CloudFetchResultHandler implements IResultsProvider<ArrowBa
       throw new Error('CloudFetch link has expired');
     }
 
-    const response = await this.fetch(link.fileLink);
+    const response = await this.fetch(link.fileLink, { headers: link.httpHeaders });
     if (!response.ok) {
       throw new Error(`CloudFetch HTTP error ${response.status} ${response.statusText}`);
     }


### PR DESCRIPTION
When file encryption is enabled with customer provided keys (SSE-CPK), we must pass the keys in HTTP headers in the fetch request. These headers are provided in the property `httpHeaders` in the `TSparkArrowResultLink`