### PR TITLE
[PECO-2153] Support OAuth on databricks.azure.cn

### DIFF
--- a/lib/connection/auth/DatabricksOAuth/OAuthManager.ts
+++ b/lib/connection/auth/DatabricksOAuth/OAuthManager.ts
@@ -219,7 +219,7 @@ export default abstract class OAuthManager {
     }
 
     if (options.useDatabricksOAuthInAzure) {
-      const azureDomains = ['.azuredatabricks.net'];
+      const azureDomains = ['.azuredatabricks.net', '.databricks.azure.cn'];
       const isAzureDomain = azureDomains.some((domain) => host.endsWith(domain));
       if (isAzureDomain) {
         // eslint-disable-next-line @typescript-eslint/no-use-before-define


### PR DESCRIPTION
Databricks OAuth is supported on `databricks.azure.cn`