### PR TITLE
Replace archived lz4 package with actively maintained lz4-napi

### DIFF
--- a/lib/result/ArrowResultHandler.ts
+++ b/lib/result/ArrowResultHandler.ts
@@ -27,7 +27,7 @@ export default class ArrowResultHandler implements IResultsProvider<ArrowBatch> 
     this.isLZ4Compressed = lz4Compressed ?? false;
 
     if (this.isLZ4Compressed && !LZ4()) {
-      throw new HiveDriverError('Cannot handle LZ4 compressed result: module `lz4` not installed');
+      throw new HiveDriverError('Cannot handle LZ4 compressed result: module `lz4-napi` not installed');
     }
   }
 

--- a/lib/result/CloudFetchResultHandler.ts
+++ b/lib/result/CloudFetchResultHandler.ts
@@ -28,7 +28,7 @@ export default class CloudFetchResultHandler implements IResultsProvider<ArrowBa
     this.isLZ4Compressed = lz4Compressed ?? false;
 
     if (this.isLZ4Compressed && !LZ4()) {
-      throw new HiveDriverError('Cannot handle LZ4 compressed result: module `lz4` not installed');
+      throw new HiveDriverError('Cannot handle LZ4 compressed result: module `lz4-napi` not installed');
     }
   }
 

