### PR TITLE
[XTA-15079] Add SPOG ?o= routing support and fix final-flush auth on close

### DIFF
--- a/lib/DBSQLClient.ts
+++ b/lib/DBSQLClient.ts
@@ -377,10 +377,7 @@ export default class DBSQLClient extends EventEmitter implements IDBSQLClient, I
     const merged: Record<string, string> = { ...(userHeaders ?? {}) };
     const hasOrgIdAlready = Object.keys(merged).some((k) => k.toLowerCase() === 'x-databricks-org-id');
     if (hasOrgIdAlready) {
-      this.logger.log(
-        LogLevel.debug,
-        'SPOG: x-databricks-org-id supplied by caller; not extracting from httpPath',
-      );
+      this.logger.log(LogLevel.debug, 'SPOG: x-databricks-org-id supplied by caller; not extracting from httpPath');
     } else {
       const orgId = DBSQLClient.extractWorkspaceId(httpPath);
       if (orgId) {

--- a/lib/DBSQLClient.ts
+++ b/lib/DBSQLClient.ts
@@ -331,6 +331,27 @@ export default class DBSQLClient extends EventEmitter implements IDBSQLClient, I
   }
 
   /**
+   * Build the customHeaders map applied to telemetry POSTs and feature-flag
+   * GETs (SPOG / Single Panel of Glass support). When `httpPath` carries
+   * `?o=<workspaceId>` — account-level vanity URL routing — endpoints that
+   * don't include the workspace in their path need the workspace conveyed via
+   * the `x-databricks-org-id` header instead. A user-supplied value in
+   * `options.customHeaders` (case-insensitively keyed) wins over the parsed
+   * value.
+   */
+  private buildCustomHeaders(options: ConnectionOptions): Record<string, string> | undefined {
+    const merged: Record<string, string> = { ...(options.customHeaders ?? {}) };
+    const hasOrgIdAlready = Object.keys(merged).some((k) => k.toLowerCase() === 'x-databricks-org-id');
+    if (!hasOrgIdAlready) {
+      const orgId = this.extractWorkspaceId();
+      if (orgId) {
+        merged['x-databricks-org-id'] = orgId;
+      }
+    }
+    return Object.keys(merged).length > 0 ? merged : undefined;
+  }
+
+  /**
    * Build driver configuration for telemetry reporting.
    * @returns DriverConfiguration object with current driver settings
    */
@@ -560,6 +581,11 @@ export default class DBSQLClient extends EventEmitter implements IDBSQLClient, I
     if (options.userAgentEntry !== undefined) {
       this.config.userAgentEntry = options.userAgentEntry;
     }
+
+    // SPOG: parse `?o=<workspaceId>` out of httpPath and stash it as
+    // `x-databricks-org-id` for the telemetry + feature-flag clients, which
+    // hit endpoints that don't carry the workspace in their URL path.
+    this.config.customHeaders = this.buildCustomHeaders(options);
 
     this.authProvider = this.createAuthProvider(options, authProvider);
 

--- a/lib/DBSQLClient.ts
+++ b/lib/DBSQLClient.ts
@@ -298,9 +298,9 @@ export default class DBSQLClient extends EventEmitter implements IDBSQLClient, I
   /**
    * Extract the numeric workspace ID for telemetry.
    *
-   * The only reliable carrier in the connection params today is the `?o=N`
-   * query parameter on `httpPath` — Databricks SQL warehouses are typically
-   * connected to via paths like `/sql/1.0/warehouses/<id>?o=12345678901234`.
+   * Two URL shapes carry the workspace ID today:
+   *  - Warehouse, query form: `/sql/1.0/warehouses/<id>?o=<wsId>`
+   *  - All-purpose cluster, path form: `sql/protocolv1/o/<wsId>/<cluster-id>`
    *
    * Host-based extraction was tried previously but produced confidently-wrong
    * values:
@@ -313,39 +313,84 @@ export default class DBSQLClient extends EventEmitter implements IDBSQLClient, I
    * Returns `undefined` when no workspace ID can be derived. Server-side
    * attribution is better off seeing a missing field than a wrong value.
    */
-  private extractWorkspaceId(): string | undefined {
-    const { httpPath } = this;
+  private static extractWorkspaceId(httpPath: string | undefined): string | undefined {
     if (!httpPath) {
       return undefined;
     }
     const queryIdx = httpPath.indexOf('?');
-    if (queryIdx < 0) {
-      return undefined;
+    // Warehouse form: `?o=<digits>` in the query string.
+    if (queryIdx >= 0) {
+      const query = httpPath.slice(queryIdx + 1);
+      // Match `o=<digits>` as the first param, an inner `&o=<digits>`, etc.
+      // Workspace IDs are decimal integers; reject anything else so a stray
+      // `o=tenant_42` doesn't ship as a workspace ID.
+      const queryMatch = query.match(/(?:^|&)o=(\d+)(?:&|$)/);
+      if (queryMatch) {
+        return queryMatch[1];
+      }
     }
-    const query = httpPath.slice(queryIdx + 1);
-    // Match `o=<digits>` as the first param, an inner `&o=<digits>`, etc.
-    // Workspace IDs are decimal integers; reject anything else so a stray
-    // `o=tenant_42` doesn't ship as a workspace ID.
-    const match = query.match(/(?:^|&)o=(\d+)(?:&|$)/);
-    return match ? match[1] : undefined;
+    // All-purpose cluster form: `/o/<digits>/<cluster-id>` as a path segment.
+    const pathOnly = queryIdx >= 0 ? httpPath.slice(0, queryIdx) : httpPath;
+    const pathMatch = pathOnly.match(/(?:^|\/)o\/(\d+)(?:\/|$)/);
+    return pathMatch ? pathMatch[1] : undefined;
+  }
+
+  // Detects an `o=<value>` or `/o/<value>` where `<value>` is present but
+  // non-numeric, so the caller can warn instead of silently dropping a
+  // malformed workspace param.
+  private static hasMalformedOrgParam(httpPath: string | undefined): boolean {
+    if (!httpPath) {
+      return false;
+    }
+    const queryIdx = httpPath.indexOf('?');
+    if (queryIdx >= 0) {
+      const query = httpPath.slice(queryIdx + 1);
+      const hasOrg = /(?:^|&)o=/.test(query);
+      const hasNumericOrg = /(?:^|&)o=\d+(?:&|$)/.test(query);
+      if (hasOrg && !hasNumericOrg) {
+        return true;
+      }
+    }
+    const pathOnly = queryIdx >= 0 ? httpPath.slice(0, queryIdx) : httpPath;
+    const hasPathOrg = /(?:^|\/)o\/[^/]+/.test(pathOnly);
+    const hasNumericPathOrg = /(?:^|\/)o\/\d+(?:\/|$)/.test(pathOnly);
+    return hasPathOrg && !hasNumericPathOrg;
   }
 
   /**
    * Build the customHeaders map applied to telemetry POSTs and feature-flag
-   * GETs (SPOG / Single Panel of Glass support). When `httpPath` carries
-   * `?o=<workspaceId>` — account-level vanity URL routing — endpoints that
-   * don't include the workspace in their path need the workspace conveyed via
+   * GETs (SPOG / Single Panel of Glass support). When `httpPath` carries a
+   * workspace ID — either as a `?o=<wsId>` query (warehouse) or a
+   * `/o/<wsId>/<cluster-id>` path segment (all-purpose cluster) — endpoints
+   * that don't include the workspace in their URL path need it conveyed via
    * the `x-databricks-org-id` header instead. A user-supplied value in
-   * `options.customHeaders` (case-insensitively keyed) wins over the parsed
-   * value.
+   * `userHeaders` (case-insensitively keyed) wins over the parsed value.
+   *
+   * `httpPath` is passed explicitly (rather than read off `this.httpPath`) so
+   * the SPOG-routing dependency is visible in the signature — a future
+   * refactor that reorders connect() can't silently break injection.
    */
-  private buildCustomHeaders(options: ConnectionOptions): Record<string, string> | undefined {
-    const merged: Record<string, string> = { ...(options.customHeaders ?? {}) };
+  private buildCustomHeaders(
+    httpPath: string | undefined,
+    userHeaders: Record<string, string> | undefined,
+  ): Record<string, string> | undefined {
+    const merged: Record<string, string> = { ...(userHeaders ?? {}) };
     const hasOrgIdAlready = Object.keys(merged).some((k) => k.toLowerCase() === 'x-databricks-org-id');
-    if (!hasOrgIdAlready) {
-      const orgId = this.extractWorkspaceId();
+    if (hasOrgIdAlready) {
+      this.logger.log(
+        LogLevel.debug,
+        'SPOG: x-databricks-org-id supplied by caller; not extracting from httpPath',
+      );
+    } else {
+      const orgId = DBSQLClient.extractWorkspaceId(httpPath);
       if (orgId) {
         merged['x-databricks-org-id'] = orgId;
+        this.logger.log(LogLevel.debug, `SPOG: injecting x-databricks-org-id=${orgId} (extracted from httpPath)`);
+      } else if (DBSQLClient.hasMalformedOrgParam(httpPath)) {
+        this.logger.log(
+          LogLevel.warn,
+          'SPOG: httpPath contains non-numeric workspace ID; x-databricks-org-id not injected',
+        );
       }
     }
     return Object.keys(merged).length > 0 ? merged : undefined;
@@ -585,7 +630,7 @@ export default class DBSQLClient extends EventEmitter implements IDBSQLClient, I
     // SPOG: parse `?o=<workspaceId>` out of httpPath and stash it as
     // `x-databricks-org-id` for the telemetry + feature-flag clients, which
     // hit endpoints that don't carry the workspace in their URL path.
-    this.config.customHeaders = this.buildCustomHeaders(options);
+    this.config.customHeaders = this.buildCustomHeaders(options.path, options.customHeaders);
 
     this.authProvider = this.createAuthProvider(options, authProvider);
 
@@ -703,7 +748,7 @@ export default class DBSQLClient extends EventEmitter implements IDBSQLClient, I
     safeEmit(this, (emitter) => {
       if (!this.host) return;
       const latencyMs = Date.now() - startTime;
-      const workspaceId = this.extractWorkspaceId();
+      const workspaceId = DBSQLClient.extractWorkspaceId(this.httpPath);
       const driverConfig = this.driverConfigShipped ? undefined : this.buildDriverConfiguration();
       if (driverConfig) {
         this.driverConfigShipped = true;

--- a/lib/contracts/IClientContext.ts
+++ b/lib/contracts/IClientContext.ts
@@ -52,6 +52,17 @@ export interface ClientConfig {
    */
   telemetryFlushOnExit?: boolean;
   userAgentEntry?: string;
+
+  /**
+   * Extra HTTP headers attached to driver-owned out-of-band requests
+   * (telemetry, feature flags). Populated by `DBSQLClient.connect()` from
+   * `ConnectionOptions.customHeaders` plus an `x-databricks-org-id` header
+   * derived from the `?o=` query parameter on `httpPath` when present, to
+   * support SPOG (Single Panel of Glass) account-level routing on endpoints
+   * that don't carry `?o=` in their URL path. NOT applied to Thrift or
+   * OAuth/OIDC requests.
+   */
+  customHeaders?: Record<string, string>;
 }
 
 export default interface IClientContext {

--- a/lib/contracts/IDBSQLClient.ts
+++ b/lib/contracts/IDBSQLClient.ts
@@ -56,6 +56,17 @@ export type ConnectionOptions = {
   enableMetricViewMetadata?: boolean;
 
   /**
+   * Extra HTTP headers attached to driver-owned out-of-band requests
+   * (telemetry POSTs and feature-flag GETs). Not applied to the primary
+   * Thrift transport or to OAuth/OIDC token requests.
+   *
+   * When `path` contains `?o=<workspaceId>` (SPOG account-level routing),
+   * the driver automatically injects an `x-databricks-org-id` header unless
+   * one is already present in this map.
+   */
+  customHeaders?: Record<string, string>;
+
+  /**
    * Whether the driver emits telemetry events (connection / statement /
    * cloud-fetch / error). Defaults to `true`.
    *

--- a/lib/telemetry/DatabricksTelemetryExporter.ts
+++ b/lib/telemetry/DatabricksTelemetryExporter.ts
@@ -249,6 +249,7 @@ export default class DatabricksTelemetryExporter {
     let headers: Record<string, string> = {
       'Content-Type': 'application/json',
       'User-Agent': userAgent,
+      ...(config.customHeaders ?? {}),
     };
 
     if (authenticatedExport) {

--- a/lib/telemetry/FeatureFlagCache.ts
+++ b/lib/telemetry/FeatureFlagCache.ts
@@ -140,6 +140,7 @@ export default class FeatureFlagCache {
       const headers: Record<string, string> = {
         'Content-Type': 'application/json',
         'User-Agent': this.userAgent,
+        ...(this.context.getConfig().customHeaders ?? {}),
         ...(await this.getAuthHeaders()),
       };
 

--- a/lib/telemetry/TelemetryClient.ts
+++ b/lib/telemetry/TelemetryClient.ts
@@ -169,8 +169,10 @@ class TelemetryClient implements IClientContext {
 
   /**
    * Remove a `DBSQLClient`'s context from the pool. Called by
-   * `TelemetryClientProvider.releaseClient` before refcount decrement so the
-   * exporter doesn't keep trying to use a closed context.
+   * `TelemetryClientProvider.releaseClient` in the multi-refcount case so the
+   * exporter doesn't keep trying to use a closing context. Deliberately
+   * NOT called on the last refcount release: `close()` needs the snapshot
+   * pair to resolve auth/connection providers for the final flush.
    *
    * Uses the cached snapshot pair (`context`, `authProvider`) from register
    * time, not a fresh `context.getAuthProvider?.()` call. If the underlying

--- a/lib/telemetry/TelemetryClient.ts
+++ b/lib/telemetry/TelemetryClient.ts
@@ -169,10 +169,8 @@ class TelemetryClient implements IClientContext {
 
   /**
    * Remove a `DBSQLClient`'s context from the pool. Called by
-   * `TelemetryClientProvider.releaseClient` in the multi-refcount case so the
-   * exporter doesn't keep trying to use a closing context. Deliberately
-   * NOT called on the last refcount release: `close()` needs the snapshot
-   * pair to resolve auth/connection providers for the final flush.
+   * `TelemetryClientProvider.releaseClient` before refcount decrement so the
+   * exporter doesn't keep trying to use a closed context.
    *
    * Uses the cached snapshot pair (`context`, `authProvider`) from register
    * time, not a fresh `context.getAuthProvider?.()` call. If the underlying

--- a/lib/telemetry/TelemetryClientProvider.ts
+++ b/lib/telemetry/TelemetryClientProvider.ts
@@ -133,35 +133,26 @@ class TelemetryClientProvider {
       return;
     }
 
+    // Skip unregister on the last release so close()'s final flush can still
+    // resolve auth/connection providers from the FIFO snapshot.
     if (holder.refCount > 1) {
-      // Other registrants remain — drop this context now so subsequent
-      // flushes by surviving consumers don't try to authenticate via a
-      // context whose underlying DBSQLClient is closing.
       holder.client.unregisterContext(context);
-      holder.refCount -= 1;
-      logger.log(LogLevel.debug, `TelemetryClient reference count for ${host}: ${holder.refCount}`);
-      return;
     }
-
-    // Last refcount holder. Keep the context registered through close()
-    // so the final flush can still resolve `getAuthProvider()` and
-    // `getConnectionProvider()` from the FIFO snapshot — otherwise the
-    // exporter drops the final batch with "missing Authorization header".
-    // The TelemetryClient is fully closed below, so the lingering FIFO
-    // entry has no further effect.
     holder.refCount -= 1;
     logger.log(LogLevel.debug, `TelemetryClient reference count for ${host}: ${holder.refCount}`);
 
-    // Remove from map BEFORE awaiting close so a concurrent
-    // getOrCreateClient creates a fresh instance rather than receiving
-    // this closing one.
-    this.clients.delete(key);
-    try {
-      await holder.client.close();
-      logger.log(LogLevel.debug, `Closed and removed TelemetryClient for host: ${host}`);
-    } catch (error) {
-      const msg = error instanceof Error ? error.message : String(error);
-      logger.log(LogLevel.debug, `Error releasing TelemetryClient: ${msg}`);
+    if (holder.refCount <= 0) {
+      // Remove from map BEFORE awaiting close so a concurrent
+      // getOrCreateClient creates a fresh instance rather than receiving
+      // this closing one.
+      this.clients.delete(key);
+      try {
+        await holder.client.close();
+        logger.log(LogLevel.debug, `Closed and removed TelemetryClient for host: ${host}`);
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        logger.log(LogLevel.debug, `Error releasing TelemetryClient: ${msg}`);
+      }
     }
   }
 

--- a/lib/telemetry/TelemetryClientProvider.ts
+++ b/lib/telemetry/TelemetryClientProvider.ts
@@ -133,22 +133,35 @@ class TelemetryClientProvider {
       return;
     }
 
-    holder.client.unregisterContext(context);
+    if (holder.refCount > 1) {
+      // Other registrants remain — drop this context now so subsequent
+      // flushes by surviving consumers don't try to authenticate via a
+      // context whose underlying DBSQLClient is closing.
+      holder.client.unregisterContext(context);
+      holder.refCount -= 1;
+      logger.log(LogLevel.debug, `TelemetryClient reference count for ${host}: ${holder.refCount}`);
+      return;
+    }
+
+    // Last refcount holder. Keep the context registered through close()
+    // so the final flush can still resolve `getAuthProvider()` and
+    // `getConnectionProvider()` from the FIFO snapshot — otherwise the
+    // exporter drops the final batch with "missing Authorization header".
+    // The TelemetryClient is fully closed below, so the lingering FIFO
+    // entry has no further effect.
     holder.refCount -= 1;
     logger.log(LogLevel.debug, `TelemetryClient reference count for ${host}: ${holder.refCount}`);
 
-    if (holder.refCount <= 0) {
-      // Remove from map BEFORE awaiting close so a concurrent
-      // getOrCreateClient creates a fresh instance rather than receiving
-      // this closing one.
-      this.clients.delete(key);
-      try {
-        await holder.client.close();
-        logger.log(LogLevel.debug, `Closed and removed TelemetryClient for host: ${host}`);
-      } catch (error) {
-        const msg = error instanceof Error ? error.message : String(error);
-        logger.log(LogLevel.debug, `Error releasing TelemetryClient: ${msg}`);
-      }
+    // Remove from map BEFORE awaiting close so a concurrent
+    // getOrCreateClient creates a fresh instance rather than receiving
+    // this closing one.
+    this.clients.delete(key);
+    try {
+      await holder.client.close();
+      logger.log(LogLevel.debug, `Closed and removed TelemetryClient for host: ${host}`);
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      logger.log(LogLevel.debug, `Error releasing TelemetryClient: ${msg}`);
     }
   }
 

--- a/tests/unit/DBSQLClient.test.ts
+++ b/tests/unit/DBSQLClient.test.ts
@@ -103,6 +103,18 @@ describe('DBSQLClient.connect', () => {
 
     logSpy.restore();
   });
+
+  it('populates config.customHeaders with org-id parsed from ?o= (SPOG)', async () => {
+    const client = new DBSQLClient();
+    await client.connect({ ...connectOptions, path: '/sql/1.0/warehouses/abc?o=12345678901234' });
+    expect(client.getConfig().customHeaders).to.deep.equal({ 'x-databricks-org-id': '12345678901234' });
+  });
+
+  it('leaves config.customHeaders undefined when path has no ?o= and none supplied', async () => {
+    const client = new DBSQLClient();
+    await client.connect({ ...connectOptions, path: '/sql/1.0/warehouses/abc' });
+    expect(client.getConfig().customHeaders).to.be.undefined;
+  });
 });
 
 describe('DBSQLClient.openSession', () => {
@@ -782,6 +794,49 @@ describe('DBSQLClient telemetry paths', () => {
     it('returns undefined when httpPath is unset', () => {
       const client = new DBSQLClient();
       expect((client as any).extractWorkspaceId()).to.be.undefined;
+    });
+  });
+
+  describe('buildCustomHeaders (SPOG)', () => {
+    it('injects x-databricks-org-id from ?o= in httpPath', () => {
+      const client = new DBSQLClient();
+      (client as any).httpPath = '/sql/1.0/warehouses/abc?o=12345678901234';
+      const headers = (client as any).buildCustomHeaders({ path: '/sql/1.0/warehouses/abc?o=12345678901234' });
+      expect(headers).to.deep.equal({ 'x-databricks-org-id': '12345678901234' });
+    });
+
+    it('returns undefined when no ?o= and no user-supplied customHeaders', () => {
+      const client = new DBSQLClient();
+      (client as any).httpPath = '/sql/1.0/warehouses/abc';
+      const headers = (client as any).buildCustomHeaders({ path: '/sql/1.0/warehouses/abc' });
+      expect(headers).to.be.undefined;
+    });
+
+    it('preserves user-supplied customHeaders alongside parsed org-id', () => {
+      const client = new DBSQLClient();
+      (client as any).httpPath = '/sql/1.0/warehouses/abc?o=42';
+      const headers = (client as any).buildCustomHeaders({
+        path: '/sql/1.0/warehouses/abc?o=42',
+        customHeaders: { 'x-trace-id': 'tid-001' },
+      });
+      expect(headers).to.deep.equal({ 'x-trace-id': 'tid-001', 'x-databricks-org-id': '42' });
+    });
+
+    it('user-supplied x-databricks-org-id wins over ?o= parsed value (case-insensitive)', () => {
+      const client = new DBSQLClient();
+      (client as any).httpPath = '/sql/1.0/warehouses/abc?o=42';
+      const headers = (client as any).buildCustomHeaders({
+        path: '/sql/1.0/warehouses/abc?o=42',
+        customHeaders: { 'X-Databricks-Org-Id': '999' },
+      });
+      expect(headers).to.deep.equal({ 'X-Databricks-Org-Id': '999' });
+    });
+
+    it('does not inject org-id when ?o= value is non-numeric', () => {
+      const client = new DBSQLClient();
+      (client as any).httpPath = '/sql/1.0/warehouses/abc?o=tenant_xyz';
+      const headers = (client as any).buildCustomHeaders({ path: '/sql/1.0/warehouses/abc?o=tenant_xyz' });
+      expect(headers).to.be.undefined;
     });
   });
 

--- a/tests/unit/DBSQLClient.test.ts
+++ b/tests/unit/DBSQLClient.test.ts
@@ -788,27 +788,22 @@ describe('DBSQLClient telemetry paths', () => {
     });
 
     it('returns the numeric workspace id from all-purpose cluster path form', () => {
-      expect(
-        (DBSQLClient as any).extractWorkspaceId('sql/protocolv1/o/99999999999999/0101-000000-aaaaaaaa'),
-      ).to.equal('99999999999999');
+      expect((DBSQLClient as any).extractWorkspaceId('sql/protocolv1/o/99999999999999/0101-000000-aaaaaaaa')).to.equal(
+        '99999999999999',
+      );
     });
 
     it('returns the numeric workspace id from all-purpose cluster path with leading slash', () => {
-      expect(
-        (DBSQLClient as any).extractWorkspaceId('/sql/protocolv1/o/12345/0101-000000-aaaaaaaa'),
-      ).to.equal('12345');
+      expect((DBSQLClient as any).extractWorkspaceId('/sql/protocolv1/o/12345/0101-000000-aaaaaaaa')).to.equal('12345');
     });
 
     it('returns undefined when all-purpose cluster path has non-numeric workspace segment', () => {
-      expect(
-        (DBSQLClient as any).extractWorkspaceId('sql/protocolv1/o/tenant_xyz/0101-000000-aaaaaaaa'),
-      ).to.be.undefined;
+      expect((DBSQLClient as any).extractWorkspaceId('sql/protocolv1/o/tenant_xyz/0101-000000-aaaaaaaa')).to.be
+        .undefined;
     });
 
     it('prefers ?o= query form over /o/ path form when both are present', () => {
-      expect(
-        (DBSQLClient as any).extractWorkspaceId('sql/protocolv1/o/111/cluster?o=222'),
-      ).to.equal('222');
+      expect((DBSQLClient as any).extractWorkspaceId('sql/protocolv1/o/111/cluster?o=222')).to.equal('222');
     });
   });
 

--- a/tests/unit/DBSQLClient.test.ts
+++ b/tests/unit/DBSQLClient.test.ts
@@ -767,76 +767,145 @@ describe('DBSQLClient telemetry paths', () => {
 
   describe('extractWorkspaceId', () => {
     it('returns the numeric o= param from httpPath', () => {
-      const client = new DBSQLClient();
-      (client as any).httpPath = '/sql/1.0/warehouses/abc?o=12345678901234';
-      const id = (client as any).extractWorkspaceId();
+      const id = (DBSQLClient as any).extractWorkspaceId('/sql/1.0/warehouses/abc?o=12345678901234');
       expect(id).to.equal('12345678901234');
     });
 
     it('returns undefined when no query string', () => {
-      const client = new DBSQLClient();
-      (client as any).httpPath = '/sql/1.0/warehouses/abc';
-      expect((client as any).extractWorkspaceId()).to.be.undefined;
+      expect((DBSQLClient as any).extractWorkspaceId('/sql/1.0/warehouses/abc')).to.be.undefined;
     });
 
     it('returns undefined when o= is not numeric', () => {
-      const client = new DBSQLClient();
-      (client as any).httpPath = '/sql/1.0/warehouses/abc?o=tenant_xyz';
-      expect((client as any).extractWorkspaceId()).to.be.undefined;
+      expect((DBSQLClient as any).extractWorkspaceId('/sql/1.0/warehouses/abc?o=tenant_xyz')).to.be.undefined;
     });
 
     it('handles o= as a non-first param', () => {
-      const client = new DBSQLClient();
-      (client as any).httpPath = '/sql/1.0/warehouses/abc?foo=bar&o=42&baz=qux';
-      expect((client as any).extractWorkspaceId()).to.equal('42');
+      expect((DBSQLClient as any).extractWorkspaceId('/sql/1.0/warehouses/abc?foo=bar&o=42&baz=qux')).to.equal('42');
     });
 
     it('returns undefined when httpPath is unset', () => {
-      const client = new DBSQLClient();
-      expect((client as any).extractWorkspaceId()).to.be.undefined;
+      expect((DBSQLClient as any).extractWorkspaceId(undefined)).to.be.undefined;
+    });
+
+    it('returns the numeric workspace id from all-purpose cluster path form', () => {
+      expect(
+        (DBSQLClient as any).extractWorkspaceId('sql/protocolv1/o/99999999999999/0101-000000-aaaaaaaa'),
+      ).to.equal('99999999999999');
+    });
+
+    it('returns the numeric workspace id from all-purpose cluster path with leading slash', () => {
+      expect(
+        (DBSQLClient as any).extractWorkspaceId('/sql/protocolv1/o/12345/0101-000000-aaaaaaaa'),
+      ).to.equal('12345');
+    });
+
+    it('returns undefined when all-purpose cluster path has non-numeric workspace segment', () => {
+      expect(
+        (DBSQLClient as any).extractWorkspaceId('sql/protocolv1/o/tenant_xyz/0101-000000-aaaaaaaa'),
+      ).to.be.undefined;
+    });
+
+    it('prefers ?o= query form over /o/ path form when both are present', () => {
+      expect(
+        (DBSQLClient as any).extractWorkspaceId('sql/protocolv1/o/111/cluster?o=222'),
+      ).to.equal('222');
     });
   });
 
   describe('buildCustomHeaders (SPOG)', () => {
     it('injects x-databricks-org-id from ?o= in httpPath', () => {
       const client = new DBSQLClient();
-      (client as any).httpPath = '/sql/1.0/warehouses/abc?o=12345678901234';
-      const headers = (client as any).buildCustomHeaders({ path: '/sql/1.0/warehouses/abc?o=12345678901234' });
+      const headers = (client as any).buildCustomHeaders('/sql/1.0/warehouses/abc?o=12345678901234', undefined);
       expect(headers).to.deep.equal({ 'x-databricks-org-id': '12345678901234' });
     });
 
     it('returns undefined when no ?o= and no user-supplied customHeaders', () => {
       const client = new DBSQLClient();
-      (client as any).httpPath = '/sql/1.0/warehouses/abc';
-      const headers = (client as any).buildCustomHeaders({ path: '/sql/1.0/warehouses/abc' });
+      const headers = (client as any).buildCustomHeaders('/sql/1.0/warehouses/abc', undefined);
       expect(headers).to.be.undefined;
     });
 
     it('preserves user-supplied customHeaders alongside parsed org-id', () => {
       const client = new DBSQLClient();
-      (client as any).httpPath = '/sql/1.0/warehouses/abc?o=42';
-      const headers = (client as any).buildCustomHeaders({
-        path: '/sql/1.0/warehouses/abc?o=42',
-        customHeaders: { 'x-trace-id': 'tid-001' },
-      });
+      const headers = (client as any).buildCustomHeaders('/sql/1.0/warehouses/abc?o=42', { 'x-trace-id': 'tid-001' });
       expect(headers).to.deep.equal({ 'x-trace-id': 'tid-001', 'x-databricks-org-id': '42' });
     });
 
     it('user-supplied x-databricks-org-id wins over ?o= parsed value (case-insensitive)', () => {
       const client = new DBSQLClient();
-      (client as any).httpPath = '/sql/1.0/warehouses/abc?o=42';
-      const headers = (client as any).buildCustomHeaders({
-        path: '/sql/1.0/warehouses/abc?o=42',
-        customHeaders: { 'X-Databricks-Org-Id': '999' },
+      const headers = (client as any).buildCustomHeaders('/sql/1.0/warehouses/abc?o=42', {
+        'X-Databricks-Org-Id': '999',
       });
       expect(headers).to.deep.equal({ 'X-Databricks-Org-Id': '999' });
     });
 
     it('does not inject org-id when ?o= value is non-numeric', () => {
       const client = new DBSQLClient();
-      (client as any).httpPath = '/sql/1.0/warehouses/abc?o=tenant_xyz';
-      const headers = (client as any).buildCustomHeaders({ path: '/sql/1.0/warehouses/abc?o=tenant_xyz' });
+      const headers = (client as any).buildCustomHeaders('/sql/1.0/warehouses/abc?o=tenant_xyz', undefined);
       expect(headers).to.be.undefined;
+    });
+
+    it('injects x-databricks-org-id from all-purpose cluster path form', () => {
+      const client = new DBSQLClient();
+      const headers = (client as any).buildCustomHeaders(
+        'sql/protocolv1/o/99999999999999/0101-000000-aaaaaaaa',
+        undefined,
+      );
+      expect(headers).to.deep.equal({ 'x-databricks-org-id': '99999999999999' });
+    });
+
+    it('logs a warning when workspace ID segment is non-numeric (path form)', () => {
+      const client = new DBSQLClient();
+      const logSpy = sinon.spy((client as any).logger, 'log');
+      try {
+        (client as any).buildCustomHeaders('sql/protocolv1/o/tenant_xyz/cluster', undefined);
+        const warnCalls = logSpy.getCalls().filter((c) => c.args[0] === LogLevel.warn);
+        expect(warnCalls).to.have.lengthOf(1);
+        expect(warnCalls[0].args[1]).to.match(/non-numeric workspace ID/);
+      } finally {
+        logSpy.restore();
+      }
+    });
+
+    it('logs a warning when ?o= is present but non-numeric', () => {
+      const client = new DBSQLClient();
+      const logSpy = sinon.spy((client as any).logger, 'log');
+      try {
+        (client as any).buildCustomHeaders('/sql/1.0/warehouses/abc?o=tenant_xyz', undefined);
+        const warnCalls = logSpy.getCalls().filter((c) => c.args[0] === LogLevel.warn);
+        expect(warnCalls).to.have.lengthOf(1);
+        expect(warnCalls[0].args[1]).to.match(/non-numeric workspace ID/);
+      } finally {
+        logSpy.restore();
+      }
+    });
+
+    it('logs a debug line when injecting org-id from httpPath', () => {
+      const client = new DBSQLClient();
+      const logSpy = sinon.spy((client as any).logger, 'log');
+      try {
+        (client as any).buildCustomHeaders('/sql/1.0/warehouses/abc?o=42', undefined);
+        const injectLog = logSpy
+          .getCalls()
+          .find((c) => c.args[0] === LogLevel.debug && /injecting x-databricks-org-id=42/.test(String(c.args[1])));
+        expect(injectLog, 'expected SPOG inject debug log').to.exist;
+      } finally {
+        logSpy.restore();
+      }
+    });
+
+    it('logs a debug line when caller supplies x-databricks-org-id', () => {
+      const client = new DBSQLClient();
+      const logSpy = sinon.spy((client as any).logger, 'log');
+      try {
+        (client as any).buildCustomHeaders('/sql/1.0/warehouses/abc?o=42', { 'x-databricks-org-id': '999' });
+        const callerLog = logSpy
+          .getCalls()
+          .find((c) => c.args[0] === LogLevel.debug && /supplied by caller/.test(String(c.args[1])));
+        expect(callerLog, 'expected SPOG caller-supplied debug log').to.exist;
+      } finally {
+        logSpy.restore();
+      }
     });
   });
 

--- a/tests/unit/telemetry/DatabricksTelemetryExporter.test.ts
+++ b/tests/unit/telemetry/DatabricksTelemetryExporter.test.ts
@@ -120,6 +120,46 @@ describe('DatabricksTelemetryExporter', () => {
       }
       expect(threw).to.be.false;
     });
+
+    it('should attach config.customHeaders to the POST (SPOG)', async () => {
+      const context = new ClientContextStub({
+        customHeaders: { 'x-databricks-org-id': '12345678901234' },
+      } as any);
+      const registry = new CircuitBreakerRegistry(context);
+      const exporter = new DatabricksTelemetryExporter(context, 'host.example.com', registry, fakeAuthProvider);
+      const sendRequestStub = sinon.stub(exporter as any, 'sendRequest').returns(makeOkResponse());
+
+      await exporter.export([makeMetric()]);
+
+      const init = sendRequestStub.firstCall.args[1] as { headers: Record<string, string> };
+      expect(init.headers['x-databricks-org-id']).to.equal('12345678901234');
+    });
+
+    it('auth headers win over customHeaders on key collision', async () => {
+      const context = new ClientContextStub({
+        customHeaders: { Authorization: 'Bearer not-the-real-token' },
+      } as any);
+      const registry = new CircuitBreakerRegistry(context);
+      const exporter = new DatabricksTelemetryExporter(context, 'host.example.com', registry, fakeAuthProvider);
+      const sendRequestStub = sinon.stub(exporter as any, 'sendRequest').returns(makeOkResponse());
+
+      await exporter.export([makeMetric()]);
+
+      const init = sendRequestStub.firstCall.args[1] as { headers: Record<string, string> };
+      expect(init.headers.Authorization).to.equal('Bearer test-token');
+    });
+
+    it('does not attach customHeaders when none are configured', async () => {
+      const context = new ClientContextStub();
+      const registry = new CircuitBreakerRegistry(context);
+      const exporter = new DatabricksTelemetryExporter(context, 'host.example.com', registry, fakeAuthProvider);
+      const sendRequestStub = sinon.stub(exporter as any, 'sendRequest').returns(makeOkResponse());
+
+      await exporter.export([makeMetric()]);
+
+      const init = sendRequestStub.firstCall.args[1] as { headers: Record<string, string> };
+      expect(init.headers).to.not.have.property('x-databricks-org-id');
+    });
   });
 
   describe('export() - retry logic', () => {

--- a/tests/unit/telemetry/FeatureFlagCache.test.ts
+++ b/tests/unit/telemetry/FeatureFlagCache.test.ts
@@ -317,4 +317,43 @@ describe('FeatureFlagCache', () => {
       fetchStub.restore();
     });
   });
+
+  describe('customHeaders propagation (SPOG)', () => {
+    function makeJsonResponse(body: unknown) {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: () => Promise.resolve(body),
+        text: () => Promise.resolve(''),
+      });
+    }
+
+    it('attaches config.customHeaders to the feature-flag GET', async () => {
+      const context = new ClientContextStub({
+        customHeaders: { 'x-databricks-org-id': '12345678901234' },
+      } as any);
+      const cache = new FeatureFlagCache(context);
+      const stub = sinon.stub(cache as any, 'fetchWithRetry').returns(makeJsonResponse({ flags: [] }));
+
+      await (cache as any).fetchFeatureFlag('host.example.com');
+
+      expect(stub.calledOnce).to.be.true;
+      const init = stub.firstCall.args[1] as { headers: Record<string, string> };
+      expect(init.headers['x-databricks-org-id']).to.equal('12345678901234');
+      stub.restore();
+    });
+
+    it('does not set x-databricks-org-id when customHeaders is empty', async () => {
+      const context = new ClientContextStub();
+      const cache = new FeatureFlagCache(context);
+      const stub = sinon.stub(cache as any, 'fetchWithRetry').returns(makeJsonResponse({ flags: [] }));
+
+      await (cache as any).fetchFeatureFlag('host.example.com');
+
+      const init = stub.firstCall.args[1] as { headers: Record<string, string> };
+      expect(init.headers).to.not.have.property('x-databricks-org-id');
+      stub.restore();
+    });
+  });
 });

--- a/tests/unit/telemetry/TelemetryClientProvider.test.ts
+++ b/tests/unit/telemetry/TelemetryClientProvider.test.ts
@@ -267,6 +267,50 @@ describe('TelemetryClientProvider', () => {
       expect(second.isClosed()).to.be.false;
       expect(provider.getRefCount(HOST1)).to.equal(1);
     });
+
+    it('keeps the context registered through close() on last refcount', async () => {
+      // Regression: releaseClient used to call unregisterContext before
+      // close(), which dropped the only FIFO entry and left the final
+      // flush without an auth provider — metrics were dropped with
+      // "missing Authorization header".
+      const context = new ClientContextStub();
+      const provider = new TelemetryClientProvider();
+
+      const client = provider.getOrCreateClient(context, HOST1);
+      let authProviderAtClose: unknown = 'unset';
+      sinon.stub(client, 'close').callsFake(async () => {
+        // The TelemetryClient is its own IClientContext. While close() runs,
+        // getAuthProvider() must still resolve (the FIFO entry survives).
+        authProviderAtClose = client.getAuthProvider?.();
+      });
+
+      await provider.releaseClient(context, HOST1);
+
+      // The FIFO walk hits the (still-registered) context; the stub's
+      // getAuthProvider returns undefined but the lookup itself completes.
+      // What we're really asserting is that the FIFO wasn't pre-emptied:
+      // pre-fix, this assertion would not even fire because close() runs
+      // against an empty FIFO and the auth-provider walk short-circuits
+      // before close()'s callsFake. Here we verify the spy ran AND the
+      // context is still registered at that moment.
+      expect(authProviderAtClose).to.not.equal('unset');
+      expect((client as any).contexts.length).to.equal(1);
+    });
+
+    it('drops the context immediately when other refcounts remain', async () => {
+      const context = new ClientContextStub();
+      const provider = new TelemetryClientProvider();
+
+      const client = provider.getOrCreateClient(context, HOST1);
+      provider.getOrCreateClient(context, HOST1); // refcount=2
+
+      await provider.releaseClient(context, HOST1);
+
+      // Multi-refcount path: unregisterContext runs immediately; the
+      // (single) FIFO entry tracking this context was removed.
+      expect((client as any).contexts.length).to.equal(0);
+      expect(provider.getRefCount(HOST1)).to.equal(1);
+    });
   });
 
   describe('Host normalization', () => {


### PR DESCRIPTION
## Summary

Ports the SPOG (Single Panel of Glass) routing fix from
[databricks/databricks-jdbc#1316](https://github.com/databricks/databricks-jdbc/pull/1316)
to the Node.js driver, and fixes a related close-ordering bug uncovered
while validating the port against a real SPOG host.

### Change 1: SPOG header injection

SPOG replaces workspace-specific hostnames with account-level vanity URLs.
When `httpPath` carries `?o=<workspaceId>`, endpoints that don't include
the workspace in their URL path need the workspace conveyed via the
`x-databricks-org-id` header instead.

- Parse `?o=<digits>` out of `httpPath` in `DBSQLClient.connect()` and
  stash the org-id as `x-databricks-org-id` on a new
  `ClientConfig.customHeaders` field. A user-supplied `customHeaders`
  entry (case-insensitively keyed) takes precedence.
- `DatabricksTelemetryExporter` spreads `config.customHeaders` into the
  outgoing POST headers; auth headers still win on collision.
- `FeatureFlagCache` does the same for the feature-flag GET.
- `ConnectionOptions.customHeaders` exposed so callers can also inject
  their own out-of-band headers.

OAuth / OIDC token requests use `openid-client`'s private HTTP transport
and never see `customHeaders`, matching JDBC's exemption.

**Not needed vs JDBC**: this driver passes `options.path` through
unmodified (no split-on-`=` parser), uses Thrift only (no SEA JSON body
warehouse-ID extraction), and exposes no Volume API surface.

### Change 2: Close-ordering fix

While verifying Change 1 against a real SPOG warehouse, the final
`client.close()` flush emitted:

```
[warn] Telemetry: Authorization header missing — metrics will be dropped
[debug] Telemetry export auth failure: Telemetry export: missing Authorization header
```

Root cause: `TelemetryClientProvider.releaseClient` called
`unregisterContext` *before* `client.close()`. On the last refcount, that
emptied the FIFO of `(context, authProvider)` pairs before the final
flush, so the exporter's `getAuthProvider()` walk returned undefined and
the batch was dropped.

Fix: skip the `unregister` on the last release so the FIFO snapshot
survives through `close()`'s final flush. Multi-refcount path is
unchanged. No leak — the TelemetryClient is unreachable as soon as
`releaseClient` returns, and the retained `(context, authProvider)`
pair dies with it.

## Live verification

Ran against `dogfood-spog.staging.azuredatabricks.net` warehouse
`ad6f9b54e6593746?o=7064161269814046`:

```
customHeaders={"x-databricks-org-id":"7064161269814046"}     ← SPOG header injected
Feature flag enableTelemetryForNodeJs: true                  ← header propagated via SPOG
Result: [{"v":1}]                                            ← SELECT 1 worked
Successfully exported 3 telemetry metrics                    ← final flush no longer drops
```

## Test plan

Unit tests added (all passing locally):

- [x] `buildCustomHeaders` parses `?o=` into `x-databricks-org-id`
- [x] No header when `?o=` is absent and no user-supplied `customHeaders`
- [x] User-supplied `customHeaders` is preserved alongside parsed org-id
- [x] User-supplied `x-databricks-org-id` (any case) wins over `?o=`
- [x] Non-numeric `o=<value>` does not inject a header
- [x] End-to-end `DBSQLClient.connect()` populates
      `config.customHeaders['x-databricks-org-id']` from the path
- [x] `DatabricksTelemetryExporter` attaches `config.customHeaders` to
      the POST headers
- [x] Auth headers still override `customHeaders` on key collision
- [x] No header is attached when `config.customHeaders` is empty
- [x] `FeatureFlagCache.fetchFeatureFlag` attaches `customHeaders` to
      the GET headers
- [x] `releaseClient` keeps the context registered through `close()` on
      last refcount
- [x] `releaseClient` drops the context immediately when other
      refcounts remain

This pull request and its description were written by Isaac.