### PR TITLE
renamed clientId to userAgentHeader in connect args

### DIFF
--- a/examples/repl
+++ b/examples/repl
@@ -15,7 +15,7 @@ async function initClient({ host, endpointId, token }) {
         host,
         path: `/sql/2.0/warehouses/${endpointId}`,
         token,
-        userAgentHeader: 'REPL',
+        userAgentEntry: 'REPL',
     });
 }
 

--- a/examples/repl
+++ b/examples/repl
@@ -15,7 +15,7 @@ async function initClient({ host, endpointId, token }) {
         host,
         path: `/sql/2.0/warehouses/${endpointId}`,
         token,
-        clientId: 'REPL',
+        userAgentHeader: 'REPL',
     });
 }
 

--- a/lib/DBSQLClient.ts
+++ b/lib/DBSQLClient.ts
@@ -111,7 +111,7 @@ export default class DBSQLClient extends EventEmitter implements IDBSQLClient, I
       socketTimeout: options.socketTimeout,
       proxy: options.proxy,
       headers: {
-        'User-Agent': buildUserAgentString(options.userAgentHeader),
+        'User-Agent': buildUserAgentString(options.userAgentEntry),
       },
     };
   }

--- a/lib/DBSQLClient.ts
+++ b/lib/DBSQLClient.ts
@@ -111,7 +111,7 @@ export default class DBSQLClient extends EventEmitter implements IDBSQLClient, I
       socketTimeout: options.socketTimeout,
       proxy: options.proxy,
       headers: {
-        'User-Agent': buildUserAgentString(options.clientId),
+        'User-Agent': buildUserAgentString(options.userAgentHeader),
       },
     };
   }

--- a/lib/contracts/IDBSQLClient.ts
+++ b/lib/contracts/IDBSQLClient.ts
@@ -30,7 +30,7 @@ export type ConnectionOptions = {
   host: string;
   port?: number;
   path: string;
-  userAgentHeader?: string;
+  userAgentEntry?: string;
   socketTimeout?: number;
   proxy?: ProxyOptions;
 } & AuthOptions;

--- a/lib/contracts/IDBSQLClient.ts
+++ b/lib/contracts/IDBSQLClient.ts
@@ -30,7 +30,7 @@ export type ConnectionOptions = {
   host: string;
   port?: number;
   path: string;
-  clientId?: string;
+  userAgentHeader?: string;
   socketTimeout?: number;
   proxy?: ProxyOptions;
 } & AuthOptions;

--- a/lib/utils/buildUserAgentString.ts
+++ b/lib/utils/buildUserAgentString.ts
@@ -11,7 +11,7 @@ function getOperatingSystemVersion(): string {
   return `${os.type()} ${os.release()}`;
 }
 