--- a/lib/utils/lz4.ts
+++ b/lib/utils/lz4.ts
@@ -1,10 +1,16 @@
-import type LZ4Namespace from 'lz4';
-
-type LZ4Module = typeof LZ4Namespace;
+interface LZ4Module {
+  encode(data: Buffer): Buffer;
+  decode(data: Buffer): Buffer;
+}
 
 function tryLoadLZ4Module(): LZ4Module | undefined {
   try {
-    return require('lz4'); // eslint-disable-line global-require
+    // eslint-disable-next-line global-require
+    const lz4napi = require('lz4-napi');
+    return {
+      encode: lz4napi.compressFrameSync,
+      decode: lz4napi.decompressFrameSync,
+    };
   } catch (err) {
     if (!(err instanceof Error) || !('code' in err)) {
       // eslint-disable-next-line no-console

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
       "devDependencies": {
         "@types/chai": "^4.3.14",
         "@types/http-proxy": "^1.17.14",
-        "@types/lz4": "^0.6.4",
         "@types/mocha": "^10.0.6",
         "@types/node": "^18.11.9",
         "@types/node-fetch": "^2.6.4",
@@ -54,7 +53,7 @@
         "node": ">=14.0.0"
       },
       "optionalDependencies": {
-        "lz4": "^0.6.5"
+        "lz4-napi": "^2.9.0"
       }
     },
     "node_modules/@75lb/deep-merge": {
@@ -88,6 +87,213 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-android-arm-eabi": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-android-arm-eabi/-/lz4-napi-android-arm-eabi-2.9.0.tgz",
+      "integrity": "sha512-aeT/9SoWq7rnmzssWuCKUPaxVt3fzE9q+xq/ZHbnUSmrm8/EhLOACMvQeCOnL0IZsmPh8EpuwIE1TZyM9iQPRA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-android-arm64": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-android-arm64/-/lz4-napi-android-arm64-2.9.0.tgz",
+      "integrity": "sha512-ibQ0qiEvmljXAM97IgOZfh+PeiSQ0Rqf2HErJlZPVm2v4GVJoB67v21v1TUydqNNV5L8bwufVoZ90nheL8X9ZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-darwin-arm64": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-darwin-arm64/-/lz4-napi-darwin-arm64-2.9.0.tgz",
+      "integrity": "sha512-1su4K1MWa4bcWoZlHajv+luGmFDV1JwIsvjtDF+0HhUveSDPP+8A4Z34zOZidURIr08Sl7M7ViPth6ZQ9SqnAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-darwin-x64": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-darwin-x64/-/lz4-napi-darwin-x64-2.9.0.tgz",
+      "integrity": "sha512-8Lnbm2MkdJtiJ/nbcRS9zRyGp3G0sG6D+Y/x1vTP8nZs3/f8tBwYNsjxCQyyXNNyHcYWwVGbk68onP/pyDljOA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-freebsd-x64": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-freebsd-x64/-/lz4-napi-freebsd-x64-2.9.0.tgz",
+      "integrity": "sha512-k04EMVOjntKDPrdR4Tf8WyNseuk9PTtSGw8WHyp4CTjoR1s+YJxtp9SMnThe5o2q0TATwk8WGYb/Howrp5OMxw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-linux-arm-gnueabihf": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-linux-arm-gnueabihf/-/lz4-napi-linux-arm-gnueabihf-2.9.0.tgz",
+      "integrity": "sha512-H92F8zPZmgy2r8IhCWh3qIBfLp2BQ5cp18RoDXhtGFWwkh+5gVWrZp11IVznrsdgB0QeW0VR7dAMMHg3WLOPfA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-linux-arm64-gnu": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-linux-arm64-gnu/-/lz4-napi-linux-arm64-gnu-2.9.0.tgz",
+      "integrity": "sha512-25crh0qs/3Rj3fMI8ulYD0DoaKsidUhMBki2aeO69ZK+F8bmQ/e2++FlgJ6f3EgMP5CNxJtnZXKhPOraQWjwAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-linux-arm64-musl": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-linux-arm64-musl/-/lz4-napi-linux-arm64-musl-2.9.0.tgz",
+      "integrity": "sha512-eJtHp38zuLaYI0/cOV/BKcNQiXUBo4GPx53FTf0Y307yUjLsn48LNeN0vD28Ct9YrbUae3bQvMD5AD86She0ww==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-linux-x64-gnu": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-linux-x64-gnu/-/lz4-napi-linux-x64-gnu-2.9.0.tgz",
+      "integrity": "sha512-mDjS4dyjRKaZQcAP71SphkYH5r3kufB30ih/VETVu/br2toCfBk6Zr1xhL1r+L7FaVAFzF62B7h30CiqrN0Awg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-linux-x64-musl": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-linux-x64-musl/-/lz4-napi-linux-x64-musl-2.9.0.tgz",
+      "integrity": "sha512-pvU7Z7qjkjn17NkddBtBQ7C2iRqjtZ7WJ3Jqrjtj4XxolY3Q0HaYMvWjkWhzb9AKGZbj5y+EHYtbVoZJ2TSQhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-win32-arm64-msvc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-win32-arm64-msvc/-/lz4-napi-win32-arm64-msvc-2.9.0.tgz",
+      "integrity": "sha512-aioLlbpJl0QPEXLXhh2bzyitc3T7Jot3f1ap6WdKiRa+CIjMHXw1nxJXy07MLXif10r+qVZr86ic8dvwErgqEQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-win32-ia32-msvc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-win32-ia32-msvc/-/lz4-napi-win32-ia32-msvc-2.9.0.tgz",
+      "integrity": "sha512-VaF4XMTdYb59TsPsiqnWwsNaWKHhgxF33z5p4zg4n0tp20eWozl76hn8B+aXthSs40W0W1N97QhxxV4oXGd8cg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@antoniomuso/lz4-napi-win32-x64-msvc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-win32-x64-msvc/-/lz4-napi-win32-x64-msvc-2.9.0.tgz",
+      "integrity": "sha512-wfA8ShO3eGLxJ1LDwXJo87XL2D4NkMJV1pfHPvLZpD0MWb9u8VfgS+gKK5YhT7XKjzVdeIna9jgFdn2HBnZBxA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -833,6 +1039,23 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/triples": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/triples/-/triples-1.2.0.tgz",
+      "integrity": "sha512-HAPjR3bnCsdXBsATpDIP5WCrw0JcACwhhrwIAQhiR46n+jm+a2F8kBsfseAuWtSyQ+H3Yebt2k43B5dy+04yMA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@node-rs/helper": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/helper/-/helper-1.6.0.tgz",
+      "integrity": "sha512-2OTh/tokcLA1qom1zuCJm2gQzaZljCCbtX1YCrwRVd/toz7KxaDRFeLTAPwhs8m9hWgzrBn5rShRm6IaZofCPw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/triples": "^1.2.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -977,15 +1200,6 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
-    },
-    "node_modules/@types/lz4": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/@types/lz4/-/lz4-0.6.4.tgz",
-      "integrity": "sha512-vvxMIkowyHbY6zkCantyYwAK83N5E04bzFZSPJICG1SDpaL89L7lObs9DhLuhJhXHCQMkjzN3LYoAH6LjfwMFQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/mocha": {
       "version": "10.0.6",
@@ -1582,26 +1796,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "optional": true
-    },
     "node_modules/basic-ftp": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.3.tgz",
@@ -1678,30 +1872,6 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "optional": true,
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "node_modules/caching-transform": {
@@ -2058,12 +2228,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/cuint": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
-      "integrity": "sha512-d4ZVpCW31eWwCMe1YT3ur7mUDnTXbgwyzaL320DrcRT45rfjYxkt5QWLrmOJ+/UEAI2+fQgKe/fCjR8l4TpRgw==",
-      "optional": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -3440,26 +3604,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "optional": true
-    },
     "node_modules/ignore": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
@@ -4205,20 +4349,32 @@
         "node": ">=10"
       }
     },
