### PR TITLE
fix: change .npmrc package-lock from false to true

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-package-lock=false
+package-lock=true


### PR DESCRIPTION
## Summary

Change `package-lock=false` to `package-lock=true` in `.npmrc`. The old setting prevents npm from updating `package-lock.json` during local development, causing drift between what developers test locally and what `npm ci` installs in CI.

Flagged as MEDIUM in the Isaac V2 supply chain security analysis.

## Test plan

- [ ] Verify `npm ci` still works correctly
- [ ] Verify `npm install` now updates `package-lock.json` as expected

This pull request was AI-assisted by Isaac.