### PR TITLE
Removed the LZ4 module not found warning

### DIFF
--- a/lib/utils/lz4.ts
+++ b/lib/utils/lz4.ts
@@ -12,7 +12,6 @@ function tryLoadLZ4Module(): LZ4Module | undefined {
     }
 
     if (err.code === 'MODULE_NOT_FOUND') {
-      console.warn('LZ4 module not installed: Missing dependency', err);
       return undefined;
     }
 


### PR DESCRIPTION
## Description 

Removing the warning log when LZ4 is not installed. If customer wants to use LZ4 and it is not installed we anyway throw an error. So this warning seems unnecessary for customers not wanting to use LZ4 in the first place

Related github issue
https://github.com/databricks/databricks-sql-nodejs/issues/300