-    "node_modules/lz4": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/lz4/-/lz4-0.6.5.tgz",
-      "integrity": "sha512-KSZcJU49QZOlJSItaeIU3p8WoAvkTmD9fJqeahQXNu1iQ/kR0/mQLdbrK8JY9MY8f6AhJoMrihp1nu1xDbscSQ==",
-      "hasInstallScript": true,
+    "node_modules/lz4-napi": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/lz4-napi/-/lz4-napi-2.9.0.tgz",
+      "integrity": "sha512-ZOWqxBMIK5768aD20tYn5B6Pp9WPM9UG/LHk8neG9p0gC1DtjdzhTtlkxhAjvTRpmJvMtnnqLKlT+COlqAt9cQ==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
-        "buffer": "^5.2.1",
-        "cuint": "^0.2.2",
-        "nan": "^2.13.2",
-        "xxhashjs": "^0.2.2"
+        "@node-rs/helper": "^1.3.3"
       },
       "engines": {
-        "node": ">= 0.10"
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@antoniomuso/lz4-napi-android-arm-eabi": "2.9.0",
+        "@antoniomuso/lz4-napi-android-arm64": "2.9.0",
+        "@antoniomuso/lz4-napi-darwin-arm64": "2.9.0",
+        "@antoniomuso/lz4-napi-darwin-x64": "2.9.0",
+        "@antoniomuso/lz4-napi-freebsd-x64": "2.9.0",
+        "@antoniomuso/lz4-napi-linux-arm-gnueabihf": "2.9.0",
+        "@antoniomuso/lz4-napi-linux-arm64-gnu": "2.9.0",
+        "@antoniomuso/lz4-napi-linux-arm64-musl": "2.9.0",
+        "@antoniomuso/lz4-napi-linux-x64-gnu": "2.9.0",
+        "@antoniomuso/lz4-napi-linux-x64-musl": "2.9.0",
+        "@antoniomuso/lz4-napi-win32-arm64-msvc": "2.9.0",
+        "@antoniomuso/lz4-napi-win32-ia32-msvc": "2.9.0",
+        "@antoniomuso/lz4-napi-win32-x64-msvc": "2.9.0"
       }
     },
     "node_modules/make-dir": {
@@ -4398,12 +4554,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "node_modules/nan": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
-      "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==",
-      "optional": true
     },
     "node_modules/nanoid": {
       "version": "3.3.3",
@@ -6291,15 +6441,6 @@
         "async-limiter": "~1.0.0"
       }
     },
