### PR TITLE
add metric logging for cloud fetch

### DIFF
--- a/lib/DBSQLClient.ts
+++ b/lib/DBSQLClient.ts
@@ -90,6 +90,7 @@ export default class DBSQLClient extends EventEmitter implements IDBSQLClient, I
 
       useCloudFetch: true, // enabling cloud fetch by default.
       cloudFetchConcurrentDownloads: 10,
+      cloudFetchSpeedThresholdMBps: 0.1,
 
       useLZ4Compression: true,
     };

--- a/lib/contracts/IClientContext.ts
+++ b/lib/contracts/IClientContext.ts
@@ -18,6 +18,7 @@ export interface ClientConfig {
 
   useCloudFetch: boolean;
   cloudFetchConcurrentDownloads: number;
+  cloudFetchSpeedThresholdMBps: number;
 
   useLZ4Compression: boolean;
 }


### PR DESCRIPTION
## Description
Add logs for cloud fetch download speed

## Testing
verified logs are printed when log level is set to INFO