-export default function buildUserAgentString(userAgentHeader?: string): string {
-  const extra = [userAgentHeader, getNodeVersion(), getOperatingSystemVersion()].filter(Boolean);
+export default function buildUserAgentString(userAgentEntry?: string): string {
+  const extra = [userAgentEntry, getNodeVersion(), getOperatingSystemVersion()].filter(Boolean);
   return `${productName}/${packageVersion} (${extra.join('; ')})`;
 }

--- a/lib/utils/buildUserAgentString.ts
+++ b/lib/utils/buildUserAgentString.ts
@@ -11,7 +11,7 @@ function getOperatingSystemVersion(): string {
   return `${os.type()} ${os.release()}`;
 }
 
-export default function buildUserAgentString(clientId?: string): string {
-  const extra = [clientId, getNodeVersion(), getOperatingSystemVersion()].filter(Boolean);
+export default function buildUserAgentString(userAgentHeader?: string): string {
+  const extra = [userAgentHeader, getNodeVersion(), getOperatingSystemVersion()].filter(Boolean);
   return `${productName}/${packageVersion} (${extra.join('; ')})`;
 }

--- a/tests/unit/utils/utils.test.ts
+++ b/tests/unit/utils/utils.test.ts
@@ -19,14 +19,16 @@ describe('buildUserAgentString', () => {
   // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent
   //
   // UserAgent ::= <ProductName> '/' <ProductVersion> '(' <Comment> ')'
+  // where:
   // ProductName ::= 'NodejsDatabricksSqlConnector'
-  // <Comment> ::= [ <userAgentHeader> ';' ] 'Node.js' <NodeJsVersion> ';' <OSPlatform> <OSVersion>
+  // ProductVersion ::= three period-separated digits
+  // <Comment> ::= [ <userAgentEntry> ';' ] 'Node.js' <NodeJsVersion> ';' <OSPlatform> <OSVersion>
   //
   // Examples:
-  // - with <userAgentHeader> provided: NodejsDatabricksSqlConnector/0.1.8-beta.1 (Client ID; Node.js 16.13.1; Darwin 21.5.0)
-  // - without <userAgentHeader> provided: NodejsDatabricksSqlConnector/0.1.8-beta.1 (Node.js 16.13.1; Darwin 21.5.0)
+  // - with <userAgentEntry> provided: NodejsDatabricksSqlConnector/0.1.8-beta.1 (<userAgentEntry>; Node.js 16.13.1; Darwin 21.5.0)
+  // - without <userAgentEntry> provided: NodejsDatabricksSqlConnector/0.1.8-beta.1 (Node.js 16.13.1; Darwin 21.5.0)
 
-  function checkUserAgentString(ua: string, userAgentHeader?: string) {
+  function checkUserAgentString(ua: string, userAgentEntry?: string) {
     // Prefix: 'NodejsDatabricksSqlConnector/'
     // Version: three period-separated digits and optional suffix
     const re =
@@ -39,18 +41,18 @@ describe('buildUserAgentString', () => {
     const parts = comment.split(';').map((s) => s.trim());
     expect(parts.length).to.be.gte(2); // at least Node and OS version should be there
 
-    if (userAgentHeader) {
-      expect(comment.trim()).to.satisfy((s: string) => s.startsWith(`${userAgentHeader};`));
+    if (userAgentEntry) {
+      expect(comment.trim()).to.satisfy((s: string) => s.startsWith(`${userAgentEntry};`));
     }
   }
 
-  it('matches pattern with userAgentHeader', () => {
-    const userAgentHeader = 'Some Client ID';
-    const ua = buildUserAgentString(userAgentHeader);
-    checkUserAgentString(ua, userAgentHeader);
+  it('matches pattern with userAgentEntry', () => {
+    const userAgentEntry = 'Some user agent';
+    const ua = buildUserAgentString(userAgentEntry);
+    checkUserAgentString(ua, userAgentEntry);
   });
 
-  it('matches pattern without userAgentHeader', () => {
+  it('matches pattern without userAgentEntry', () => {
     const ua = buildUserAgentString();
     checkUserAgentString(ua);
   });

--- a/tests/unit/utils/utils.test.ts
+++ b/tests/unit/utils/utils.test.ts
@@ -20,13 +20,13 @@ describe('buildUserAgentString', () => {
   //
   // UserAgent ::= <ProductName> '/' <ProductVersion> '(' <Comment> ')'
   // ProductName ::= 'NodejsDatabricksSqlConnector'
-  // <Comment> ::= [ <ClientId> ';' ] 'Node.js' <NodeJsVersion> ';' <OSPlatform> <OSVersion>
+  // <Comment> ::= [ <userAgentHeader> ';' ] 'Node.js' <NodeJsVersion> ';' <OSPlatform> <OSVersion>
   //
   // Examples:
-  // - with <ClientId> provided: NodejsDatabricksSqlConnector/0.1.8-beta.1 (Client ID; Node.js 16.13.1; Darwin 21.5.0)
-  // - without <ClientId> provided: NodejsDatabricksSqlConnector/0.1.8-beta.1 (Node.js 16.13.1; Darwin 21.5.0)
+  // - with <userAgentHeader> provided: NodejsDatabricksSqlConnector/0.1.8-beta.1 (Client ID; Node.js 16.13.1; Darwin 21.5.0)
+  // - without <userAgentHeader> provided: NodejsDatabricksSqlConnector/0.1.8-beta.1 (Node.js 16.13.1; Darwin 21.5.0)
 
-  function checkUserAgentString(ua: string, clientId?: string) {
+  function checkUserAgentString(ua: string, userAgentHeader?: string) {
     // Prefix: 'NodejsDatabricksSqlConnector/'
     // Version: three period-separated digits and optional suffix
     const re =
@@ -38,18 +38,18 @@ describe('buildUserAgentString', () => {
 
     expect(comment.split(';').length).to.be.gte(2); // at least Node and OS version should be there
 
-    if (clientId) {
-      expect(comment.trim()).to.satisfy((s: string) => s.startsWith(`${clientId};`));
+    if (userAgentHeader) {
+      expect(comment.trim()).to.satisfy((s: string) => s.startsWith(`${userAgentHeader};`));
     }
   }
 
-  it('matches pattern with clientId', () => {
-    const clientId = 'Some Client ID';
-    const ua = buildUserAgentString(clientId);
-    checkUserAgentString(ua, clientId);
+  it('matches pattern with userAgentHeader', () => {
+    const userAgentHeader = 'Some Client ID';
+    const ua = buildUserAgentString(userAgentHeader);
+    checkUserAgentString(ua, userAgentHeader);
   });
 
-  it('matches pattern without clientId', () => {
+  it('matches pattern without userAgentHeader', () => {
     const ua = buildUserAgentString();
     checkUserAgentString(ua);
   });


### PR DESCRIPTION
## Description
This PR adds `userAgentHeader` option in connect call, so users can configure the user agent string generated. 
Note: clientId arg in `connect` options is renamed to userAgentHeader. The clientId in `OAuthManager` options exists and corresponds to the Databricks Service Principal clientId.

## Testing
unit tests