### PR TITLE
Add metric view metadata support

### DIFF
--- a/lib/contracts/IClientContext.ts
+++ b/lib/contracts/IClientContext.ts
@@ -21,6 +21,7 @@ export interface ClientConfig {
   cloudFetchSpeedThresholdMBps: number;
 
   useLZ4Compression: boolean;
+  enableMetricViewMetadata?: boolean;
 }
 
 export default interface IClientContext {

--- a/lib/contracts/IDBSQLClient.ts
+++ b/lib/contracts/IDBSQLClient.ts
@@ -33,6 +33,7 @@ export type ConnectionOptions = {
   userAgentEntry?: string;
   socketTimeout?: number;
   proxy?: ProxyOptions;
+  enableMetricViewMetadata?: boolean;
 } & AuthOptions;
 
 export interface OpenSessionRequest {


### PR DESCRIPTION
  ## Description
  This PR adds support for metric view metadata in the Databricks SQL Node.js driver, following the JDBC driver implementation.

  ## Changes
  - Added `enableMetricViewMetadata` optional boolean to `ConnectionOptions` interface
  - Added `enableMetricViewMetadata` optional boolean to `ClientConfig` interface
  - Updated `DBSQLClient.connect()` to store the configuration
  - Updated `DBSQLClient.openSession()` to inject `spark.sql.thriftserver.metadata.metricview.enabled=true` when enabled
  - Added 6 comprehensive unit tests

  ## Behavior
  When `enableMetricViewMetadata=true`:
  - `getTables()` and `getTableTypes()` will include METRIC_VIEW entries
  - `getColumns()` will return measure columns with `<data_type> measure` format in TYPE_NAME

  ## Usage
  ```javascript
  const client = new DBSQLClient();

  await client.connect({
    host: 'your-workspace.cloud.databricks.com',
    path: '/sql/protocolv1/o/...',
    token: 'dapi***',
    enableMetricViewMetadata: true
  });

  const session = await client.openSession();
```

  Testing

  All 437 unit tests pass including 6 new tests for this feature.

  Backward Compatibility

  Feature is disabled by default - fully backward compatible.