-    "node_modules/xxhashjs": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/xxhashjs/-/xxhashjs-0.2.2.tgz",
-      "integrity": "sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==",
-      "optional": true,
-      "dependencies": {
-        "cuint": "^0.2.2"
-      }
-    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -6428,6 +6569,84 @@
         "@jridgewell/gen-mapping": "^0.1.0",
         "@jridgewell/trace-mapping": "^0.3.9"
       }
+    },
+    "@antoniomuso/lz4-napi-android-arm-eabi": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-android-arm-eabi/-/lz4-napi-android-arm-eabi-2.9.0.tgz",
+      "integrity": "sha512-aeT/9SoWq7rnmzssWuCKUPaxVt3fzE9q+xq/ZHbnUSmrm8/EhLOACMvQeCOnL0IZsmPh8EpuwIE1TZyM9iQPRA==",
+      "optional": true
+    },
+    "@antoniomuso/lz4-napi-android-arm64": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-android-arm64/-/lz4-napi-android-arm64-2.9.0.tgz",
+      "integrity": "sha512-ibQ0qiEvmljXAM97IgOZfh+PeiSQ0Rqf2HErJlZPVm2v4GVJoB67v21v1TUydqNNV5L8bwufVoZ90nheL8X9ZA==",
+      "optional": true
+    },
+    "@antoniomuso/lz4-napi-darwin-arm64": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-darwin-arm64/-/lz4-napi-darwin-arm64-2.9.0.tgz",
+      "integrity": "sha512-1su4K1MWa4bcWoZlHajv+luGmFDV1JwIsvjtDF+0HhUveSDPP+8A4Z34zOZidURIr08Sl7M7ViPth6ZQ9SqnAA==",
+      "optional": true
+    },
+    "@antoniomuso/lz4-napi-darwin-x64": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-darwin-x64/-/lz4-napi-darwin-x64-2.9.0.tgz",
+      "integrity": "sha512-8Lnbm2MkdJtiJ/nbcRS9zRyGp3G0sG6D+Y/x1vTP8nZs3/f8tBwYNsjxCQyyXNNyHcYWwVGbk68onP/pyDljOA==",
+      "optional": true
+    },
+    "@antoniomuso/lz4-napi-freebsd-x64": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-freebsd-x64/-/lz4-napi-freebsd-x64-2.9.0.tgz",
+      "integrity": "sha512-k04EMVOjntKDPrdR4Tf8WyNseuk9PTtSGw8WHyp4CTjoR1s+YJxtp9SMnThe5o2q0TATwk8WGYb/Howrp5OMxw==",
+      "optional": true
+    },
+    "@antoniomuso/lz4-napi-linux-arm-gnueabihf": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-linux-arm-gnueabihf/-/lz4-napi-linux-arm-gnueabihf-2.9.0.tgz",
+      "integrity": "sha512-H92F8zPZmgy2r8IhCWh3qIBfLp2BQ5cp18RoDXhtGFWwkh+5gVWrZp11IVznrsdgB0QeW0VR7dAMMHg3WLOPfA==",
+      "optional": true
+    },
+    "@antoniomuso/lz4-napi-linux-arm64-gnu": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-linux-arm64-gnu/-/lz4-napi-linux-arm64-gnu-2.9.0.tgz",
+      "integrity": "sha512-25crh0qs/3Rj3fMI8ulYD0DoaKsidUhMBki2aeO69ZK+F8bmQ/e2++FlgJ6f3EgMP5CNxJtnZXKhPOraQWjwAw==",
+      "optional": true
+    },
+    "@antoniomuso/lz4-napi-linux-arm64-musl": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-linux-arm64-musl/-/lz4-napi-linux-arm64-musl-2.9.0.tgz",
+      "integrity": "sha512-eJtHp38zuLaYI0/cOV/BKcNQiXUBo4GPx53FTf0Y307yUjLsn48LNeN0vD28Ct9YrbUae3bQvMD5AD86She0ww==",
+      "optional": true
+    },
+    "@antoniomuso/lz4-napi-linux-x64-gnu": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-linux-x64-gnu/-/lz4-napi-linux-x64-gnu-2.9.0.tgz",
+      "integrity": "sha512-mDjS4dyjRKaZQcAP71SphkYH5r3kufB30ih/VETVu/br2toCfBk6Zr1xhL1r+L7FaVAFzF62B7h30CiqrN0Awg==",
+      "optional": true
+    },
+    "@antoniomuso/lz4-napi-linux-x64-musl": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-linux-x64-musl/-/lz4-napi-linux-x64-musl-2.9.0.tgz",
+      "integrity": "sha512-pvU7Z7qjkjn17NkddBtBQ7C2iRqjtZ7WJ3Jqrjtj4XxolY3Q0HaYMvWjkWhzb9AKGZbj5y+EHYtbVoZJ2TSQhQ==",
+      "optional": true
+    },
+    "@antoniomuso/lz4-napi-win32-arm64-msvc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-win32-arm64-msvc/-/lz4-napi-win32-arm64-msvc-2.9.0.tgz",
+      "integrity": "sha512-aioLlbpJl0QPEXLXhh2bzyitc3T7Jot3f1ap6WdKiRa+CIjMHXw1nxJXy07MLXif10r+qVZr86ic8dvwErgqEQ==",
+      "optional": true
+    },
+    "@antoniomuso/lz4-napi-win32-ia32-msvc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-win32-ia32-msvc/-/lz4-napi-win32-ia32-msvc-2.9.0.tgz",
+      "integrity": "sha512-VaF4XMTdYb59TsPsiqnWwsNaWKHhgxF33z5p4zg4n0tp20eWozl76hn8B+aXthSs40W0W1N97QhxxV4oXGd8cg==",
+      "optional": true
+    },
+    "@antoniomuso/lz4-napi-win32-x64-msvc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@antoniomuso/lz4-napi-win32-x64-msvc/-/lz4-napi-win32-x64-msvc-2.9.0.tgz",
+      "integrity": "sha512-wfA8ShO3eGLxJ1LDwXJo87XL2D4NkMJV1pfHPvLZpD0MWb9u8VfgS+gKK5YhT7XKjzVdeIna9jgFdn2HBnZBxA==",
+      "optional": true
     },
     "@babel/code-frame": {
       "version": "7.22.13",
@@ -7015,6 +7234,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "@napi-rs/triples": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/triples/-/triples-1.2.0.tgz",
+      "integrity": "sha512-HAPjR3bnCsdXBsATpDIP5WCrw0JcACwhhrwIAQhiR46n+jm+a2F8kBsfseAuWtSyQ+H3Yebt2k43B5dy+04yMA==",
+      "optional": true
+    },
+    "@node-rs/helper": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/helper/-/helper-1.6.0.tgz",
+      "integrity": "sha512-2OTh/tokcLA1qom1zuCJm2gQzaZljCCbtX1YCrwRVd/toz7KxaDRFeLTAPwhs8m9hWgzrBn5rShRm6IaZofCPw==",
+      "optional": true,
+      "requires": {
+        "@napi-rs/triples": "^1.2.0"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -7152,15 +7386,6 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
-    },
-    "@types/lz4": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/@types/lz4/-/lz4-0.6.4.tgz",
-      "integrity": "sha512-vvxMIkowyHbY6zkCantyYwAK83N5E04bzFZSPJICG1SDpaL89L7lObs9DhLuhJhXHCQMkjzN3LYoAH6LjfwMFQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@types/mocha": {
       "version": "10.0.6",
@@ -7594,12 +7819,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
-    "base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "optional": true
-    },
     "basic-ftp": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.3.tgz",
