### PR TITLE
updated py version for node14 testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,11 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - uses: actions/checkout@v3
+      - name: Set up Python 3.10 for Node 14
+        if: ${{ matrix.node-version == '14' }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
       - name: Cache node modules
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
When running unit tests with node v14 got error: ValueError: invalid mode: 'rU'
updating python version used when running unit tests for node version 14. [REF](https://stackoverflow.com/questions/74715990/node-gyp-err-invalid-mode-ru-while-trying-to-load-binding-gyp)