### PR TITLE
Fix Azure AD OAuth: tenant-aware discovery URL + correct scope resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## Unreleased
+
+- Fix Azure AD OAuth for tenant-specific and single-tenant Entra apps, and correct the scope resource: use the Databricks Azure Login App ID (not the tenant GUID) as the OAuth scope; route OIDC discovery to `login.microsoftonline.com/${azureTenantId}/` when `azureTenantId` is provided (fallback `/organizations/` preserved).
+
 ## 1.13.0
 
 - Add token federation support with custom token providers (databricks/databricks-sql-nodejs#318, databricks/databricks-sql-nodejs#319, databricks/databricks-sql-nodejs#320 by @madhav-db)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Release History
 
-## Unreleased
-
-- Fix Azure AD OAuth for tenant-specific and single-tenant Entra apps, and correct the scope resource: use the Databricks Azure Login App ID (not the tenant GUID) as the OAuth scope; route OIDC discovery to `login.microsoftonline.com/${azureTenantId}/` when `azureTenantId` is provided (fallback `/organizations/` preserved).
-
 ## 1.14.0
 
 - Add statement-level query tag support (databricks/databricks-sql-nodejs#366 by @sreekanth-db)

--- a/lib/connection/auth/DatabricksOAuth/OAuthManager.ts
+++ b/lib/connection/auth/DatabricksOAuth/OAuthManager.ts
@@ -277,7 +277,8 @@ export class AzureOAuthManager extends OAuthManager {
   public static datatricksAzureApp = '2ff814a6-3304-4ab8-85cb-cd0e6f879c1d';
 
   protected getOIDCConfigUrl(): string {
-    return 'https://login.microsoftonline.com/organizations/v2.0/.well-known/openid-configuration';
+    const tenantPath = this.options.azureTenantId ?? 'organizations';
+    return `https://login.microsoftonline.com/${tenantPath}/v2.0/.well-known/openid-configuration`;
   }
 
   protected getAuthorizationUrl(): string {
@@ -293,17 +294,18 @@ export class AzureOAuthManager extends OAuthManager {
   }
 
   protected getScopes(requestedScopes: OAuthScopes): OAuthScopes {
-    // There is no corresponding scopes in Azure, instead, access control will be delegated to Databricks
-    const tenantId = this.options.azureTenantId ?? AzureOAuthManager.datatricksAzureApp;
+    // There is no corresponding scopes in Azure, instead, access control will be delegated to Databricks.
+    // Scope must be the Azure *resource* ID (the Databricks Azure Login App), NOT the tenant ID.
+    const resourceId = AzureOAuthManager.datatricksAzureApp;
 
     const azureScopes = [];
 
     switch (this.options.flow) {
       case OAuthFlow.U2M:
-        azureScopes.push(`${tenantId}/user_impersonation`);
+        azureScopes.push(`${resourceId}/user_impersonation`);
         break;
       case OAuthFlow.M2M:
-        azureScopes.push(`${tenantId}/.default`);
+        azureScopes.push(`${resourceId}/.default`);
         break;
       // no default
     }

--- a/lib/connection/auth/DatabricksOAuth/OAuthManager.ts
+++ b/lib/connection/auth/DatabricksOAuth/OAuthManager.ts
@@ -277,7 +277,9 @@ export class AzureOAuthManager extends OAuthManager {
   public static datatricksAzureApp = '2ff814a6-3304-4ab8-85cb-cd0e6f879c1d';
 
   protected getOIDCConfigUrl(): string {
-    const tenantPath = this.options.azureTenantId ?? 'organizations';
+    // Use logical OR so empty / whitespace-only azureTenantId also falls back to /organizations/
+    // (`??` only substitutes for null/undefined, leaving `''` to produce a malformed `//v2.0/...` URL).
+    const tenantPath = this.options.azureTenantId?.trim() || 'organizations';
     return `https://login.microsoftonline.com/${tenantPath}/v2.0/.well-known/openid-configuration`;
   }
 

--- a/tests/unit/connection/auth/DatabricksOAuth/OAuthManager.test.ts
+++ b/tests/unit/connection/auth/DatabricksOAuth/OAuthManager.test.ts
@@ -547,6 +547,14 @@ describe('AzureOAuthManager (tenant awareness)', () => {
       const url = call<string>(mgr, 'getOIDCConfigUrl');
       expect(url).to.equal(`https://login.microsoftonline.com/${tenant}/v2.0/.well-known/openid-configuration`);
     });
+
+    it('falls back to /organizations/ when azureTenantId is empty or whitespace', () => {
+      for (const tenant of ['', '   ']) {
+        const mgr = makeAzure({ azureTenantId: tenant });
+        const url = call<string>(mgr, 'getOIDCConfigUrl');
+        expect(url).to.equal('https://login.microsoftonline.com/organizations/v2.0/.well-known/openid-configuration');
+      }
+    });
   });
 
   describe('getScopes — resource ID is always the Azure Login App, never a tenant GUID', () => {

--- a/tests/unit/connection/auth/DatabricksOAuth/OAuthManager.test.ts
+++ b/tests/unit/connection/auth/DatabricksOAuth/OAuthManager.test.ts
@@ -519,3 +519,57 @@ class OpenIDClientStub implements BaseClient {
     });
   });
 });
+
+describe('AzureOAuthManager (tenant awareness)', () => {
+  function makeAzure(overrides: Partial<OAuthManagerOptions> = {}) {
+    return new AzureOAuthManager({
+      host: 'adb-1234567890123456.1.azuredatabricks.net',
+      flow: OAuthFlow.M2M,
+      context: new ClientContextStub(),
+      ...overrides,
+    });
+  }
+
+  // Access protected methods for unit inspection.
+  const call = <T>(mgr: AzureOAuthManager, name: string, ...args: unknown[]): T =>
+    (mgr as unknown as Record<string, (...a: unknown[]) => T>)[name](...args);
+
+  describe('getOIDCConfigUrl', () => {
+    it('falls back to /organizations/ when azureTenantId is not set (baseline-compatible)', () => {
+      const mgr = makeAzure();
+      const url = call<string>(mgr, 'getOIDCConfigUrl');
+      expect(url).to.equal('https://login.microsoftonline.com/organizations/v2.0/.well-known/openid-configuration');
+    });
+
+    it('uses the caller-supplied tenant in the discovery URL when provided', () => {
+      const tenant = '9f37a392-f0ae-4280-9796-f1864a10effc';
+      const mgr = makeAzure({ azureTenantId: tenant });
+      const url = call<string>(mgr, 'getOIDCConfigUrl');
+      expect(url).to.equal(`https://login.microsoftonline.com/${tenant}/v2.0/.well-known/openid-configuration`);
+    });
+  });
+
+  describe('getScopes — resource ID is always the Azure Login App, never a tenant GUID', () => {
+    it('M2M scope uses the Databricks Azure Login App resource ID even when azureTenantId is set', () => {
+      const tenant = '9f37a392-f0ae-4280-9796-f1864a10effc';
+      const mgr = makeAzure({ azureTenantId: tenant, flow: OAuthFlow.M2M });
+      const scopes = call<string[]>(mgr, 'getScopes', []);
+      expect(scopes).to.include(`${AzureOAuthManager.datatricksAzureApp}/.default`);
+      expect(scopes).to.not.include(`${tenant}/.default`);
+    });
+
+    it('U2M scope uses the Databricks Azure Login App resource ID even when azureTenantId is set', () => {
+      const tenant = '9f37a392-f0ae-4280-9796-f1864a10effc';
+      const mgr = makeAzure({ azureTenantId: tenant, flow: OAuthFlow.U2M });
+      const scopes = call<string[]>(mgr, 'getScopes', []);
+      expect(scopes).to.include(`${AzureOAuthManager.datatricksAzureApp}/user_impersonation`);
+      expect(scopes).to.not.include(`${tenant}/user_impersonation`);
+    });
+
+    it('preserves offline_access when requested alongside M2M', () => {
+      const mgr = makeAzure({ flow: OAuthFlow.M2M });
+      const scopes = call<string[]>(mgr, 'getScopes', [OAuthScope.offlineAccess]);
+      expect(scopes).to.include(OAuthScope.offlineAccess);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`AzureOAuthManager` had two coupled bugs in how it constructed the Azure AD OAuth request. They were masked on the default path by two unrelated defaults happening to line up, but fired the moment a customer brought their own Entra app or set `azureTenantId` — which is the production-recommended posture (single-tenant Entra app per workspace, tenant supplied explicitly).

This PR fixes both Azure-AD-side bugs, plus a third small footgun (empty/whitespace `azureTenantId`) that the new template URL introduced.

## When this fires

Both U2M and M2M go through the same `AzureOAuthManager.getOIDCConfigUrl()` and `getScopes()` — Node has a single Azure code path, so any bug in those methods affects both flows. The bugs surface whenever any of the following is true:

- Caller sets `azureTenantId`
- Caller uses a **single-tenant** Entra app via `oauthClientId` (the security-recommended posture)
- Caller uses M2M with their own Entra app (typical for automated pipelines / SPN auth)

The default path (no `oauthClientId`, no `azureTenantId`, default multi-tenant Node client) works on baseline only because two unrelated defaults coincide. Any deviation from that exact default flips one or both bugs into a hard failure.

## Bug 1 — OIDC discovery URL is hardcoded to `/organizations/`, ignores `azureTenantId`

```ts
// before
return 'https://login.microsoftonline.com/organizations/v2.0/.well-known/openid-configuration';

// after
const tenantPath = this.options.azureTenantId?.trim() || 'organizations';
return `https://login.microsoftonline.com/${tenantPath}/v2.0/.well-known/openid-configuration`;
```

The `/organizations/` endpoint is Microsoft's "any work/school AAD tenant" multi-tenant endpoint. It only resolves for multi-tenant Entra apps. Single-tenant Entra apps fail at discovery with:

```
AADSTS50059: No tenant-identifying information found in either the request or implied by any provided credentials.
```

The customer-supplied `azureTenantId` was previously dropped on the floor — never used. After the fix, when `azureTenantId` is set the URL routes through that tenant; when unset the byte-identical `/organizations/` fallback is preserved for the default path.

The `?.trim() || 'organizations'` form (rather than `?? 'organizations'`) also handles empty-string and whitespace-only inputs (e.g. `process.env.AZURE_TENANT_ID ?? ''`) — without this, an empty value would render `https://login.microsoftonline.com//v2.0/...` (double slash) and surface as an opaque Azure 404.

## Bug 2 — OAuth scope used the tenant GUID where the Azure resource App ID belongs

```ts
// before
const tenantId = this.options.azureTenantId ?? AzureOAuthManager.datatricksAzureApp;
azureScopes.push(`${tenantId}/user_impersonation`);   // U2M
azureScopes.push(`${tenantId}/.default`);             // M2M

// after
const resourceId = AzureOAuthManager.datatricksAzureApp;
azureScopes.push(`${resourceId}/user_impersonation`);
azureScopes.push(`${resourceId}/.default`);
```

Azure v2.0 scope grammar is `<resource-app-id>/<permission-name>` — the segment before the slash is the application you're requesting a token *for* (the Databricks Azure Login App, `2ff814a6-3304-4ab8-85cb-cd0e6f879c1d`), not the user's tenant. The pre-fix variable name `tenantId` was a misnomer; the *fallback value* (`datatricksAzureApp`) happened to be the correct resource ID, so the default path produced a working scope by coincidence. The moment a caller set `azureTenantId`, the scope became `<tenant-GUID>/...` and Azure rejected with:

```
AADSTS500011: The resource principal named <tenant-GUID> was not found in the tenant named <tenant-GUID>.
```

The fix separates the two concepts cleanly:
- **Tenant** identifies an Entra directory → goes in the URL path of the discovery/token endpoints.
- **Resource** identifies an application you want a token for → goes in the `scope=` parameter.

## Empirical verification — pecotesting production workspace

Same SPN credential, same workspace, same tenant — only the SDK code differs.

`AzureOAuthManager.getToken()` directly, M2M flow with a customer Entra app (`d154b9ed-...`) and Azure-Portal client secret, against `adb-6436897454825492.12.azuredatabricks.net`, tenant `9f37a392-f0ae-4280-9796-f1864a10effc`:

| Branch | URL the manager built | Scope it sent | Azure response |
|---|---|---|---|
| `main` | `https://login.microsoftonline.com/organizations/v2.0/.well-known/openid-configuration` | `9f37a392-.../.default` (tenant GUID — Bug 2) | `AADSTS50059` — auth dies at discovery (Bug 1) |
| this PR | `https://login.microsoftonline.com/9f37a392-.../v2.0/.well-known/openid-configuration` | `2ff814a6-.../.default` (resource App ID — correct) | **real `access_token` issued** ✅ |

End-to-end through `DBSQLClient.connect()` with the same credentials:

| Branch | Result |
|---|---|
| `main` | `AADSTS50059` — driver cannot acquire an Azure token; never reaches the workspace |
| this PR | Azure issues access token; Thrift call reaches workspace; `HTTP 403` from workspace ACL on `2f03dd43e35e2aa0` (separate authorization layer — the test SPN doesn't have warehouse permissions). With a permissioned identity, this row is a clean PASS. |

The 403 in the post-fix row is the same workspace-level ACL check every Azure-authenticated client hits; it's downstream of any auth code. On `main` you cannot reach that check at all because Azure-AD authentication itself fails.

## Backward compatibility

When `azureTenantId` is unset, both methods produce **byte-identical** output to baseline:

- Discovery URL: `…/organizations/v2.0/…` — character-for-character unchanged.
- Scope: `2ff814a6-3304-4ab8-85cb-cd0e6f879c1d/.default` (M2M) or `…/user_impersonation` (U2M) — same value the pre-fix fallback produced.

Verified by reading both code paths and by running the default-path test against production (identical request, identical Azure response). No regression risk for the default multi-tenant Node client path that "worked by luck" before.

## Test plan

- [x] Unit tests: 6 new cases covering `getOIDCConfigUrl` (fallback, tenant-specific, empty/whitespace-fallback) and `getScopes` (resource-ID invariant for M2M+U2M, `offline_access` preserved). All 34 `AzureOAuthManager` + `DatabricksOAuthManager` suite tests pass locally.
- [x] Full unit test suite passes.
- [x] Live verification against pecotesting production workspace: `main` reproduces `AADSTS50059`; this branch produces a real Azure access token. End-to-end query blocked only by workspace ACL (separate from auth — confirmed by `PERMISSION_DENIED` from the SQL endpoint, not from Azure).
