### PR TITLE
disable compression if cloud fetch is enabled

### DIFF
--- a/lib/DBSQLSession.ts
+++ b/lib/DBSQLSession.ts
@@ -227,12 +227,12 @@ export default class DBSQLSession implements IDBSQLSession {
       request.parameters = getQueryParameters(options.namedParameters, options.ordinalParameters);
     }
 
-    if (ProtocolVersion.supportsArrowCompression(this.serverProtocolVersion)) {
-      request.canDecompressLZ4Result = (options.useLZ4Compression ?? clientConfig.useLZ4Compression) && Boolean(LZ4);
-    }
-
     if (ProtocolVersion.supportsCloudFetch(this.serverProtocolVersion)) {
       request.canDownloadResult = options.useCloudFetch ?? clientConfig.useCloudFetch;
+    }
+
+    if (ProtocolVersion.supportsArrowCompression(this.serverProtocolVersion) && request.canDownloadResult !== true) {
+      request.canDecompressLZ4Result = (options.useLZ4Compression ?? clientConfig.useLZ4Compression) && Boolean(LZ4);
     }
 
     const operationPromise = driver.executeStatement(request);

--- a/tests/e2e/arrow.test.ts
+++ b/tests/e2e/arrow.test.ts
@@ -187,7 +187,10 @@ describe('Arrow support', () => {
     'should handle LZ4 compressed data',
     createTest(
       async (session) => {
-        const operation = await session.executeStatement(`SELECT * FROM ${tableName}`);
+        const operation = await session.executeStatement(
+          `SELECT * FROM ${tableName}`,
+          { useCloudFetch: false }, // Explicitly disable cloud fetch to test LZ4 compression
+        );
         const result = await operation.fetchAll();
         expect(fixArrowResult(result)).to.deep.equal(expectedArrow);
 

--- a/tests/e2e/cloudfetch.test.ts
+++ b/tests/e2e/cloudfetch.test.ts
@@ -97,11 +97,11 @@ describe('CloudFetch', () => {
     expect(fetchedRowCount).to.be.equal(queriedRowsCount);
   });
 
-  it('should handle LZ4 compressed data', async () => {
+  it('should not use LZ4 compression with cloud fetch', async () => {
     const cloudFetchConcurrentDownloads = 5;
     const session = await openSession({
       cloudFetchConcurrentDownloads,
-      useLZ4Compression: true,
+      useLZ4Compression: true, // This is ignored when cloud fetch is enabled
     });
 
     const queriedRowsCount = 10000000; // result has to be quite big to enable CloudFetch
@@ -126,7 +126,8 @@ describe('CloudFetch', () => {
     expect(resultHandler).to.be.instanceof(ResultSlicer);
     expect(resultHandler.source).to.be.instanceof(ArrowResultConverter);
     expect(resultHandler.source.source).to.be.instanceOf(CloudFetchResultHandler);
-    expect(resultHandler.source.source.isLZ4Compressed).to.be.true;
+    // LZ4 compression should not be enabled with cloud fetch
+    expect(resultHandler.source.source.isLZ4Compressed).to.be.false;
 
     const chunk = await operation.fetchChunk({ maxRows: 100000, disableBuffering: true });
     expect(chunk.length).to.be.gt(0);


### PR DESCRIPTION
## Description
Disable compression if cloud fetch is enabled.
Reason: 
Transient issue `Error: Error: Invalid stream checksum: A9A9B8E @17257 at Decoder.emit_Error` when running cloud fetch query on sql warehouse
Justification:
Minimal impact(~3% on 500MB) result set.

## Testing
Unit tests
e2e test
