### PR TITLE
[PECOBLR-675] support for session params

### DIFF
--- a/examples/session_params.js
+++ b/examples/session_params.js
@@ -1,0 +1,29 @@
+const { DBSQLClient } = require('..');
+
+const client = new DBSQLClient();
+
+const host = process.env.DATABRICKS_HOST;
+const path = process.env.DATABRICKS_HTTP_PATH;
+const token = process.env.DATABRICKS_TOKEN;
+
+client
+  .connect({ host, path, token })
+  .then(async (client) => {
+    const session = await client.openSession({
+      configuration: {
+        QUERY_TAGS: 'team:engineering,test:session-params,driver:node',
+        ansi_mode: 'false',
+      },
+    });
+
+    const op = await session.executeStatement('SELECT 1');
+    const rows = await op.fetchAll();
+    console.log(rows);
+    await op.close();
+
+    await session.close();
+    await client.close();
+  })
+  .catch((error) => {
+    console.log(error);
+  });

--- a/lib/DBSQLClient.ts
+++ b/lib/DBSQLClient.ts
@@ -221,6 +221,7 @@ export default class DBSQLClient extends EventEmitter implements IDBSQLClient, I
     const response = await this.driver.openSession({
       client_protocol_i64: new Int64(TProtocolVersion.SPARK_CLI_SERVICE_PROTOCOL_V8),
       ...getInitialNamespaceOptions(request.initialCatalog, request.initialSchema),
+      configuration: request.configuration,
       canUseMultipleCatalogs: true,
     });
 

--- a/lib/contracts/IDBSQLClient.ts
+++ b/lib/contracts/IDBSQLClient.ts
@@ -38,6 +38,7 @@ export type ConnectionOptions = {
 export interface OpenSessionRequest {
   initialCatalog?: string;
   initialSchema?: string;
+  configuration?: { [key: string]: string };
 }
 
 export default interface IDBSQLClient {

--- a/tests/e2e/query_parameters.test.ts
+++ b/tests/e2e/query_parameters.test.ts
@@ -17,6 +17,9 @@ const openSession = async () => {
   return connection.openSession({
     initialCatalog: config.catalog,
     initialSchema: config.schema,
+    configuration: {
+      QUERY_TAGS: 'test:e2e,driver:node',
+    },
   });
 };
 

--- a/tests/unit/DBSQLClient.test.ts
+++ b/tests/unit/DBSQLClient.test.ts
@@ -185,6 +185,16 @@ describe('DBSQLClient.openSession', () => {
     }
   });
 
+  it('should pass session configuration to OpenSessionReq', async () => {
+    const client = new DBSQLClient();
+    const thriftClient = new ThriftClientStub();
+    sinon.stub(client, 'getClient').returns(Promise.resolve(thriftClient));
+
+    const configuration = { QUERY_TAGS: 'team:engineering', ansi_mode: 'true' };
+    await client.openSession({ configuration });
+    expect(thriftClient.openSessionReq?.configuration).to.deep.equal(configuration);
+  });
+
   it('should affect session behavior based on protocol version', async () => {
     const client = new DBSQLClient();
     const thriftClient = new ThriftClientStub();


### PR DESCRIPTION
<!-- We welcome contributions. All patches must include a sign-off. Please see CONTRIBUTING.md for details -->

## Description
This PR adds support for passing session parameters during session creation in the Node.js SQL Driver. Previously, there was no direct API to forward session configuration at `openSession` time. With this change, callers can provide a `configuration` map (e.g., `QUERY_TAGS`, `ansi_mode`) that is forwarded to Thrift `TOpenSessionReq.configuration`. This change allows users to pass query tags as well, which allow users to attach key-value pairs to SQL executions that appear in the `system.query.history` table.

### Changes Made

1. API (`lib/contracts/IDBSQLClient.ts`)
   - Added optional `configuration?: { [key: string]: string }` to `OpenSessionRequest`.

2. Implementation (`lib/DBSQLClient.ts`)
   - `openSession()` now forwards `request.configuration` to Thrift via `TOpenSessionReq.configuration` (protocol V8; `canUseMultipleCatalogs: true`).

3. Example (`examples/session_params.js`)
   - Demonstrates passing session params (`QUERY_TAGS`, `ansi_mode` etc.) via `openSession({ configuration })`.

### Query Tags usage example
```javascript
const { DBSQLClient } = require('@databricks/sql');

const client = new DBSQLClient();
await client.connect({ host, path, token });

const session = await client.openSession({
  configuration: {
    QUERY_TAGS: 'team:engineering,test:session-params,driver:node',
    ansi_mode: 'false',
  },
});

```

## How is this tested?

- [x] Unit tests
- [x] E2E tests
- [x] Manually

### Testing Details

- Unit: Verified that `configuration` is forwarded to `TOpenSessionReq.configuration`. Ran the remaining unit suite; all passing.
- E2E: Updated tests to include `QUERY_TAGS` in `openSession({ configuration })`
- Manual: Executed `examples/session_params.js` against a real backend; returned expected result.