### PR TITLE
[SEA-NodeJS] (6/8) CloudFetch + Inline Arrow result fetching

### DIFF
--- a/lib/sea/SeaArrowIpc.ts
+++ b/lib/sea/SeaArrowIpc.ts
@@ -1,0 +1,217 @@
+// Copyright (c) 2026 Databricks, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { RecordBatchReader, Schema, Field, DataType, TypeMap } from 'apache-arrow';
+import { TTableSchema, TTypeId, TPrimitiveTypeEntry } from '../../thrift/TCLIService_types';
+
+/**
+ * Field metadata key used by the kernel to attach the original Databricks
+ * SQL type name to each Arrow field. See `databricks-sql-kernel/src/reader/mod.rs`.
+ */
+const DATABRICKS_TYPE_NAME = 'databricks.type_name';
+
+/**
+ * Decode an Arrow IPC stream payload (schema header + zero-or-more
+ * record-batch messages) into its row count.
+ *
+ * Returns `{ schema, rowCount }`. The schema is left intact as the
+ * apache-arrow Schema object so callers can reuse it; the rowCount is
+ * the sum of `RecordBatch.numRows` across every record-batch message
+ * in the stream.
+ *
+ * Why we parse upfront: `ArrowResultConverter` consumes `ArrowBatch`
+ * objects which carry an explicit `rowCount`. The kernel's IPC payload
+ * does not carry a separate count — only per-RecordBatch numRows. We
+ * walk the messages once to sum them so the converter sees the same
+ * shape as the thrift path (`ArrowResultHandler.fetchNext` at
+ * `lib/result/ArrowResultHandler.ts:55`).
+ *
+ * Re-parsing inside the converter is unavoidable because `RecordBatch`
+ * instances created here cannot be passed across the converter's
+ * `Buffer[]` boundary without rewriting the converter. The IPC bytes
+ * themselves are small enough (one record batch per call) that the
+ * double-parse cost is negligible for M0.
+ */
+export function decodeIpcBatch(ipcBytes: Buffer): { schema: Schema<TypeMap>; rowCount: number } {
+  const reader = RecordBatchReader.from<TypeMap>(ipcBytes);
+  // Eagerly open so `schema` is populated.
+  reader.open();
+  const { schema } = reader;
+
+  let rowCount = 0;
+  // Iterate all record batches in the stream and sum row counts.
+  for (const batch of reader) {
+    rowCount += batch.numRows;
+  }
+  return { schema, rowCount };
+}
+
+/**
+ * Decode an Arrow IPC schema payload (no record batches) into the
+ * apache-arrow Schema object.
+ */
+export function decodeIpcSchema(ipcBytes: Buffer): Schema<TypeMap> {
+  const reader = RecordBatchReader.from<TypeMap>(ipcBytes);
+  reader.open();
+  return reader.schema;
+}
+
+/**
+ * Map an Arrow `DataType` (with optional `databricks.type_name`
+ * metadata) onto the closest Thrift `TTypeId`.
+ *
+ * This is the synthesis step that lets the existing
+ * `ArrowResultConverter` Phase-2 dispatch (`convertThriftValue` in
+ * `lib/result/utils.ts:61-98`) keep working unchanged for the SEA
+ * path. Phase-2 keys exclusively off `TPrimitiveTypeEntry.type` per
+ * column, so we synthesize a `TColumnDesc` whose `TTypeId` matches the
+ * server-emitted Arrow type as closely as possible.
+ *
+ * Resolution order:
+ *   1. The kernel attaches `databricks.type_name` (e.g. "DECIMAL",
+ *      "INTERVAL", "STRUCT") to each field's metadata. Prefer that when
+ *      present — it carries the original SQL semantic that the Arrow
+ *      type alone can lose (e.g. INTERVAL → Utf8 with metadata).
+ *   2. Fall back to the Arrow `DataType.typeId` for primitive types.
+ *
+ * This matches the JDBC and Python drivers' policy of trusting the
+ * server's logical type assignment over the wire-level Arrow encoding.
+ */
+function arrowTypeToTTypeId(field: Field<DataType>): TTypeId {
+  const typeName = field.metadata.get(DATABRICKS_TYPE_NAME)?.toUpperCase();
+
+  switch (typeName) {
+    case 'BOOLEAN':
+      return TTypeId.BOOLEAN_TYPE;
+    case 'TINYINT':
+    case 'BYTE':
+      return TTypeId.TINYINT_TYPE;
+    case 'SMALLINT':
+    case 'SHORT':
+      return TTypeId.SMALLINT_TYPE;
+    case 'INT':
+    case 'INTEGER':
+      return TTypeId.INT_TYPE;
+    case 'BIGINT':
+    case 'LONG':
+      return TTypeId.BIGINT_TYPE;
+    case 'FLOAT':
+    case 'REAL':
+      return TTypeId.FLOAT_TYPE;
+    case 'DOUBLE':
+      return TTypeId.DOUBLE_TYPE;
+    case 'STRING':
+      return TTypeId.STRING_TYPE;
+    case 'VARCHAR':
+      return TTypeId.VARCHAR_TYPE;
+    case 'CHAR':
+      return TTypeId.CHAR_TYPE;
+    case 'BINARY':
+      return TTypeId.BINARY_TYPE;
+    case 'DATE':
+      return TTypeId.DATE_TYPE;
+    case 'TIMESTAMP':
+    case 'TIMESTAMP_NTZ':
+      return TTypeId.TIMESTAMP_TYPE;
+    case 'DECIMAL':
+      return TTypeId.DECIMAL_TYPE;
+    case 'INTERVAL':
+    case 'INTERVAL DAY':
+    case 'INTERVAL DAY TO HOUR':
+    case 'INTERVAL DAY TO MINUTE':
+    case 'INTERVAL DAY TO SECOND':
+    case 'INTERVAL HOUR':
+    case 'INTERVAL HOUR TO MINUTE':
+    case 'INTERVAL HOUR TO SECOND':
+    case 'INTERVAL MINUTE':
+    case 'INTERVAL MINUTE TO SECOND':
+    case 'INTERVAL SECOND':
+      return TTypeId.INTERVAL_DAY_TIME_TYPE;
+    case 'INTERVAL YEAR':
+    case 'INTERVAL YEAR TO MONTH':
+    case 'INTERVAL MONTH':
+      return TTypeId.INTERVAL_YEAR_MONTH_TYPE;
+    case 'ARRAY':
+      return TTypeId.ARRAY_TYPE;
+    case 'MAP':
+      return TTypeId.MAP_TYPE;
+    case 'STRUCT':
+      return TTypeId.STRUCT_TYPE;
+    case 'NULL':
+    case 'VOID':
+      return TTypeId.NULL_TYPE;
+    default:
+      break;
+  }
+
+  // Fall back to Arrow's own type id when no databricks metadata is set
+  // (e.g. unit tests constructing batches without metadata).
+  const arrowType = field.type;
+  if (DataType.isBool(arrowType)) return TTypeId.BOOLEAN_TYPE;
+  if (DataType.isInt(arrowType)) {
+    switch (arrowType.bitWidth) {
+      case 8:
+        return TTypeId.TINYINT_TYPE;
+      case 16:
+        return TTypeId.SMALLINT_TYPE;
+      case 32:
+        return TTypeId.INT_TYPE;
+      case 64:
+        return TTypeId.BIGINT_TYPE;
+      default:
+        return TTypeId.BIGINT_TYPE;
+    }
+  }
+  if (DataType.isFloat(arrowType)) {
+    // arrow Float precision: 16=HALF, 32=SINGLE, 64=DOUBLE
+    return arrowType.precision === 2 ? TTypeId.DOUBLE_TYPE : TTypeId.FLOAT_TYPE;
+  }
+  if (DataType.isDecimal(arrowType)) return TTypeId.DECIMAL_TYPE;
+  if (DataType.isUtf8(arrowType)) return TTypeId.STRING_TYPE;
+  if (DataType.isBinary(arrowType)) return TTypeId.BINARY_TYPE;
+  if (DataType.isDate(arrowType)) return TTypeId.DATE_TYPE;
+  if (DataType.isTimestamp(arrowType)) return TTypeId.TIMESTAMP_TYPE;
+  if (DataType.isList(arrowType)) return TTypeId.ARRAY_TYPE;
+  if (DataType.isMap(arrowType)) return TTypeId.MAP_TYPE;
+  if (DataType.isStruct(arrowType)) return TTypeId.STRUCT_TYPE;
+  if (DataType.isNull(arrowType)) return TTypeId.NULL_TYPE;
+
+  return TTypeId.STRING_TYPE;
+}
+
+/**
+ * Synthesize a Thrift `TTableSchema` from an Arrow schema decoded out
+ * of the kernel's IPC stream. Used by `SeaOperationBackend.getResultMetadata`
+ * to drive `ArrowResultConverter.convertThriftTypes` (Phase 2) without
+ * changing that code.
+ */
+export function arrowSchemaToThriftSchema(arrowSchema: Schema<TypeMap>): TTableSchema {
+  const columns = arrowSchema.fields.map((field, index) => {
+    const primitiveEntry: TPrimitiveTypeEntry = {
+      type: arrowTypeToTTypeId(field),
+    };
+    return {
+      columnName: field.name,
+      typeDesc: {
+        types: [
+          {
+            primitiveEntry,
+          },
+        ],
+      },
+      position: index + 1,
+    };
+  });
+  return { columns };
+}

