### PR TITLE
ci: migrate to hardened runners, disable publish during freeze

### DIFF
--- a/.github/actions/setup-jfrog/action.yml
+++ b/.github/actions/setup-jfrog/action.yml
@@ -1,0 +1,36 @@
+name: Setup JFrog OIDC
+description: Obtain a JFrog access token via GitHub OIDC and configure npm to use JFrog registry proxy
+
+runs:
+  using: composite
+  steps:
+    - name: Get JFrog OIDC token
+      shell: bash
+      run: |
+        set -euo pipefail
+        ID_TOKEN=$(curl -sLS \
+          -H "User-Agent: actions/oidc-client" \
+          -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+          "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=jfrog-github" | jq .value | tr -d '"')
+        echo "::add-mask::${ID_TOKEN}"
+        ACCESS_TOKEN=$(curl -sLS -XPOST -H "Content-Type: application/json" \
+          "https://databricks.jfrog.io/access/api/v1/oidc/token" \
+          -d "{\"grant_type\": \"urn:ietf:params:oauth:grant-type:token-exchange\", \"subject_token_type\":\"urn:ietf:params:oauth:token-type:id_token\", \"subject_token\": \"${ID_TOKEN}\", \"provider_name\": \"github-actions\"}" | jq .access_token | tr -d '"')
+        echo "::add-mask::${ACCESS_TOKEN}"
+        if [ -z "$ACCESS_TOKEN" ] || [ "$ACCESS_TOKEN" = "null" ]; then
+          echo "FAIL: Could not extract JFrog access token"
+          exit 1
+        fi
+        echo "JFROG_ACCESS_TOKEN=${ACCESS_TOKEN}" >> "$GITHUB_ENV"
+        echo "JFrog OIDC token obtained successfully"
+
+    - name: Configure npm for JFrog
+      shell: bash
+      run: |
+        set -euo pipefail
+        cat > ~/.npmrc << EOF
+        registry=https://databricks.jfrog.io/artifactory/api/npm/db-npm/
+        //databricks.jfrog.io/artifactory/api/npm/db-npm/:_authToken=${JFROG_ACCESS_TOKEN}
+        always-auth=true
+        EOF
+        echo "npm configured to use JFrog registry"

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -8,7 +8,9 @@ permissions:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,33 +22,7 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
-      - name: Get JFrog OIDC token
-        run: |
-          set -euo pipefail
-          ID_TOKEN=$(curl -sLS \
-            -H "User-Agent: actions/oidc-client" \
-            -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=jfrog-github" | jq .value | tr -d '"')
-          echo "::add-mask::${ID_TOKEN}"
-          ACCESS_TOKEN=$(curl -sLS -XPOST -H "Content-Type: application/json" \
-            "https://databricks.jfrog.io/access/api/v1/oidc/token" \
-            -d "{\"grant_type\": \"urn:ietf:params:oauth:grant-type:token-exchange\", \"subject_token_type\":\"urn:ietf:params:oauth:token-type:id_token\", \"subject_token\": \"${ID_TOKEN}\", \"provider_name\": \"github-actions\"}" | jq .access_token | tr -d '"')
-          echo "::add-mask::${ACCESS_TOKEN}"
-          if [ -z "$ACCESS_TOKEN" ] || [ "$ACCESS_TOKEN" = "null" ]; then
-            echo "FAIL: Could not extract JFrog access token"
-            exit 1
-          fi
-          echo "JFROG_ACCESS_TOKEN=${ACCESS_TOKEN}" >> "$GITHUB_ENV"
-          echo "JFrog OIDC token obtained successfully"
-      - name: Configure npm for JFrog
-        run: |
-          set -euo pipefail
-          cat > ~/.npmrc << EOF
-          registry=https://databricks.jfrog.io/artifactory/api/npm/db-npm/
-          //databricks.jfrog.io/artifactory/api/npm/db-npm/:_authToken=${JFROG_ACCESS_TOKEN}
-          always-auth=true
-          EOF
-          echo "npm configured to use JFrog registry"
+      - uses: ./.github/actions/setup-jfrog
       - name: Cache node modules
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         env:
@@ -88,33 +62,7 @@ jobs:
         uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: '3.10'
-      - name: Get JFrog OIDC token
-        run: |
-          set -euo pipefail
-          ID_TOKEN=$(curl -sLS \
-            -H "User-Agent: actions/oidc-client" \
-            -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=jfrog-github" | jq .value | tr -d '"')
-          echo "::add-mask::${ID_TOKEN}"
-          ACCESS_TOKEN=$(curl -sLS -XPOST -H "Content-Type: application/json" \
-            "https://databricks.jfrog.io/access/api/v1/oidc/token" \
-            -d "{\"grant_type\": \"urn:ietf:params:oauth:grant-type:token-exchange\", \"subject_token_type\":\"urn:ietf:params:oauth:token-type:id_token\", \"subject_token\": \"${ID_TOKEN}\", \"provider_name\": \"github-actions\"}" | jq .access_token | tr -d '"')
-          echo "::add-mask::${ACCESS_TOKEN}"
-          if [ -z "$ACCESS_TOKEN" ] || [ "$ACCESS_TOKEN" = "null" ]; then
-            echo "FAIL: Could not extract JFrog access token"
-            exit 1
-          fi
-          echo "JFROG_ACCESS_TOKEN=${ACCESS_TOKEN}" >> "$GITHUB_ENV"
-          echo "JFrog OIDC token obtained successfully"
-      - name: Configure npm for JFrog
-        run: |
-          set -euo pipefail
-          cat > ~/.npmrc << EOF
-          registry=https://databricks.jfrog.io/artifactory/api/npm/db-npm/
-          //databricks.jfrog.io/artifactory/api/npm/db-npm/:_authToken=${JFROG_ACCESS_TOKEN}
-          always-auth=true
-          EOF
-          echo "npm configured to use JFrog registry"
+      - uses: ./.github/actions/setup-jfrog
       - name: Cache node modules
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
@@ -157,33 +105,7 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
-      - name: Get JFrog OIDC token
-        run: |
-          set -euo pipefail
-          ID_TOKEN=$(curl -sLS \
-            -H "User-Agent: actions/oidc-client" \
-            -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=jfrog-github" | jq .value | tr -d '"')
-          echo "::add-mask::${ID_TOKEN}"
-          ACCESS_TOKEN=$(curl -sLS -XPOST -H "Content-Type: application/json" \
-            "https://databricks.jfrog.io/access/api/v1/oidc/token" \
-            -d "{\"grant_type\": \"urn:ietf:params:oauth:grant-type:token-exchange\", \"subject_token_type\":\"urn:ietf:params:oauth:token-type:id_token\", \"subject_token\": \"${ID_TOKEN}\", \"provider_name\": \"github-actions\"}" | jq .access_token | tr -d '"')
-          echo "::add-mask::${ACCESS_TOKEN}"
-          if [ -z "$ACCESS_TOKEN" ] || [ "$ACCESS_TOKEN" = "null" ]; then
-            echo "FAIL: Could not extract JFrog access token"
-            exit 1
-          fi
-          echo "JFROG_ACCESS_TOKEN=${ACCESS_TOKEN}" >> "$GITHUB_ENV"
-          echo "JFrog OIDC token obtained successfully"
-      - name: Configure npm for JFrog
-        run: |
-          set -euo pipefail
-          cat > ~/.npmrc << EOF
-          registry=https://databricks.jfrog.io/artifactory/api/npm/db-npm/
-          //databricks.jfrog.io/artifactory/api/npm/db-npm/:_authToken=${JFROG_ACCESS_TOKEN}
-          always-auth=true
-          EOF
-          echo "npm configured to use JFrog registry"
+      - uses: ./.github/actions/setup-jfrog
       - name: Cache node modules
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,9 @@ jobs:
       labels: linux-ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 20
       - name: Get JFrog OIDC token
         run: |
           set -euo pipefail
@@ -151,6 +154,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 20
       - name: Get JFrog OIDC token
         run: |
           set -euo pipefail

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   lint:
@@ -18,6 +19,33 @@ jobs:
       labels: linux-ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Get JFrog OIDC token
+        run: |
+          set -euo pipefail
+          ID_TOKEN=$(curl -sLS \
+            -H "User-Agent: actions/oidc-client" \
+            -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=jfrog-github" | jq .value | tr -d '"')
+          echo "::add-mask::${ID_TOKEN}"
+          ACCESS_TOKEN=$(curl -sLS -XPOST -H "Content-Type: application/json" \
+            "https://databricks.jfrog.io/access/api/v1/oidc/token" \
+            -d "{\"grant_type\": \"urn:ietf:params:oauth:grant-type:token-exchange\", \"subject_token_type\":\"urn:ietf:params:oauth:token-type:id_token\", \"subject_token\": \"${ID_TOKEN}\", \"provider_name\": \"github-actions\"}" | jq .access_token | tr -d '"')
+          echo "::add-mask::${ACCESS_TOKEN}"
+          if [ -z "$ACCESS_TOKEN" ] || [ "$ACCESS_TOKEN" = "null" ]; then
+            echo "FAIL: Could not extract JFrog access token"
+            exit 1
+          fi
+          echo "JFROG_ACCESS_TOKEN=${ACCESS_TOKEN}" >> "$GITHUB_ENV"
+          echo "JFrog OIDC token obtained successfully"
+      - name: Configure npm for JFrog
+        run: |
+          set -euo pipefail
+          cat > ~/.npmrc << EOF
+          registry=https://databricks.jfrog.io/artifactory/api/npm/db-npm/
+          //databricks.jfrog.io/artifactory/api/npm/db-npm/:_authToken=${JFROG_ACCESS_TOKEN}
+          always-auth=true
+          EOF
+          echo "npm configured to use JFrog registry"
       - name: Cache node modules
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         env:
@@ -57,6 +85,33 @@ jobs:
         uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: '3.10'
+      - name: Get JFrog OIDC token
+        run: |
+          set -euo pipefail
+          ID_TOKEN=$(curl -sLS \
+            -H "User-Agent: actions/oidc-client" \
+            -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=jfrog-github" | jq .value | tr -d '"')
+          echo "::add-mask::${ID_TOKEN}"
+          ACCESS_TOKEN=$(curl -sLS -XPOST -H "Content-Type: application/json" \
+            "https://databricks.jfrog.io/access/api/v1/oidc/token" \
+            -d "{\"grant_type\": \"urn:ietf:params:oauth:grant-type:token-exchange\", \"subject_token_type\":\"urn:ietf:params:oauth:token-type:id_token\", \"subject_token\": \"${ID_TOKEN}\", \"provider_name\": \"github-actions\"}" | jq .access_token | tr -d '"')
+          echo "::add-mask::${ACCESS_TOKEN}"
+          if [ -z "$ACCESS_TOKEN" ] || [ "$ACCESS_TOKEN" = "null" ]; then
+            echo "FAIL: Could not extract JFrog access token"
+            exit 1
+          fi
+          echo "JFROG_ACCESS_TOKEN=${ACCESS_TOKEN}" >> "$GITHUB_ENV"
+          echo "JFrog OIDC token obtained successfully"
+      - name: Configure npm for JFrog
+        run: |
+          set -euo pipefail
+          cat > ~/.npmrc << EOF
+          registry=https://databricks.jfrog.io/artifactory/api/npm/db-npm/
+          //databricks.jfrog.io/artifactory/api/npm/db-npm/:_authToken=${JFROG_ACCESS_TOKEN}
+          always-auth=true
+          EOF
+          echo "npm configured to use JFrog registry"
       - name: Cache node modules
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
@@ -96,6 +151,33 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Get JFrog OIDC token
+        run: |
+          set -euo pipefail
+          ID_TOKEN=$(curl -sLS \
+            -H "User-Agent: actions/oidc-client" \
+            -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=jfrog-github" | jq .value | tr -d '"')
+          echo "::add-mask::${ID_TOKEN}"
+          ACCESS_TOKEN=$(curl -sLS -XPOST -H "Content-Type: application/json" \
+            "https://databricks.jfrog.io/access/api/v1/oidc/token" \
+            -d "{\"grant_type\": \"urn:ietf:params:oauth:grant-type:token-exchange\", \"subject_token_type\":\"urn:ietf:params:oauth:token-type:id_token\", \"subject_token\": \"${ID_TOKEN}\", \"provider_name\": \"github-actions\"}" | jq .access_token | tr -d '"')
+          echo "::add-mask::${ACCESS_TOKEN}"
+          if [ -z "$ACCESS_TOKEN" ] || [ "$ACCESS_TOKEN" = "null" ]; then
+            echo "FAIL: Could not extract JFrog access token"
+            exit 1
+          fi
+          echo "JFROG_ACCESS_TOKEN=${ACCESS_TOKEN}" >> "$GITHUB_ENV"
+          echo "JFrog OIDC token obtained successfully"
+      - name: Configure npm for JFrog
+        run: |
+          set -euo pipefail
+          cat > ~/.npmrc << EOF
+          registry=https://databricks.jfrog.io/artifactory/api/npm/db-npm/
+          //databricks.jfrog.io/artifactory/api/npm/db-npm/:_authToken=${JFROG_ACCESS_TOKEN}
+          always-auth=true
+          EOF
+          echo "npm configured to use JFrog registry"
       - name: Cache node modules
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,9 @@ permissions:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Cache node modules
@@ -34,7 +36,9 @@ jobs:
           npm run lint
 
   unit-test:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     strategy:
       matrix:
         # only LTS versions starting from the lowest we support
@@ -75,7 +79,9 @@ jobs:
           retention-days: 1
 
   e2e-test:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     environment: azure-prod
     env:
       E2E_HOST: ${{ secrets.DATABRICKS_HOST }}
@@ -113,7 +119,9 @@ jobs:
 
   coverage:
     needs: [unit-test, e2e-test]
-    runs-on: ubuntu-latest
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     env:
       cache-name: cache-node-modules
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-package-lock=true
+package-lock=false

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-package-lock=false
+package-lock=true


### PR DESCRIPTION
## Summary

- Switch all workflow jobs in `main.yml` and `dco-check.yml` from `ubuntu-latest` to `databricks-protected-runner-group` hardened runners per [go/hardened-gha](http://go/hardened-gha) step 3
- Add JFrog Artifactory OIDC proxy for npm registry access — hardened runners block direct access to public registries, so all jobs running `npm ci` now authenticate via JFrog OIDC token exchange per the remote registry access guidance
- Add explicit `setup-node` to `lint` and `e2e-test` jobs — hardened runners may not have Node.js pre-installed (reported by Pieter in #unblock-github-action-for-eng)

Related PRs: release workflow removed in #354, .npmrc fix in #355.

### Context

This is part of the release freeze unblock process. The repo GitHub Actions are currently disabled at the org level. This PR addresses checklist steps 3 and 9 (registry access) to unblock CI re-enablement.

### Known limitations

- **Fork PRs**: The JFrog OIDC token exchange requires id-token: write, which GitHub does not grant to pull_request events from forks. Fork PRs will fail at the "Get JFrog OIDC token" step. This is inherent to the hardened runner setup and affects all public OSS repos.

## Test plan

- [ ] After Actions are re-enabled, verify CI jobs (lint, unit-test, e2e-test, coverage, dco-check) run successfully on hardened runners
- [ ] Verify JFrog OIDC token exchange succeeds and npm ci pulls packages through the proxy

This pull request was AI-assisted by Isaac.