### PR TITLE
fix: use valid SPDX license identifier in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "hive",
     "hive js"
   ],
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "devDependencies": {
     "@types/chai": "^4.3.14",
     "@types/http-proxy": "^1.17.14",


### PR DESCRIPTION
## Summary
- Fixes #387 — changes `"license": "Apache 2.0"` to `"license": "Apache-2.0"` in `package.json`
- `Apache-2.0` is the correct [SPDX identifier](https://spdx.org/licenses/Apache-2.0.html), which allows GitHub and npm to properly recognize the license

## Test plan
- [x] Verified `Apache-2.0` is the correct SPDX identifier via the official SPDX license list
- [ ] Confirm GitHub no longer shows a license warning after merge

This pull request and its description were written by Isaac.