@@ -7651,16 +7870,6 @@
         "electron-to-chromium": "^1.4.202",
         "node-releases": "^2.0.6",
         "update-browserslist-db": "^1.0.5"
-      }
-    },
-    "buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "optional": true,
-      "requires": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
       }
     },
     "caching-transform": {
@@ -7937,12 +8146,6 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
-    },
-    "cuint": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
-      "integrity": "sha512-d4ZVpCW31eWwCMe1YT3ur7mUDnTXbgwyzaL320DrcRT45rfjYxkt5QWLrmOJ+/UEAI2+fQgKe/fCjR8l4TpRgw==",
-      "optional": true
     },
     "damerau-levenshtein": {
       "version": "1.0.8",
@@ -8953,12 +9156,6 @@
         "debug": "4"
       }
     },
-    "ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "optional": true
-    },
     "ignore": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
@@ -9510,16 +9707,26 @@
         "yallist": "^4.0.0"
       }
     },
-    "lz4": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/lz4/-/lz4-0.6.5.tgz",
-      "integrity": "sha512-KSZcJU49QZOlJSItaeIU3p8WoAvkTmD9fJqeahQXNu1iQ/kR0/mQLdbrK8JY9MY8f6AhJoMrihp1nu1xDbscSQ==",
+    "lz4-napi": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/lz4-napi/-/lz4-napi-2.9.0.tgz",
+      "integrity": "sha512-ZOWqxBMIK5768aD20tYn5B6Pp9WPM9UG/LHk8neG9p0gC1DtjdzhTtlkxhAjvTRpmJvMtnnqLKlT+COlqAt9cQ==",
       "optional": true,
       "requires": {
-        "buffer": "^5.2.1",
-        "cuint": "^0.2.2",
-        "nan": "^2.13.2",
-        "xxhashjs": "^0.2.2"
+        "@antoniomuso/lz4-napi-android-arm-eabi": "2.9.0",
+        "@antoniomuso/lz4-napi-android-arm64": "2.9.0",
+        "@antoniomuso/lz4-napi-darwin-arm64": "2.9.0",
+        "@antoniomuso/lz4-napi-darwin-x64": "2.9.0",
+        "@antoniomuso/lz4-napi-freebsd-x64": "2.9.0",
+        "@antoniomuso/lz4-napi-linux-arm-gnueabihf": "2.9.0",
+        "@antoniomuso/lz4-napi-linux-arm64-gnu": "2.9.0",
+        "@antoniomuso/lz4-napi-linux-arm64-musl": "2.9.0",
+        "@antoniomuso/lz4-napi-linux-x64-gnu": "2.9.0",
+        "@antoniomuso/lz4-napi-linux-x64-musl": "2.9.0",
+        "@antoniomuso/lz4-napi-win32-arm64-msvc": "2.9.0",
+        "@antoniomuso/lz4-napi-win32-ia32-msvc": "2.9.0",
+        "@antoniomuso/lz4-napi-win32-x64-msvc": "2.9.0",
+        "@node-rs/helper": "^1.3.3"
       }
     },
     "make-dir": {
@@ -9659,12 +9866,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "nan": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
-      "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==",
-      "optional": true
     },
     "nanoid": {
       "version": "3.3.3",
@@ -11051,15 +11252,6 @@
       "integrity": "sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==",
       "requires": {
         "async-limiter": "~1.0.0"
-      }
-    },
-    "xxhashjs": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/xxhashjs/-/xxhashjs-0.2.2.tgz",
-      "integrity": "sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==",
-      "optional": true,
-      "requires": {
-        "cuint": "^0.2.2"
       }
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
   "devDependencies": {
     "@types/chai": "^4.3.14",
     "@types/http-proxy": "^1.17.14",
-    "@types/lz4": "^0.6.4",
     "@types/mocha": "^10.0.6",
     "@types/node": "^18.11.9",
     "@types/node-fetch": "^2.6.4",
@@ -89,6 +88,6 @@
     "winston": "^3.8.2"
   },
   "optionalDependencies": {
-    "lz4": "^0.6.5"
+    "lz4-napi": "^2.9.0"
   }
 }

