### PR TITLE
prepare release 1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.14.0
+
+- Add statement-level query tag support (databricks/databricks-sql-nodejs#366 by @sreekanth-db)
+- Add AI coding agent detection to User-Agent header (databricks/databricks-sql-nodejs#333 by @vikrantpuppala)
+- Internal: telemetry infrastructure improvements — circuit breaker, feature flag cache, telemetry client management (off by default) (databricks/databricks-sql-nodejs#325, #326, #362)
+
 ## 1.13.0
 
 - Add token federation support with custom token providers (databricks/databricks-sql-nodejs#318, databricks/databricks-sql-nodejs#319, databricks/databricks-sql-nodejs#320 by @madhav-db)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@databricks/sql",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@databricks/sql",
-      "version": "1.13.0",
+      "version": "1.14.0",
       "license": "Apache 2.0",
       "dependencies": {
         "apache-arrow": "^13.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks/sql",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "Driver for connection to Databricks SQL via Thrift API.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
Bump version to 1.14.0 and add the 1.14.0 entry to CHANGELOG.md.

### Notable changes since 1.13.0
- Add statement-level query tag support (#366)
- Add AI coding agent detection to User-Agent header (#333)
- Internal: telemetry infrastructure improvements — circuit breaker, feature flag cache, telemetry client management (off by default) (#325, #326, #362)

CI-only / infra changes are omitted from user-facing notes (workflow hardening, dependabot, etc.).

## Test plan
- [x] `npm install --package-lock-only` updates only version fields in lockfile
- [x] `npm run build` clean
- [ ] CI green
- [x] Local `npm test` blocked by lz4 native build in sandbox; CI runs it

## Next steps after merge
1. Tag the merge commit as `1.14.0` and push the tag (no `v` prefix per repo convention)
2. Trigger `peco-databricks-sql-nodejs` in secure-public-registry-releases-eng with `ref=1.14.0`, `dry-run=true`
3. Re-run with `dry-run=false` for the actual release

This pull request was AI-assisted by Isaac.