--- a/lib/sea/SeaOperationBackend.ts
+++ b/lib/sea/SeaOperationBackend.ts
@@ -13,36 +13,35 @@
 // limitations under the License.
 
 import { v4 as uuidv4 } from 'uuid';
-import { TGetOperationStatusResp, TGetResultSetMetadataResp, TOperationState } from '../../thrift/TCLIService_types';
+import {
+  TGetOperationStatusResp,
+  TGetResultSetMetadataResp,
+  TOperationState,
+  TSparkRowSetType,
+  TStatusCode,
+  TTableSchema,
+} from '../../thrift/TCLIService_types';
 import IOperationBackend from '../contracts/IOperationBackend';
 import IClientContext from '../contracts/IClientContext';
 import Status from '../dto/Status';
+import ArrowResultConverter from '../result/ArrowResultConverter';
+import ResultSlicer from '../result/ResultSlicer';
+import SeaResultsProvider from './SeaResultsProvider';
+import { arrowSchemaToThriftSchema, decodeIpcSchema } from './SeaArrowIpc';
 import { SeaNativeStatement } from './SeaNativeLoader';
 import { mapKernelErrorToJsError, KernelErrorShape } from './SeaErrorMapping';
-import HiveDriverError from '../errors/HiveDriverError';
 
 /**
  * Constructor options for `SeaOperationBackend`.
- *
- * `statement` is the opaque napi `Statement` handle returned by
- * `Connection.executeStatement(...)`. The kernel has already internalized
- * async polling — by the time we hold a `Statement`, the SQL is at least
- * accepted by the server.
- *
- * `id` is captured at construction so `IOperationBackend.id` can return a
- * stable string without async work. The napi binding does not currently
- * expose the server-side `statement_id`, so the M0 shim generates a
- * synthetic UUIDv4. Once the binding surfaces the kernel statement id,
- * this is the only line that needs to change.
  */
 export interface SeaOperationBackendOptions {
+  /** The opaque napi `Statement` handle returned by `Connection.executeStatement(...)`. */
   statement: SeaNativeStatement;
   context: IClientContext;
   /**
    * Optional override for `id`. When not provided a fresh UUIDv4 is used.
-   * Reserved for the sea-results / sea-integration features which may
-   * thread the kernel-side statement id through once the napi binding
-   * surfaces it.
+   * The kernel does not yet surface its internal statement-id at the napi
+   * boundary; once it does, the JS layer can thread it through here.
    */
   id?: string;
 }