--- a/tests/unit/result/ArrowResultHandler.test.ts
+++ b/tests/unit/result/ArrowResultHandler.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import Int64 from 'node-int64';
-import LZ4 from 'lz4';
+import { compressFrameSync } from 'lz4-napi';
 import ArrowResultHandler from '../../../lib/result/ArrowResultHandler';
 import ResultsProviderStub from '../.stubs/ResultsProviderStub';
 import { TRowSet, TSparkArrowBatch, TStatusCode, TTableSchema } from '../../../thrift/TCLIService_types';
@@ -39,7 +39,7 @@ const sampleRowSet1LZ4Compressed: TRowSet = {
   rows: [],
   arrowBatches: sampleRowSet1.arrowBatches?.map((item) => ({
     ...item,
-    batch: LZ4.encode(item.batch),
+    batch: compressFrameSync(item.batch),
   })),
 };
 

--- a/tests/unit/result/CloudFetchResultHandler.test.ts
+++ b/tests/unit/result/CloudFetchResultHandler.test.ts
@@ -1,7 +1,7 @@
 import { expect, AssertionError } from 'chai';
 import sinon, { SinonStub } from 'sinon';
 import Int64 from 'node-int64';
-import LZ4 from 'lz4';
+import { compressFrameSync } from 'lz4-napi';
 import { Request, Response } from 'node-fetch';
 import { ShouldRetryResult } from '../../../lib/connection/contracts/IRetryPolicy';
 import { HttpTransactionDetails } from '../../../lib/connection/contracts/IConnectionProvider';
