### PR TITLE
Make the LZ4 dependency check lenient

### DIFF
--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -4,7 +4,9 @@ on: [pull_request]
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     steps:
       - name: Check for DCO
         id: dco-check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
     branches:
       - main
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,13 +4,16 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     branches:
       - main
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+    
     steps:
       - uses: actions/checkout@v3
       - name: Cache node modules
@@ -31,7 +34,9 @@ jobs:
           npm run lint
 
   unit-test:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     strategy:
       matrix:
         # only LTS versions starting from the lowest we support
@@ -72,7 +77,9 @@ jobs:
           retention-days: 1
 
   e2e-test:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     environment: azure-prod
     env:
       E2E_HOST: ${{ secrets.DATABRICKS_HOST }}
@@ -110,7 +117,9 @@ jobs:
 
   coverage:
     needs: [unit-test, e2e-test]
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     env:
       cache-name: cache-node-modules
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,9 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v1

--- a/lib/utils/lz4.ts
+++ b/lib/utils/lz4.ts
@@ -7,22 +7,22 @@ function tryLoadLZ4Module(): LZ4Module | undefined {
     return require('lz4'); // eslint-disable-line global-require
   } catch (err) {
     if (!(err instanceof Error) || !('code' in err)) {
-      console.warn('Unexpected error loading LZ4 module: Invalid error object');
+      console.warn('Unexpected error loading LZ4 module: Invalid error object', err);
       return undefined;
     }
 
     if (err.code === 'MODULE_NOT_FOUND') {
-      console.warn('LZ4 module not installed: Missing dependency');
+      console.warn('LZ4 module not installed: Missing dependency', err);
       return undefined;
     }
 
     if (err.code === 'ERR_DLOPEN_FAILED') {
-      console.warn('LZ4 native module failed to load: Architecture or version mismatch');
+      console.warn('LZ4 native module failed to load: Architecture or version mismatch', err);
       return undefined;
     }
 
     // If it's not a known error, return undefined
-    console.warn('Unknown error loading LZ4 module: Unhandled error code');
+    console.warn('Unknown error loading LZ4 module: Unhandled error code', err);
     return undefined;
   }
 }

--- a/lib/utils/lz4.ts
+++ b/lib/utils/lz4.ts
@@ -6,10 +6,24 @@ function tryLoadLZ4Module(): LZ4Module | undefined {
   try {
     return require('lz4'); // eslint-disable-line global-require
   } catch (err) {
-    const isModuleNotFoundError = err instanceof Error && 'code' in err && err.code === 'MODULE_NOT_FOUND';
-    if (!isModuleNotFoundError) {
-      throw err;
+    if (!(err instanceof Error) || !('code' in err)) {
+      console.warn('Unexpected error loading LZ4 module: Invalid error object');
+      return undefined;
     }
+
+    if (err.code === 'MODULE_NOT_FOUND') {
+      console.warn('LZ4 module not installed: Missing dependency');
+      return undefined;
+    }
+
+    if (err.code === 'ERR_DLOPEN_FAILED') {
+      console.warn('LZ4 native module failed to load: Architecture or version mismatch');
+      return undefined;
+    }
+
+    // If it's not a known error, return undefined
+    console.warn('Unknown error loading LZ4 module: Unhandled error code');
+    return undefined;
   }
 }
 


### PR DESCRIPTION
Currently, LZ4 compression is not used if module is not found (i..e,  when `lz4` module is not installed). At times customer is running databricks nodejs driver in Azure functions or a non-supported arch compute, in that case it throws 

```
{...}/node_modules/@databricks/sql/dist/utils/lz4.js:10
            throw err;
            ^

Error: {...}/node_modules/lz4/build/Release/xxhash.node: invalid ELF header
    at Module._extensions..node (node:internal/modules/cjs/loader:1460:18)
    at Module.load (node:internal/modules/cjs/loader:1203:32)
    at Module._load (node:internal/modules/cjs/loader:1019:12)
    at Module.require (node:internal/modules/cjs/loader:1231:19)
    at require (node:internal/modules/helpers:177:18)
    at Object.<anonymous> (/home/dejhjs3e/projects/databricks-node/node_modules/lz4/lib/utils.js:4:11)
    at Module._compile (node:internal/modules/cjs/loader:1364:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1422:10)
    at Module.load (node:internal/modules/cjs/loader:1203:32)
    at Module._load (node:internal/modules/cjs/loader:1019:12) {
  code: 'ERR_DLOPEN_FAILED'
}
```

Making the error handling more lenient inorder to exclude lz4 compression whenever a dependency error is thrown. 

This fixes the problems stated in : #289 #275 #266 #270