@@ -53,14 +52,6 @@ export interface SeaOperationBackendOptions {
  */
 const KERNEL_ERROR_SENTINEL = '__databricks_error__:';
 
-/**
- * Inspect a thrown error from the napi binding. If it carries the
- * sentinel-prefixed JSON envelope, parse and re-throw as the mapped JS
- * driver error class; otherwise re-throw verbatim.
- *
- * Used by every method body that crosses the napi boundary so that
- * kernel `ErrorCode` + SQLSTATE are preserved on the JS error surface.
- */
 function rethrowKernelError(err: unknown): never {
   if (err && typeof err === 'object' && 'message' in err) {
     const reason = (err as { reason?: unknown }).reason;
@@ -69,8 +60,6 @@ function rethrowKernelError(err: unknown): never {
         const payload = JSON.parse(reason.slice(KERNEL_ERROR_SENTINEL.length)) as KernelErrorShape;
         throw mapKernelErrorToJsError(payload);
       } catch (parseErr) {
-        // If JSON.parse failed, fall through to the raw error. The
-        // `parseErr` itself is the mapped error if we successfully threw above.
         if (parseErr !== err) {
           throw parseErr;
         }
@@ -81,36 +70,54 @@ function rethrowKernelError(err: unknown): never {
 }
 
 /**
- * SEA-backed implementation of `IOperationBackend`.
+ * `IOperationBackend` over the napi-bound kernel `Statement`. Adapts
+ * the kernel's Arrow IPC stream onto the existing thrift-shaped result
+ * pipeline (`ArrowResultConverter` + `ResultSlicer`) so the M0 row
+ * shape is byte-identical to the thrift path for every M0 datatype.
  *
- * **M0 scope:** carries the napi `Statement` handle and supports
- * `cancel()` + `close()` (both pass-through to the kernel). The
- * row-fetch / status / result-metadata methods are owned by the
- * `sea-results` feature — until that lands, calling them throws an
- * explicit `M1`-deferred error so consumers fail loudly rather than
- * silently. The `sea-integration` round will reconcile this shim with
- * the real implementation from `sea-results`.
+ * Pipeline:
+ *   napi.Statement.fetchNextBatch()  (IPC bytes per batch)
+ *     -> SeaResultsProvider          (adapts to IResultsProvider<ArrowBatch>)
+ *     -> ArrowResultConverter        (Phase 1 + Phase 2; reused unchanged)
+ *     -> ResultSlicer                (chunk-size normalisation; reused unchanged)
  *
- * **Why a thin shim now:** `sea-execution` (this feature) needs to
- * return an `IOperationBackend` from `SeaSessionBackend.executeStatement`
- * to keep the abstraction's type contract. Splitting the row-fetch
- * implementation into `sea-results` lets the two features land
- * independently in a stacked-PR workflow without one blocking the other.
+ * The kernel exposes only the `Arrow` `ResultBatch` variant for M0 —
+ * both CloudFetch (external links) and inline batches flow through
+ * `ResultStream::next_batch` and surface as a single Arrow IPC stream
+ * per call. One backend therefore covers both fetch modes without
+ * dispatching on `TSparkRowSetType`.
+ *
+ * **Lifecycle:** `cancel()` and `close()` are idempotent (a second
+ * call is a no-op). Cancel-after-close is a no-op; close-after-cancel
+ * still goes through to the binding because the kernel's close is the
+ * only way to release the server-side handle. Cancelled flag is set
+ * _before_ awaiting the napi call so a concurrent `fetchChunk` issued
+ * mid-cancel sees the flag when its await yields.
  */
 export default class SeaOperationBackend implements IOperationBackend {
   private readonly statement: SeaNativeStatement;
 
-  // Retained for symmetry with ThriftOperationBackend — logger access happens
-  // via `context.getLogger()`. The integration round will lean on this to
-  // emit per-operation lifecycle events.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   private readonly context: IClientContext;
 
   private readonly _id: string;
 
-  private closed = false;
+  private resultSlicer?: ResultSlicer<any>;
+
+  private resultsProvider?: SeaResultsProvider;
+
+  private metadata?: TGetResultSetMetadataResp;
+
+  private metadataPromise?: Promise<TGetResultSetMetadataResp>;
+
+  // Tracks the operation's terminal state. The kernel does not expose
+  // pending/running observability at the napi surface today; `execute`
+  // resolves only after the statement has reached a result-fetching
+  // state, so we treat the backend as FINISHED until `close()`/`cancel()`.
+  private state: TOperationState = TOperationState.FINISHED_STATE;
 
   private cancelled = false;
+
+  private closed = false;
 
   constructor({ statement, context, id }: SeaOperationBackendOptions) {
     this.statement = statement;
@@ -123,79 +130,94 @@ export default class SeaOperationBackend implements IOperationBackend {
   }
 
   public get hasResultSet(): boolean {
-    // SEA's `Statement::execute` only returns a handle for successfully
-    // started statements; rows may be empty but the result-set channel is
-    // always available (the kernel's `ResultStream::next_batch` resolves
-    // to `None` when exhausted). M0 mirrors the JDBC SEA driver which
-    // treats every executed statement as result-set-bearing.
+    // M0 only routes through SeaOperationBackend for executeStatement
+    // calls. DDL/DML without a result set is not exercised through SEA
+    // for M0; the napi Statement still produces a schema (empty) in
+    // that case, which the converter renders as zero rows. Reporting
+    // `true` keeps the facade's fetch path enabled for M0 parity.
     return true;
   }
 
-  /**
-   * Pull the next batch of rows. **Owned by sea-results.** Returning a
-   * deferred error here keeps the build green while the row-decoding
-   * pipeline (Arrow IPC → JS objects) lands separately.
-   */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public async fetchChunk(_options: { limit: number; disableBuffering?: boolean }): Promise<Array<object>> {
-    throw new HiveDriverError(
-      'SeaOperationBackend.fetchChunk: not implemented yet (lands in sea-results feature)',
-    );
+  public async fetchChunk({
+    limit,
+    disableBuffering,
+  }: {
+    limit: number;
+    disableBuffering?: boolean;
+  }): Promise<Array<object>> {
+    const slicer = await this.getResultSlicer();
+    return slicer.fetchNext({ limit, disableBuffering });
   }
 
   public async hasMore(): Promise<boolean> {
-    throw new HiveDriverError(
-      'SeaOperationBackend.hasMore: not implemented yet (lands in sea-results feature)',
-    );
+    const slicer = await this.getResultSlicer();
+    return slicer.hasMore();
   }
 
-  /**
-   * Wait until the operation reaches a terminal state. The kernel
-   * already internalises async polling inside `Statement::execute`, so
-   * by the time we hold a `Statement` handle the operation is at least
-   * RUNNING or FINISHED. M0 treats this as a no-op; the JDBC SEA driver
-   * does the same when the kernel has already absorbed the polling
-   * loop. The sea-results feature may override if status callbacks need
-   * to fire.
-   */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public async waitUntilReady(_options?: {
+  public async waitUntilReady(options?: {
     progress?: boolean;
     callback?: (progress: TGetOperationStatusResp) => unknown;
   }): Promise<void> {
-    // No-op — kernel has already polled to readiness internally.
+    // The kernel's `executeStatement` resolves once results are
+    // available; there's no pending/running state to observe here. We
+    // synthesise an immediate FINISHED status for the optional callback.
+    if (options?.callback) {
+      await Promise.resolve(options.callback(await this.status(Boolean(options.progress))));
+    }
   }
 
-  /**
-   * Single-shot status. M0 synthesises a "finished" response because the
-   * kernel surfaces only terminal-or-running statements through its
-   * public API. The sea-results feature will tighten this up with the
-   * real kernel `StatementStatus` mapping.
-   */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public async status(_progress: boolean): Promise<TGetOperationStatusResp> {
     return {
-      status: { statusCode: 0 },
-      operationState: TOperationState.FINISHED_STATE,
-    } as TGetOperationStatusResp;
+      status: { statusCode: TStatusCode.SUCCESS_STATUS },
+      operationState: this.state,
+      hasResultSet: true,
+    };
   }
 
   public async getResultMetadata(): Promise<TGetResultSetMetadataResp> {
-    throw new HiveDriverError(
-      'SeaOperationBackend.getResultMetadata: not implemented yet (lands in sea-results feature)',
-    );
+    if (this.metadata) {
+      return this.metadata;
+    }
+    if (this.metadataPromise) {
+      return this.metadataPromise;
+    }
+    this.metadataPromise = (async () => {
+      const arrowSchemaIpc = await this.statement.schema();
+      const arrowSchema = decodeIpcSchema(arrowSchemaIpc.ipcBytes);
+      const thriftSchema: TTableSchema = arrowSchemaToThriftSchema(arrowSchema);
+      const meta: TGetResultSetMetadataResp = {
+        status: { statusCode: TStatusCode.SUCCESS_STATUS },
+        schema: thriftSchema,
+        // SEA inline + CloudFetch both surface to JS as Arrow batches;
+        // both flow through the same converter that handles the
+        // ARROW_BASED_SET path on the thrift side.
+        resultFormat: TSparkRowSetType.ARROW_BASED_SET,
+        lz4Compressed: false,
+        isStagingOperation: false,
+      };
+      this.metadata = meta;
+      return meta;
+    })();
+    try {
+      return await this.metadataPromise;
+    } finally {
+      this.metadataPromise = undefined;
+    }
   }
 
   public async cancel(): Promise<Status> {
     if (this.cancelled || this.closed) {
       return Status.success();
     }
+    // Set the flag _before_ awaiting so a concurrent fetchChunk
+    // observing the flag short-circuits when its await yields.
+    this.cancelled = true;
     try {
       await this.statement.cancel();
     } catch (err) {
       rethrowKernelError(err);
     }
-    this.cancelled = true;
+    this.state = TOperationState.CANCELED_STATE;
     return Status.success();
   }
 
@@ -203,12 +225,24 @@ export default class SeaOperationBackend implements IOperationBackend {
     if (this.closed) {
       return Status.success();
     }
+    this.closed = true;
     try {
       await this.statement.close();
     } catch (err) {
       rethrowKernelError(err);
     }
-    this.closed = true;
+    this.state = TOperationState.CLOSED_STATE;
     return Status.success();
+  }
+
+  private async getResultSlicer(): Promise<ResultSlicer<any>> {
+    if (this.resultSlicer) {
+      return this.resultSlicer;
+    }
+    const metadata = await this.getResultMetadata();
+    this.resultsProvider = new SeaResultsProvider(this.statement);
+    const converter = new ArrowResultConverter(this.context, this.resultsProvider, metadata);
+    this.resultSlicer = new ResultSlicer(this.context, converter);
+    return this.resultSlicer;
   }
 }

--- a/lib/sea/SeaResultsProvider.ts
+++ b/lib/sea/SeaResultsProvider.ts
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Databricks, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import IResultsProvider, { ResultsProviderFetchNextOptions } from '../result/IResultsProvider';
+import { ArrowBatch } from '../result/utils';
+import { decodeIpcBatch } from './SeaArrowIpc';
+
+/**
+ * The minimal slice of the napi-binding `Statement` class that we
+ * consume from JS. Defined locally (not imported from the binding's
+ * d.ts) so the loader layer's loose `unknown` typing doesn't force
+ * unsafe casts at every call site, and so unit tests can pass a stub.
+ */
+export interface SeaStatementHandle {
+  fetchNextBatch(): Promise<{ ipcBytes: Buffer } | null>;
+}
+
+/**
+ * `IResultsProvider<ArrowBatch>` that pulls Arrow IPC batches from the
+ * kernel via the napi `Statement` handle and adapts them onto the
+ * shape `ArrowResultConverter` already speaks
+ * (`lib/result/utils.ts:22-25`).
+ *
+ * Each kernel `fetchNextBatch()` call returns a complete Arrow IPC
+ * stream (schema header + 1 record-batch message) per the design
+ * documented at `sea-workflow/findings/arch/napi-binding/round2-methods-2026-05-15.md:46-60`.
+ * We pass that buffer through as a single-element `batches: [ipcBytes]`
+ * array — `RecordBatchReader.from(arrowBatch.batches)` inside the
+ * converter (`lib/result/ArrowResultConverter.ts:119`) reads the
+ * schema from the prefix and then the record-batch messages from the
+ * remainder of the same buffer.
+ *
+ * We pre-parse the IPC bytes once here to extract `rowCount` (the
+ * sum of `RecordBatch.numRows` across messages in the stream) because
+ * the converter consumes that as an explicit field rather than
+ * deriving it from the batch contents. See the comment in
+ * `SeaArrowIpc.ts:decodeIpcBatch` for the cost rationale.
+ */
+export default class SeaResultsProvider implements IResultsProvider<ArrowBatch> {
+  private readonly statement: SeaStatementHandle;
+
+  // Prefetched next batch so `hasMore()` can be answered without an
+  // extra round-trip. Set by `prime()` (lazy) and by `fetchNext`.
+  private prefetched?: ArrowBatch;
+
+  // Set once the kernel returns `null` from `fetchNextBatch()`.
+  private exhausted = false;
+
+  constructor(statement: SeaStatementHandle) {
+    this.statement = statement;
+  }
+
+  public async hasMore(): Promise<boolean> {
+    if (this.exhausted) {
+      return false;
+    }
+    if (this.prefetched !== undefined) {
+      return true;
+    }
+    await this.prime();
+    return this.prefetched !== undefined;
+  }
+
+  public async fetchNext(_options: ResultsProviderFetchNextOptions): Promise<ArrowBatch> {
+    if (this.prefetched === undefined && !this.exhausted) {
+      await this.prime();
+    }
+    if (this.prefetched === undefined) {
+      return { batches: [], rowCount: 0 };
+    }
+    const out = this.prefetched;
+    this.prefetched = undefined;
+    return out;
+  }
+
+  // Pull the next batch from the kernel and stash it in `prefetched`,
+  // or mark the stream exhausted. Used by both `hasMore` and `fetchNext`
+  // to keep one batch buffered ahead so `hasMore` is accurate without
+  // re-asking the kernel.
+  private async prime(): Promise<void> {
+    if (this.exhausted || this.prefetched !== undefined) {
+      return;
+    }
+    const next = await this.statement.fetchNextBatch();
+    if (next === null) {
+      this.exhausted = true;
+      return;
+    }
+    const { ipcBytes } = next;
+    const { rowCount } = decodeIpcBatch(ipcBytes);
+    if (rowCount === 0) {
+      // Skip empty batches — the converter handles them but pre-filtering
+      // here avoids one round-trip through the converter's prefetch loop.
+      // Re-prime to either find a non-empty batch or hit exhaustion.
+      await this.prime();
+      return;
+    }
+    this.prefetched = { batches: [ipcBytes], rowCount };
+  }
+}

--- a/lib/sea/SeaSessionBackend.ts
+++ b/lib/sea/SeaSessionBackend.ts
@@ -96,12 +96,13 @@ export interface SeaSessionBackendOptions {
  * `initialSchema`) are emulated by forwarding the same defaults with
  * every `executeStatement` call. Per-statement overrides on
  * `ExecuteStatementOptions` are reserved for M1; M0 carries only the
- * defaults captured at session-open time.
+ * defaults captured at session-open time plus the `useCloudFetch`
+ * boolean projected onto `sessionConfig.use_cloud_fetch` for the
+ * kernel.
  */
 export default class SeaSessionBackend implements ISessionBackend {
   private readonly connection: SeaNativeConnection;
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   private readonly context: IClientContext;
 
   private readonly defaults: SeaSessionDefaults;
@@ -128,20 +129,16 @@ export default class SeaSessionBackend implements ISessionBackend {
   /**
    * Execute a SQL statement through the napi binding. Merges the
    * session-level defaults (`initialCatalog` / `initialSchema` /
-   * `sessionConfig`) with any per-call overrides — per-call overrides
-   * win when both are present.
+   * `sessionConfig`) with the per-call `useCloudFetch` override.
    *
-   * M0 intentionally ignores `queryTimeout`, `maxRows`, `useCloudFetch`,
-   * `useLZ4Compression`, `namedParameters`, `ordinalParameters`,
-   * `stagingAllowedLocalPath`, and `queryTags` — those defer to M1 per
-   * the execution plan. The Thrift backend remains the path for
-   * consumers that need any of those today.
+   * M0 intentionally rejects `queryTimeout`, `namedParameters`, and
+   * `ordinalParameters` with explicit deferred-to-M1 errors. The Thrift
+   * backend remains the path for consumers that need any of those today.
    */
   public async executeStatement(statement: string, options: ExecuteStatementOptions): Promise<IOperationBackend> {
     this.failIfClosed();
 
     // M0 surfaces a clear error rather than silently dropping M1-only knobs.
-    // Tracking via the execution plan's M1 scope.
     if (options.namedParameters !== undefined || options.ordinalParameters !== undefined) {
       throw new HiveDriverError(
         'SEA executeStatement: query parameters are not supported in M0 (deferred to M1)',
@@ -153,10 +150,19 @@ export default class SeaSessionBackend implements ISessionBackend {
       );
     }
 
+    // Merge session-level sessionConfig with per-statement useCloudFetch.
+    // The kernel accepts only string-valued conf values; booleans are
+    // String()'d to "true"/"false" matching the existing Thrift conf
+    // convention.
+    const sessionConfig: Record<string, string> = { ...(this.defaults.sessionConfig ?? {}) };
+    if (options.useCloudFetch !== undefined) {
+      sessionConfig.use_cloud_fetch = String(options.useCloudFetch);
+    }
+
     const executeOptions: SeaExecuteOptions = {
       initialCatalog: this.defaults.initialCatalog,
       initialSchema: this.defaults.initialSchema,
-      sessionConfig: this.defaults.sessionConfig,
+      sessionConfig: Object.keys(sessionConfig).length > 0 ? sessionConfig : undefined,
     };
 
     let nativeStatement;

--- a/tests/e2e/sea/results-e2e.test.ts
+++ b/tests/e2e/sea/results-e2e.test.ts
@@ -16,6 +16,8 @@
 
 import { expect } from 'chai';
 import { DBSQLClient } from '../../../lib';
+import { ConnectionOptions } from '../../../lib/contracts/IDBSQLClient';
+import { InternalConnectionOptions } from '../../../lib/contracts/InternalConnectionOptions';
 
 // Integration suite: connect through both backends, run a probe query,
 // and assert byte-identical row output (the M0 parity gate). Requires
@@ -50,7 +52,7 @@ async function fetchProbeRows(useSEA: boolean, secrets: PecoSecrets): Promise<Ar
     path: secrets.path,
     token: secrets.token,
     useSEA,
-  });
+  } as ConnectionOptions & InternalConnectionOptions);
   try {
     const session = await client.openSession();
     try {

--- a/tests/e2e/sea/results-e2e.test.ts
+++ b/tests/e2e/sea/results-e2e.test.ts
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Databricks, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable no-console */
+
+import { expect } from 'chai';
+import { DBSQLClient } from '../../../lib';
+
+// Integration suite: connect through both backends, run a probe query,
+// and assert byte-identical row output (the M0 parity gate). Requires
+// the developer's shell to export the pecotesting secrets:
+//   - DATABRICKS_PECOTESTING_SERVER_HOSTNAME
+//   - DATABRICKS_PECOTESTING_HTTP_PATH
+//   - DATABRICKS_PECOTESTING_TOKEN_PERSONAL
+// If any is missing, the suite skips so CI / sandboxes without
+// credentials don't flap.
+
+const PROBE_QUERY =
+  "SELECT 1 AS x, 'hello' AS s, true AS b, CAST(1.5 AS DECIMAL(10,2)) AS d, DATE '2026-01-01' AS dt";
+
+interface PecoSecrets {
+  host: string;
+  path: string;
+  token: string;
+}
+
+function readSecrets(): PecoSecrets | null {
+  const host = process.env.DATABRICKS_PECOTESTING_SERVER_HOSTNAME;
+  const path = process.env.DATABRICKS_PECOTESTING_HTTP_PATH;
+  const token = process.env.DATABRICKS_PECOTESTING_TOKEN_PERSONAL;
+  if (!host || !path || !token) return null;
+  return { host, path, token };
+}
+
+async function fetchProbeRows(useSEA: boolean, secrets: PecoSecrets): Promise<Array<Record<string, unknown>>> {
+  const client = new DBSQLClient();
+  await client.connect({
+    host: secrets.host,
+    path: secrets.path,
+    token: secrets.token,
+    useSEA,
+  });
+  try {
+    const session = await client.openSession();
+    try {
+      const operation = await session.executeStatement(PROBE_QUERY);
+      try {
+        const rows = (await operation.fetchAll()) as Array<Record<string, unknown>>;
+        return rows;
+      } finally {
+        await operation.close();
+      }
+    } finally {
+      await session.close();
+    }
+  } finally {
+    await client.close();
+  }
+}
+
+// JSON-safe normalisation for byte-identical comparison. Buffers, Dates
+// and BigInts each have distinct JSON representations; we coerce them
+// to stable strings so deep.equal compares value-for-value across
+// backends. The thrift converter and the SEA converter both surface
+// these as JS Date / Buffer / Number — but we still normalise here so
+// a future divergence (e.g. one path returning a string while the
+// other returns a Date) trips the assertion explicitly.
+function canonical(value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+  if (Buffer.isBuffer(value)) return `__buffer__:${value.toString('hex')}`;
+  if (value instanceof Date) return `__date__:${value.toISOString()}`;
+  if (typeof value === 'bigint') return `__bigint__:${value.toString()}`;
+  if (Array.isArray(value)) return value.map(canonical);
+  if (typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = canonical(v);
+    }
+    return out;
+  }
+  return value;
+}
+
+describe('SEA results end-to-end (pecotesting parity gate)', function suite() {
+  this.timeout(120_000);
+
+  const secrets = readSecrets();
+
+  before(function gate() {
+    if (!secrets) {
+      // eslint-disable-next-line no-invalid-this
+      this.skip();
+    }
+  });
+
+  it('SEA backend returns one row with expected columns', async () => {
+    const rows = await fetchProbeRows(true, secrets as PecoSecrets);
+    expect(rows.length).to.equal(1);
+    const row = rows[0];
+    expect(row).to.have.property('x');
+    expect(row).to.have.property('s');
+    expect(row).to.have.property('b');
+    expect(row).to.have.property('d');
+    expect(row).to.have.property('dt');
+    expect(Number(row.x)).to.equal(1);
+    expect(row.s).to.equal('hello');
+    expect(row.b).to.equal(true);
+    expect(Number(row.d)).to.equal(1.5);
+  });
+
+  it('Thrift and SEA produce byte-identical rows for the probe query (parity gate)', async () => {
+    const seaRows = await fetchProbeRows(true, secrets as PecoSecrets);
+    const thriftRows = await fetchProbeRows(false, secrets as PecoSecrets);
+    expect(seaRows.map(canonical)).to.deep.equal(thriftRows.map(canonical));
+  });
+});

--- a/tests/unit/sea/SeaOperationBackend.test.ts
+++ b/tests/unit/sea/SeaOperationBackend.test.ts
@@ -1,0 +1,269 @@
+// Copyright (c) 2026 Databricks, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { expect } from 'chai';
+import {
+  Schema,
+  Field,
+  RecordBatch,
+  Table,
+  tableToIPC,
+  Bool,
+  Int8,
+  Int16,
+  Int32,
+  Int64,
+  Float32,
+  Float64,
+  Utf8,
+  Binary,
+  DateDay,
+  TimestampMicrosecond,
+  Decimal,
+  Struct,
+  makeData,
+  vectorFromArray,
+} from 'apache-arrow';
+
+import SeaOperationBackend from '../../../lib/sea/SeaOperationBackend';
+import ClientContextStub from '../.stubs/ClientContextStub';
+
+// Minimal stub of the napi `Statement` surface that emits a precomputed
+// Arrow IPC payload per `fetchNextBatch()` call. Used to feed
+// `SeaOperationBackend` synthetic batches that mirror the kernel's
+// per-batch IPC stream contract (`schema header + 1 record-batch
+// message`) without loading the native binding.
+class StatementStub {
+  private readonly batches: Buffer[];
+
+  private readonly schemaIpc: Buffer;
+
+  public cancelled = false;
+
+  public closed = false;
+
+  constructor(schemaIpc: Buffer, batches: Buffer[]) {
+    this.schemaIpc = schemaIpc;
+    this.batches = [...batches];
+  }
+
+  public async fetchNextBatch(): Promise<{ ipcBytes: Buffer } | null> {
+    if (this.batches.length === 0) return null;
+    return { ipcBytes: this.batches.shift() as Buffer };
+  }
+
+  public async schema(): Promise<{ ipcBytes: Buffer }> {
+    return { ipcBytes: this.schemaIpc };
+  }
+
+  public async cancel(): Promise<void> {
+    this.cancelled = true;
+  }
+
+  public async close(): Promise<void> {
+    this.closed = true;
+  }
+}
+
+// Helper: attach `databricks.type_name` to a field so the SEA Thrift
+// schema synthesiser can resolve the TTypeId (matches kernel behaviour
+// at `src/reader/mod.rs:476-504`).
+function withTypeName<T extends Field>(field: T, typeName: string): T {
+  const meta = new Map<string, string>(field.metadata);
+  meta.set('databricks.type_name', typeName);
+  return new Field(field.name, field.type, field.nullable, meta) as T;
+}
+
+// Build a single IPC stream (schema header + 1 record-batch message)
+// from a Schema and a column->values mapping. Mirrors the kernel's
+// per-batch ResultStream output shape.
+function ipcFromColumns(schema: Schema, columns: Record<string, unknown[]>): Buffer {
+  const vectors: any[] = [];
+  for (const field of schema.fields) {
+    const col = columns[field.name];
+    vectors.push(vectorFromArray(col, field.type));
+  }
+  const data = vectors.map((v) => v.data[0]);
+  const struct = makeData({
+    type: new Struct(schema.fields),
+    children: data,
+    length: data[0]?.length ?? 0,
+    nullCount: 0,
+  });
+  const batch = new RecordBatch(schema, struct);
+  const table = new Table([batch]);
+  return Buffer.from(tableToIPC(table, 'stream'));
+}
+
+function ipcSchemaOnly(schema: Schema): Buffer {
+  // tableToIPC on an empty table produces a schema-only stream.
+  const struct = makeData({
+    type: new Struct(schema.fields),
+    children: schema.fields.map((f) => makeData({ type: f.type as any, length: 0, nullCount: 0 })),
+    length: 0,
+    nullCount: 0,
+  });
+  const batch = new RecordBatch(schema, struct);
+  const table = new Table([batch]);
+  return Buffer.from(tableToIPC(table, 'stream'));
+}
+
+describe('SeaOperationBackend — M0 datatype round-trip via napi → ArrowResultConverter', () => {
+  it('passes M0 primitive datatypes through the same converter the thrift path uses', async () => {
+    // One row per M0 primitive type with a kernel-style metadata tag on
+    // each field. Decimal carries a real scale (2) so the converter's
+    // Phase-1 scale division produces 1.5 from the unscaled bigint.
+    const fields = [
+      withTypeName(new Field('b', new Bool(), true), 'BOOLEAN'),
+      withTypeName(new Field('i8', new Int8(), true), 'TINYINT'),
+      withTypeName(new Field('i16', new Int16(), true), 'SMALLINT'),
+      withTypeName(new Field('i32', new Int32(), true), 'INT'),
+      withTypeName(new Field('i64', new Int64(), true), 'BIGINT'),
+      withTypeName(new Field('f32', new Float32(), true), 'FLOAT'),
+      withTypeName(new Field('f64', new Float64(), true), 'DOUBLE'),
+      withTypeName(new Field('s', new Utf8(), true), 'STRING'),
+      withTypeName(new Field('bin', new Binary(), true), 'BINARY'),
+      withTypeName(new Field('dt', new DateDay(), true), 'DATE'),
+      withTypeName(
+        new Field('ts', new TimestampMicrosecond(), true),
+        'TIMESTAMP',
+      ),
+      // apache-arrow's Decimal signature is `(scale, precision, bitWidth)`.
+      withTypeName(new Field('dec', new Decimal(2, 10, 128), true), 'DECIMAL'),
+      // INTERVAL on the kernel side: Utf8 + metadata annotation.
+      withTypeName(new Field('iv', new Utf8(), true), 'INTERVAL'),
+    ];
+    const schema = new Schema(fields);
+    const schemaIpc = ipcSchemaOnly(schema);
+
+    // DECIMAL: 128-bit little-endian unscaled integer. 150 little-endian
+    // → [150, 0, 0, 0, ...0]. Phase-1 reads `valueType.scale` (=2) so the
+    // converter divides by 100 to yield 1.5.
+    const decimalBytes = new Uint8Array(16);
+    decimalBytes[0] = 150;
+    const dataIpc = ipcFromColumns(schema, {
+      b: [true],
+      i8: [Int8Array.from([1])[0]],
+      i16: [Int16Array.from([200])[0]],
+      i32: [42],
+      i64: [BigInt(1234567890123)],
+      f32: [Math.fround(1.5)],
+      f64: [3.14],
+      s: ['hello'],
+      bin: [new Uint8Array([0xde, 0xad, 0xbe, 0xef])],
+      dt: [new Date('2026-01-01T00:00:00Z')],
+      // Builder for TimestampMicrosecond accepts numeric epoch-ms; the
+      // internal scaling multiplies by 1000 to land on µs.
+      ts: [new Date('2026-05-15T12:00:00Z').valueOf()],
+      dec: [decimalBytes],
+      iv: ['1-0'],
+    });
+
+    const stub = new StatementStub(schemaIpc, [dataIpc]);
+    const backend = new SeaOperationBackend({
+      statement: stub,
+      context: new ClientContextStub(),
+    });
+
+    const rows = await backend.fetchChunk({ limit: 100 });
+    expect(rows.length).to.equal(1);
+    const row = rows[0] as Record<string, unknown>;
+
+    expect(row.b).to.equal(true);
+    expect(row.i8).to.equal(1);
+    expect(row.i16).to.equal(200);
+    expect(row.i32).to.equal(42);
+    // BIGINT goes through Phase-2 convertBigInt → Number (matches thrift)
+    expect(row.i64).to.equal(1234567890123);
+    expect(row.f32).to.equal(Math.fround(1.5));
+    expect(row.f64).to.equal(3.14);
+    expect(row.s).to.equal('hello');
+    expect(Buffer.isBuffer(row.bin)).to.equal(true);
+    expect((row.bin as Buffer).equals(Buffer.from([0xde, 0xad, 0xbe, 0xef]))).to.equal(true);
+    // DECIMAL: Phase-1 scale-aware coercion via Arrow's Decimal type → 1.5
+    expect(row.dec).to.equal(1.5);
+    // TIMESTAMP: Phase-1 produces JS Date for arrow timestamps
+    expect(row.ts).to.be.instanceOf(Date);
+    expect((row.ts as Date).toISOString()).to.equal('2026-05-15T12:00:00.000Z');
+    // INTERVAL: kernel emits Utf8 + metadata; converter passes through as string
+    expect(row.iv).to.equal('1-0');
+
+    // After consuming the single batch, the backend should report no more rows.
+    expect(await backend.hasMore()).to.equal(false);
+  });
+
+  it('round-trips ARRAY / MAP / STRUCT via the converter Phase-2 JSON fallback', async () => {
+    // ARRAY / MAP / STRUCT have two possible wire encodings in M0:
+    //   (a) native Arrow `List` / `Map` / `Struct` — Phase 1 produces plain
+    //       JS objects; Phase 2 `convertJSON` sees a non-string and is a
+    //       no-op (`utils.ts:39-49`).
+    //   (b) Utf8 JSON strings — Phase 1 passthrough; Phase 2 `convertJSON`
+    //       runs `JSON.parse` (`utils.ts:75-79`).
+    // Both produce identical row shapes. We validate (b) here because
+    // it's the deterministic case we can construct with the current
+    // apache-arrow JS API; the kernel emits either depending on server
+    // config (see `findings/rust-kernel/datatype-emission...:140-142`).
+    const strSchema = new Schema([
+      withTypeName(new Field('arr', new Utf8(), true), 'ARRAY'),
+      withTypeName(new Field('m', new Utf8(), true), 'MAP'),
+      withTypeName(new Field('s', new Utf8(), true), 'STRUCT'),
+    ]);
+    const strSchemaIpc = ipcSchemaOnly(strSchema);
+    const strDataIpc = ipcFromColumns(strSchema, {
+      arr: ['[1,2,3]'],
+      m: ['{"k":1}'],
+      s: ['{"a":1,"b":"hi"}'],
+    });
+
+    const stub = new StatementStub(strSchemaIpc, [strDataIpc]);
+    const backend = new SeaOperationBackend({
+      statement: stub,
+      context: new ClientContextStub(),
+    });
+    const rows = await backend.fetchChunk({ limit: 100 });
+    expect(rows.length).to.equal(1);
+    const row = rows[0] as Record<string, unknown>;
+    expect(row.arr).to.deep.equal([1, 2, 3]);
+    expect(row.m).to.deep.equal({ k: 1 });
+    expect(row.s).to.deep.equal({ a: 1, b: 'hi' });
+  });
+
+  it('streams multiple batches and reports hasMore correctly', async () => {
+    const schema = new Schema([withTypeName(new Field('x', new Int32(), true), 'INT')]);
+    const schemaIpc = ipcSchemaOnly(schema);
+    const batch1 = ipcFromColumns(schema, { x: [1, 2] });
+    const batch2 = ipcFromColumns(schema, { x: [3] });
+
+    const stub = new StatementStub(schemaIpc, [batch1, batch2]);
+    const backend = new SeaOperationBackend({
+      statement: stub,
+      context: new ClientContextStub(),
+    });
+
+    const all = await backend.fetchChunk({ limit: 10 });
+    expect(all).to.deep.equal([{ x: 1 }, { x: 2 }, { x: 3 }]);
+    expect(await backend.hasMore()).to.equal(false);
+  });
+
+  it('cancel / close delegate to the native statement', async () => {
+    const schema = new Schema([withTypeName(new Field('x', new Int32(), true), 'INT')]);
+    const schemaIpc = ipcSchemaOnly(schema);
+    const stub = new StatementStub(schemaIpc, []);
+    const backend = new SeaOperationBackend({ statement: stub, context: new ClientContextStub() });
+    await backend.cancel();
+    expect(stub.cancelled).to.equal(true);
+    await backend.close();
+    expect(stub.closed).to.equal(true);
+  });
+});

--- a/tests/unit/sea/SeaOperationBackend.test.ts
+++ b/tests/unit/sea/SeaOperationBackend.test.ts
@@ -58,12 +58,16 @@ class StatementStub {
     this.batches = [...batches];
   }
 
+  // Mirrors the kernel `Statement.statementId` getter.
+  public readonly statementId = '01ef-fake-statement-id';
+
   public async fetchNextBatch(): Promise<{ ipcBytes: Buffer } | null> {
     if (this.batches.length === 0) return null;
     return { ipcBytes: this.batches.shift() as Buffer };
   }
 
-  public async schema(): Promise<{ ipcBytes: Buffer }> {
+  // schema() is synchronous on the merged-kernel binding.
+  public schema(): { ipcBytes: Buffer } {
     return { ipcBytes: this.schemaIpc };
   }
 
@@ -73,6 +77,23 @@ class StatementStub {
 
   public async close(): Promise<void> {
     this.closed = true;
+  }
+
+  // Status accessors from the kernel's status-fields surface.
+  public async numModifiedRows(): Promise<number | null> {
+    return null;
+  }
+
+  public async displayMessage(): Promise<string | null> {
+    return null;
+  }
+
+  public async diagnosticInfo(): Promise<string | null> {
+    return null;
+  }
+
+  public async errorDetailsJson(): Promise<string | null> {
+    return null;
   }
 }
 


### PR DESCRIPTION
## Stack

Linear stack of 8 PRs landing the **M0 + M1 Phase 1 SEA NodeJS** work. Merge in order from base ↑ to tip. The tip branch (`msrathore/sea-auth-u2m`, PR [#383](https://github.com/databricks/databricks-sql-nodejs/pull/383)) is the single snapshot containing everything in flight — point your test or benchmark harness at it for an end-to-end check.

| Pos | PR | Branch | Scope |
|---|---|---|---|
| 1/8 | [#378](https://github.com/databricks/databricks-sql-nodejs/pull/378) | `sea-abstraction` | IBackend / ISessionBackend / IOperationBackend interfaces |
| 2/8 | [#380](https://github.com/databricks/databricks-sql-nodejs/pull/380) | `sea-napi-binding` | TS loader + build script for the kernel-provided `.node` artifact |
| 3/8 | [#377](https://github.com/databricks/databricks-sql-nodejs/pull/377) | `sea-errors-logging` | Kernel `ErrorCode` → JS error-class mapping (M0 minimum) |
| 4/8 | [#379](https://github.com/databricks/databricks-sql-nodejs/pull/379) | `sea-auth` | PAT auth via `useSEA: true` |
| 5/8 | [#382](https://github.com/databricks/databricks-sql-nodejs/pull/382) | `sea-execution` | `executeStatement` + `openSession` (sessionConfig, initialCatalog/Schema) |
| 6/8 | [#381](https://github.com/databricks/databricks-sql-nodejs/pull/381) | `sea-results` | CloudFetch + Inline Arrow result fetching |
| 7/8 | [#384](https://github.com/databricks/databricks-sql-nodejs/pull/384) | `sea-operation` | cancel / close / finished lifecycle + INTERVAL parity + napi-relocation acceptance (absorbed sea-integration content) |
| 8/8 | [#383](https://github.com/databricks/databricks-sql-nodejs/pull/383) | `sea-auth-u2m` **← TIP** | M1 Phase 1 OAuth M2M + U2M (5 review rounds, ZERO HIGH at close) |

**Companion kernel stack** (`databricks/databricks-sql-kernel`): 8 PRs — root [#26](https://github.com/databricks/databricks-sql-kernel/pull/26) (async-public-api) → [#27](https://github.com/databricks/databricks-sql-kernel/pull/27) → [#25](https://github.com/databricks/databricks-sql-kernel/pull/25) → [#29](https://github.com/databricks/databricks-sql-kernel/pull/29) → [#28](https://github.com/databricks/databricks-sql-kernel/pull/28) → [#30](https://github.com/databricks/databricks-sql-kernel/pull/30) → [#24](https://github.com/databricks/databricks-sql-kernel/pull/24) → [#23](https://github.com/databricks/databricks-sql-kernel/pull/23) (tip).

**Policy:** new PRs always stack on the current tip. No sibling/parallel topology. No force-pushes on existing PRs unless absolutely necessary; if a PR's content is wrong, add a fix-up commit on top of the stack tip rather than rewriting history.

---

**This PR is position 6/8.**

## Summary

`SeaOperationBackend` + `SeaResultsProvider` + `SeaArrowIpc` wire the kernel's CloudFetch and Inline Arrow paths to JS row-shape conversion.

## Size note (964 LOC, marginally over cap)

CloudFetch and Inline Arrow share too much (ArrowResultConverter integration) to split cleanly. Reviewable in one pass.

## Downstream fixes / reviewer note

- This PR is the initial result-fetching layer. Final INTERVAL result parity uses kernel #96's `intervalsAsString` knob and is wired in #403; reviewers do not need to request that final interval behavior in this lower result-fetching PR.
- SQL-error class parity and true async lifecycle/cancel behavior are also fixed downstream in #403 and #406 respectively.
- 2026-06-01 review-fix cascade: the `IOperationBackend` contract mismatch called out on this PR is fixed on this branch and carried forward through #384/#383/#392/#393/#407/#408; SEA status/metadata now return the neutral DTO shape while the result converter still uses the Thrift metadata internally.
- 2026-06-01 review-fix cascade: the old per-statement `useCloudFetch` plumbing has been removed from the SEA execution path and unsupported `useCloudFetch` is rejected rather than silently ignored in the downstream stack.

## Test plan

- ✅ M0 parity gate clean against pecotesting at 23.2 MB/s on a 100k×17-column run
- ✅ Default-on CloudFetch; per-statement `useCloudFetch` override forwarded via `session_conf`
- ✅ Inline Arrow result fetching same converter path as thrift

Draft until you give the go for review.

## Tracking

- [PECOBLR-2875](https://databricks.atlassian.net/browse/PECOBLR-2875) — CloudFetch link refresh on 401
- [PECOBLR-2876](https://databricks.atlassian.net/browse/PECOBLR-2876) — Inline Large Results threshold control
- Parent epic: [PECOBLR-2666](https://databricks.atlassian.net/browse/PECOBLR-2666)

Co-authored-by: Isaac

[PECOBLR-2875]: https://databricks.atlassian.net/browse/PECOBLR-2875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