@@ -306,7 +306,7 @@ describe('CloudFetchResultHandler', () => {
 
     context.invokeWithRetryStub.callsFake(async () => ({
       request: new Request('localhost'),
-      response: new Response(LZ4.encode(expectedBatch), { status: 200 }),
+      response: new Response(compressFrameSync(expectedBatch), { status: 200 }),
     }));
 
     expect(await rowSetProvider.hasMore()).to.be.true;

--- a/tests/unit/utils/lz4.test.ts
+++ b/tests/unit/utils/lz4.test.ts
@@ -22,9 +22,7 @@ describe('lz4 module loader', () => {
     });
   });
 
-  const mockModuleLoad = (
-    lz4MockOrError: unknown,
-  ): { restore: () => void; wasLz4LoadAttempted: () => boolean } => {
+  const mockModuleLoad = (lz4MockOrError: unknown): { restore: () => void; wasLz4LoadAttempted: () => boolean } => {
     // eslint-disable-next-line global-require
     const Module = require('module');
     const originalLoad = Module._load;

--- a/tests/unit/utils/lz4.test.ts
+++ b/tests/unit/utils/lz4.test.ts
@@ -22,14 +22,16 @@ describe('lz4 module loader', () => {
     });
   });
 
-  const mockModuleLoad = (lz4MockOrError: unknown): { restore: () => void; wasLz4LoadAttempted: () => boolean } => {
+  const mockModuleLoad = (
+    lz4MockOrError: unknown,
+  ): { restore: () => void; wasLz4LoadAttempted: () => boolean } => {
     // eslint-disable-next-line global-require
     const Module = require('module');
     const originalLoad = Module._load;
     let lz4LoadAttempted = false;
 
     Module._load = (request: string, parent: unknown, isMain: boolean) => {
-      if (request === 'lz4') {
+      if (request === 'lz4-napi') {
         lz4LoadAttempted = true;
         if (lz4MockOrError instanceof Error) {
           throw lz4MockOrError;
@@ -53,19 +55,19 @@ describe('lz4 module loader', () => {
     return require('../../../lib/utils/lz4');
   };
 
-  it('should successfully load and use lz4 module when available', () => {
-    const fakeLz4 = {
-      encode: (buf: Buffer) => {
+  it('should successfully load and use lz4-napi module when available', () => {
+    const fakeLz4Napi = {
+      compressFrameSync: (buf: Buffer) => {
         const compressed = Buffer.from(`compressed:${buf.toString()}`);
         return compressed;
       },
-      decode: (buf: Buffer) => {
+      decompressFrameSync: (buf: Buffer) => {
         const decompressed = buf.toString().replace('compressed:', '');
         return Buffer.from(decompressed);
       },
     };
 
-    const { restore } = mockModuleLoad(fakeLz4);
+    const { restore } = mockModuleLoad(fakeLz4Napi);
     const moduleExports = loadLz4Module();
     const lz4Module = moduleExports.default();
     restore();
@@ -82,8 +84,8 @@ describe('lz4 module loader', () => {
     expect(consoleWarnStub.called).to.be.false;
   });
 
-  it('should return undefined when lz4 module fails to load with MODULE_NOT_FOUND', () => {
-    const err: NodeJS.ErrnoException = new Error("Cannot find module 'lz4'");
+  it('should return undefined when lz4-napi module fails to load with MODULE_NOT_FOUND', () => {
+    const err: NodeJS.ErrnoException = new Error("Cannot find module 'lz4-napi'");
     err.code = 'MODULE_NOT_FOUND';
 
     const { restore } = mockModuleLoad(err);
@@ -95,7 +97,7 @@ describe('lz4 module loader', () => {
     expect(consoleWarnStub.called).to.be.false;
   });
 
-  it('should return undefined and log warning when lz4 fails with ERR_DLOPEN_FAILED', () => {
+  it('should return undefined and log warning when lz4-napi fails with ERR_DLOPEN_FAILED', () => {
     const err: NodeJS.ErrnoException = new Error('Module did not self-register');
     err.code = 'ERR_DLOPEN_FAILED';
 
@@ -109,7 +111,7 @@ describe('lz4 module loader', () => {
     expect(consoleWarnStub.firstCall.args[0]).to.include('Architecture or version mismatch');
   });
 
-  it('should return undefined and log warning when lz4 fails with unknown error code', () => {
+  it('should return undefined and log warning when lz4-napi fails with unknown error code', () => {
     const err: NodeJS.ErrnoException = new Error('Some unknown error');
     err.code = 'UNKNOWN_ERROR';
 
@@ -136,13 +138,13 @@ describe('lz4 module loader', () => {
     expect(consoleWarnStub.firstCall.args[0]).to.include('Invalid error object');
   });
 
-  it('should not attempt to load lz4 module when getResolvedModule is not called', () => {
-    const fakeLz4 = {
-      encode: () => Buffer.from(''),
-      decode: () => Buffer.from(''),
+  it('should not attempt to load lz4-napi module when getResolvedModule is not called', () => {
+    const fakeLz4Napi = {
+      compressFrameSync: () => Buffer.from(''),
+      decompressFrameSync: () => Buffer.from(''),
     };
 
-    const { restore, wasLz4LoadAttempted } = mockModuleLoad(fakeLz4);
+    const { restore, wasLz4LoadAttempted } = mockModuleLoad(fakeLz4Napi);
 
     // Load the module but don't call getResolvedModule
     loadLz4Module();


### PR DESCRIPTION
The lz4 npm package (pierrec/node-lz4) is archived and bundles liblz4 v1.9.2, which is vulnerable to CVE-2021-3520 (CVSS 9.8). Replace it with lz4-napi, which uses Rust/napi-rs bindings and supports the LZ4 frame API required for result decompression.

Resolves: SEC-15865, PECO-2020