### PR TITLE
feat(sea): expose maxConnections + lock complex types as Arrow default

### DIFF
--- a/lib/contracts/IDBSQLClient.ts
+++ b/lib/contracts/IDBSQLClient.ts
@@ -54,6 +54,14 @@ export type ConnectionOptions = {
   socketTimeout?: number;
   proxy?: ProxyOptions;
   enableMetricViewMetadata?: boolean;
+  /**
+   * Maximum number of pooled HTTP connections per host. SEA backend
+   * only — Thrift backend currently ignores this. Mirrors the Python
+   * connector's `max_connections` kwarg (default 100 in the kernel's
+   * connection pool). Tune up when many statements run concurrently
+   * against the same warehouse to reduce reconnect overhead.
+   */
+  maxConnections?: number;
 } & AuthOptions;
 
 export interface OpenSessionRequest {

--- a/lib/sea/SeaAuth.ts
+++ b/lib/sea/SeaAuth.ts
@@ -66,6 +66,15 @@ export interface SeaSessionDefaults {
   catalog?: string;
   schema?: string;
   sessionConf?: Record<string, string>;
+  /**
+   * Maximum pooled HTTP connections per host. Forwarded to the
+   * napi `ConnectionOptions.maxConnections` field, which the kernel
+   * threads into `HttpConfig::pool_max_idle_per_host`. Connection-
+   * level (not session-level), but grouped with the session defaults
+   * here because both flow through the same napi `openSession` call.
+   * Omitted → kernel default (100) applies.
+   */
+  maxConnections?: number;
 }
 
 export type SeaNativeConnectionOptions = SeaSessionDefaults &
@@ -158,10 +167,22 @@ export function isBlankOrReserved(s: string): boolean {
 export function buildSeaConnectionOptions(options: ConnectionOptions): SeaNativeConnectionOptions {
   const { authType } = options as { authType?: string };
 
-  const base = {
+  const base: { hostName: string; httpPath: string; maxConnections?: number } = {
     hostName: options.host,
     httpPath: prependSlash(options.path),
   };
+  // Connection-level pool size — forwarded to the napi binding,
+  // ignored when undefined so the kernel default (100) applies.
+  // Validate at the JS layer (positive integer) so a misuse fails
+  // here instead of inside the kernel with a cryptic message.
+  if (options.maxConnections !== undefined) {
+    if (!Number.isInteger(options.maxConnections) || options.maxConnections < 1) {
+      throw new HiveDriverError(
+        `SEA backend: \`maxConnections\` must be a positive integer; got ${options.maxConnections}.`,
+      );
+    }
+    base.maxConnections = options.maxConnections;
+  }
 
   const oauth = options as {
     oauthClientId?: string;

--- a/lib/sea/SeaAuth.ts
+++ b/lib/sea/SeaAuth.ts
@@ -173,12 +173,21 @@ export function buildSeaConnectionOptions(options: ConnectionOptions): SeaNative
   };
   // Connection-level pool size — forwarded to the napi binding,
   // ignored when undefined so the kernel default (100) applies.
-  // Validate at the JS layer (positive integer) so a misuse fails
-  // here instead of inside the kernel with a cryptic message.
+  // Validate at the JS layer (positive integer, ≤ 2^32 - 1 since the
+  // napi binding accepts `u32`) so a misuse fails here with a clear
+  // `HiveDriverError` instead of either silently truncating at the
+  // FFI boundary or surfacing a cryptic kernel-side error. Upper-
+  // bound check addresses DA round-1 M1 finding.
+  const MAX_U32 = 0xff_ff_ff_ff; // 4_294_967_295
   if (options.maxConnections !== undefined) {
     if (!Number.isInteger(options.maxConnections) || options.maxConnections < 1) {
       throw new HiveDriverError(
         `SEA backend: \`maxConnections\` must be a positive integer; got ${options.maxConnections}.`,
+      );
+    }
+    if (options.maxConnections > MAX_U32) {
+      throw new HiveDriverError(
+        `SEA backend: \`maxConnections\` exceeds the napi u32 limit (${MAX_U32}); got ${options.maxConnections}. Typical pool sizes are 10-500.`,
       );
     }
     base.maxConnections = options.maxConnections;

--- a/tests/e2e/sea/complex-types-e2e.test.ts
+++ b/tests/e2e/sea/complex-types-e2e.test.ts
@@ -1,0 +1,139 @@
+// Copyright (c) 2026 Databricks, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * End-to-end check that complex types (ARRAY / MAP / STRUCT and nested
+ * combinations) flow through the SEA path as **native Arrow** shapes —
+ * not JSON strings.
+ *
+ * Kernel default is `ResultConfig::complex_types_as_json = false`
+ * (Arrow-native is the default). The kernel-side equivalent of this
+ * test lives at
+ * `tests/v0_execute_e2e.rs::complex_types_as_json_flag_stringifies_complex_columns`
+ * and asserts the dual: both `false` (Arrow) and `true` (Utf8 JSON)
+ * paths produce the expected shape.
+ *
+ * Matrix parity: this matches the NodeJS Thrift backend's behaviour
+ * when `useArrowNativeTypes: true` (the default — see
+ * `DBSQLSession.getArrowOptions` setting `complexTypesAsArrow: true`).
+ *
+ * Skipped when DATABRICKS_PECOTESTING_* env vars are absent. Pulls
+ * credentials from the standard pecotesting set (see
+ * `tests/e2e/sea/operation-lifecycle-e2e.test.ts` for the same gate).
+ */
+
+import { expect } from 'chai';
+import { tableFromIPC } from 'apache-arrow';
+import { getSeaNative } from '../../../lib/sea/SeaNativeLoader';
+
+interface NativeBinding {
+  openSession(opts: {
+    hostName: string;
+    httpPath: string;
+    token: string;
+  }): Promise<NativeConnection>;
+}
+
+interface NativeConnection {
+  executeStatement(sql: string): Promise<NativeStatement>;
+  close(): Promise<void>;
+}
+
+interface NativeStatement {
+  fetchNextBatch(): Promise<{ ipcBytes: Buffer } | null>;
+  schema(): Promise<{ ipcBytes: Buffer }>;
+  cancel(): Promise<void>;
+  close(): Promise<void>;
+}
+
+describe('SEA complex types — native Arrow default', function suite() {
+  this.timeout(120_000);
+
+  const hostName =
+    process.env.DATABRICKS_PECOTESTING_SERVER_HOSTNAME || process.env.E2E_HOST;
+  const httpPath =
+    process.env.DATABRICKS_PECOTESTING_HTTP_PATH || process.env.E2E_PATH;
+  const token =
+    process.env.DATABRICKS_PECOTESTING_TOKEN || process.env.E2E_ACCESS_TOKEN;
+
+  before(function gate() {
+    if (!hostName || !httpPath || !token) {
+      // eslint-disable-next-line no-invalid-this
+      this.skip();
+    }
+  });
+
+  it('ARRAY / MAP / STRUCT come back as native Arrow shapes', async () => {
+    const binding = getSeaNative() as unknown as NativeBinding;
+    const connection = await binding.openSession({
+      hostName: hostName as string,
+      httpPath: httpPath as string,
+      token: token as string,
+    });
+
+    let statement: NativeStatement | null = null;
+    try {
+      const sql = `SELECT
+        ARRAY(1, 2, 3)                                AS c_arr,
+        MAP('k1', 'v1', 'k2', 'v2')                   AS c_map,
+        NAMED_STRUCT('a', 'foo', 'b', 1)              AS c_struct,
+        ARRAY(NAMED_STRUCT('a', 'x', 'b', 1),
+              NAMED_STRUCT('a', 'y', 'b', 2))         AS c_arr_struct`;
+
+      statement = await connection.executeStatement(sql);
+      const batchEnvelope = await statement.fetchNextBatch();
+      expect(batchEnvelope).to.not.equal(null);
+
+      const table = tableFromIPC(batchEnvelope!.ipcBytes);
+      const schema = table.schema;
+
+      // Each complex column should be a native Arrow nested type, not Utf8.
+      const arrField = schema.fields.find((f) => f.name === 'c_arr');
+      const mapField = schema.fields.find((f) => f.name === 'c_map');
+      const structField = schema.fields.find((f) => f.name === 'c_struct');
+      const arrStructField = schema.fields.find((f) => f.name === 'c_arr_struct');
+
+      expect(arrField, 'c_arr field present').to.not.equal(undefined);
+      expect(mapField, 'c_map field present').to.not.equal(undefined);
+      expect(structField, 'c_struct field present').to.not.equal(undefined);
+      expect(arrStructField, 'c_arr_struct field present').to.not.equal(undefined);
+
+      // Arrow type ids per arrow-js — these are the structural checks
+      // that distinguish "native Arrow" from "JSON Utf8". Arrow type
+      // names are stable across arrow-js minor versions.
+      expect(arrField!.type.toString()).to.match(/List/i, 'c_arr should be List');
+      expect(mapField!.type.toString()).to.match(/Map|List/i, 'c_map should be Map (or List of Struct of key/value)');
+      expect(structField!.type.toString()).to.match(/Struct/i, 'c_struct should be Struct');
+      expect(arrStructField!.type.toString()).to.match(/List/i, 'c_arr_struct should be List of Struct');
+
+      // Sanity-check: NONE of the complex columns should be Utf8 — that
+      // would indicate complex_types_as_json was inadvertently enabled.
+      for (const f of [arrField!, mapField!, structField!, arrStructField!]) {
+        expect(f.type.toString()).to.not.match(
+          /^Utf8$/,
+          `${f.name} must not be a JSON string column`,
+        );
+      }
+    } finally {
+      if (statement !== null) {
+        try {
+          await statement.close();
+        } catch (_) {
+          // best-effort cleanup
+        }
+      }
+      await connection.close();
+    }
+  });
+});

--- a/tests/e2e/sea/complex-types-e2e.test.ts
+++ b/tests/e2e/sea/complex-types-e2e.test.ts
@@ -145,7 +145,7 @@ describe('SEA complex types — native Arrow default', function suite() {
       expect(batchEnvelope).to.not.equal(null);
 
       const table = tableFromIPC(batchEnvelope!.ipcBytes);
-      const schema = table.schema;
+      const { schema } = table;
 
       // Each complex column should be a native Arrow nested type, not Utf8.
       const arrField = schema.fields.find((f) => f.name === 'c_arr');

--- a/tests/e2e/sea/complex-types-e2e.test.ts
+++ b/tests/e2e/sea/complex-types-e2e.test.ts
@@ -35,8 +35,8 @@
 
 import { expect } from 'chai';
 import { tableFromIPC, Type as ArrowType } from 'apache-arrow';
-import * as fs from 'fs';
-import * as path from 'path';
+import { existsSync } from 'fs';
+import { resolve as resolvePath } from 'path';
 import { createRequire } from 'module';
 
 // Prerequisites for the live e2e:
@@ -97,11 +97,11 @@ describe('SEA complex types — native Arrow default', function suite() {
     // reparse this file as ESM (MODULE_TYPELESS_PACKAGE_JSON path)
     // where `__dirname` is undefined. mocha always runs with cwd at
     // the package root, so this resolves consistently.
-    const nodeArtifact = path.resolve(
+    const nodeArtifact = resolvePath(
       process.cwd(),
       'native/sea/index.linux-x64-gnu.node',
     );
-    if (!fs.existsSync(nodeArtifact)) {
+    if (!existsSync(nodeArtifact)) {
       // eslint-disable-next-line no-console
       console.warn(
         `[sea complex-types e2e] skipping: native binary not built. ` +

--- a/tests/e2e/sea/complex-types-e2e.test.ts
+++ b/tests/e2e/sea/complex-types-e2e.test.ts
@@ -34,8 +34,22 @@
  */
 
 import { expect } from 'chai';
-import { tableFromIPC } from 'apache-arrow';
-import { getSeaNative } from '../../../lib/sea/SeaNativeLoader';
+import { tableFromIPC, Type as ArrowType } from 'apache-arrow';
+import * as fs from 'fs';
+import * as path from 'path';
+import { createRequire } from 'module';
+
+// Prerequisites for the live e2e:
+//   1. `DATABRICKS_PECOTESTING_*` env vars set (host, http_path, token)
+//   2. `yarn build:native` has produced `native/sea/index.linux-x64-gnu.node`
+//
+// SeaNativeLoader.ts does a module-level `const native =
+// require('../../native/sea/index.js')` which crashes file evaluation
+// (MODULE_NOT_FOUND) when the `.node` artifact is absent, BEFORE mocha
+// can run the `before()` skip-gate. So we (a) verify both prereqs from
+// the suite's `before()` and skip-and-explain, and (b) defer the
+// `getSeaNative` import to inside the test bodies via a synchronous
+// import-on-demand. DA round-1 H1 fixup.
 
 interface NativeBinding {
   openSession(opts: {
@@ -71,11 +85,46 @@ describe('SEA complex types — native Arrow default', function suite() {
     if (!hostName || !httpPath || !token) {
       // eslint-disable-next-line no-invalid-this
       this.skip();
+      return;
+    }
+    // Verify the native artifact exists before any test in the suite
+    // attempts to import `getSeaNative` from SeaNativeLoader (whose
+    // module-level require would crash the whole file load on
+    // MODULE_NOT_FOUND). Skip-with-message so a developer sees the
+    // actionable instruction instead of a cryptic crash.
+    //
+    // Use `process.cwd()` instead of `__dirname` because mocha may
+    // reparse this file as ESM (MODULE_TYPELESS_PACKAGE_JSON path)
+    // where `__dirname` is undefined. mocha always runs with cwd at
+    // the package root, so this resolves consistently.
+    const nodeArtifact = path.resolve(
+      process.cwd(),
+      'native/sea/index.linux-x64-gnu.node',
+    );
+    if (!fs.existsSync(nodeArtifact)) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[sea complex-types e2e] skipping: native binary not built. ` +
+          `Run \`yarn build:native\` (or set DATABRICKS_SQL_KERNEL_REPO + yarn build:native) first.`,
+      );
+      // eslint-disable-next-line no-invalid-this
+      this.skip();
     }
   });
 
+  // Build a `require` function from this module's URL so the call
+  // works under both CJS and ESM reparse paths. mocha 11+ may reparse
+  // ts-node-emitted files as ESM (MODULE_TYPELESS_PACKAGE_JSON), in
+  // which case the bare `require` symbol is undefined.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const requireFromHere = createRequire(import.meta.url);
+
+  function loadBinding(): NativeBinding {
+    return requireFromHere('../../../native/sea/index.js') as NativeBinding;
+  }
+
   it('ARRAY / MAP / STRUCT come back as native Arrow shapes', async () => {
-    const binding = getSeaNative() as unknown as NativeBinding;
+    const binding = loadBinding();
     const connection = await binding.openSession({
       hostName: hostName as string,
       httpPath: httpPath as string,
@@ -109,22 +158,56 @@ describe('SEA complex types — native Arrow default', function suite() {
       expect(structField, 'c_struct field present').to.not.equal(undefined);
       expect(arrStructField, 'c_arr_struct field present').to.not.equal(undefined);
 
-      // Arrow type ids per arrow-js — these are the structural checks
-      // that distinguish "native Arrow" from "JSON Utf8". Arrow type
-      // names are stable across arrow-js minor versions.
-      expect(arrField!.type.toString()).to.match(/List/i, 'c_arr should be List');
-      expect(mapField!.type.toString()).to.match(/Map|List/i, 'c_map should be Map (or List of Struct of key/value)');
-      expect(structField!.type.toString()).to.match(/Struct/i, 'c_struct should be Struct');
-      expect(arrStructField!.type.toString()).to.match(/List/i, 'c_arr_struct should be List of Struct');
+      // Strict typeId checks (DA round-1 M2 fixup — prior regex
+      // assertions matched too permissively, e.g. `/List/i` would
+      // accept LargeList or FixedSizeList too. Arrow `Type` is a
+      // numeric enum from arrow-js; comparing typeId is stable
+      // across arrow-js minor versions and a structural match.
+      //
+      // The server returns ARRAY columns as Arrow `List` (typeId 12),
+      // MAP as Arrow `Map` (typeId 17), STRUCT as Arrow `Struct`
+      // (typeId 13). Nested ARRAY<STRUCT> is `List` whose child is
+      // `Struct`.
+      expect(arrField!.type.typeId).to.equal(
+        ArrowType.List,
+        `c_arr typeId should be List(${ArrowType.List}), got ${arrField!.type.typeId} (${arrField!.type})`,
+      );
+      expect(mapField!.type.typeId).to.equal(
+        ArrowType.Map,
+        `c_map typeId should be Map(${ArrowType.Map}), got ${mapField!.type.typeId} (${mapField!.type})`,
+      );
+      expect(structField!.type.typeId).to.equal(
+        ArrowType.Struct,
+        `c_struct typeId should be Struct(${ArrowType.Struct}), got ${structField!.type.typeId} (${structField!.type})`,
+      );
+      expect(arrStructField!.type.typeId).to.equal(
+        ArrowType.List,
+        `c_arr_struct typeId should be List(${ArrowType.List}), got ${arrStructField!.type.typeId} (${arrStructField!.type})`,
+      );
 
-      // Sanity-check: NONE of the complex columns should be Utf8 — that
-      // would indicate complex_types_as_json was inadvertently enabled.
+      // Nested-structural check: c_arr_struct should be List<Struct>.
+      // Drilling into `children[0].type.typeId` catches a regression
+      // where the kernel might wrap a Struct in something else (e.g.
+      // FixedSizeList).
+      const arrStructChildType = arrStructField!.type.children[0].type;
+      expect(arrStructChildType.typeId).to.equal(
+        ArrowType.Struct,
+        `c_arr_struct child typeId should be Struct(${ArrowType.Struct}), got ${arrStructChildType.typeId}`,
+      );
+
+      // Negative assertion: NONE of the complex columns should be Utf8
+      // — that would indicate `complex_types_as_json` was inadvertently
+      // enabled on the kernel side. Using typeId here too rather than
+      // a string regex.
       for (const f of [arrField!, mapField!, structField!, arrStructField!]) {
-        expect(f.type.toString()).to.not.match(
-          /^Utf8$/,
-          `${f.name} must not be a JSON string column`,
+        expect(f.type.typeId).to.not.equal(
+          ArrowType.Utf8,
+          `${f.name} must not be a JSON string column (Utf8 typeId)`,
         );
       }
+
+      // Row-count sanity: SELECT-of-literals yields exactly one row.
+      expect(table.numRows).to.equal(1, 'literal SELECT should yield one row');
     } finally {
       if (statement !== null) {
         try {

--- a/tests/e2e/sea/max-connections-e2e.test.ts
+++ b/tests/e2e/sea/max-connections-e2e.test.ts
@@ -1,0 +1,181 @@
+// Copyright (c) 2026 Databricks, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * End-to-end check that `maxConnections` flows from
+ * `ConnectionOptions` through `buildSeaConnectionOptions` through the
+ * napi `openSession` into the kernel's `HttpConfig::pool_max_idle_per_host`,
+ * and that a session opened with a custom value round-trips a real
+ * query against pecotesting.
+ *
+ * We can't directly observe the underlying reqwest connection pool
+ * from JS, so the meaningful assertion is "session opens + query
+ * succeeds when the option is set". Combined with the unit tests
+ * that mock-verify the napi-call shape, this proves the option
+ * reaches the kernel without breaking the wire path.
+ *
+ * DA round-1 F1 L2 ("live") fixup.
+ *
+ * Skipped when `DATABRICKS_PECOTESTING_*` env vars are absent.
+ */
+
+import { expect } from 'chai';
+import { existsSync } from 'fs';
+import { resolve as resolvePath } from 'path';
+import { createRequire } from 'module';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const requireFromHere = createRequire(import.meta.url);
+
+interface NativeBinding {
+  openSession(opts: {
+    hostName: string;
+    httpPath: string;
+    token: string;
+    maxConnections?: number;
+  }): Promise<NativeConnection>;
+}
+
+interface NativeConnection {
+  executeStatement(sql: string): Promise<NativeStatement>;
+  close(): Promise<void>;
+}
+
+interface NativeStatement {
+  fetchNextBatch(): Promise<{ ipcBytes: Buffer } | null>;
+  schema(): Promise<{ ipcBytes: Buffer }>;
+  cancel(): Promise<void>;
+  close(): Promise<void>;
+}
+
+describe('SEA maxConnections — live round-trip', function suite() {
+  this.timeout(120_000);
+
+  const hostName =
+    process.env.DATABRICKS_PECOTESTING_SERVER_HOSTNAME || process.env.E2E_HOST;
+  const httpPath =
+    process.env.DATABRICKS_PECOTESTING_HTTP_PATH || process.env.E2E_PATH;
+  const token =
+    process.env.DATABRICKS_PECOTESTING_TOKEN || process.env.E2E_ACCESS_TOKEN;
+
+  before(function gate() {
+    if (!hostName || !httpPath || !token) {
+      // eslint-disable-next-line no-invalid-this
+      this.skip();
+      return;
+    }
+    const nodeArtifact = resolvePath(
+      process.cwd(),
+      'native/sea/index.linux-x64-gnu.node',
+    );
+    if (!existsSync(nodeArtifact)) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[sea max-connections e2e] skipping: native binary not built. ` +
+          `Run \`yarn build:native\` first.`,
+      );
+      // eslint-disable-next-line no-invalid-this
+      this.skip();
+    }
+  });
+
+  function loadBinding(): NativeBinding {
+    return requireFromHere('../../../native/sea/index.js') as NativeBinding;
+  }
+
+  it('opens a session with maxConnections=1 and runs a query', async () => {
+    // `maxConnections=1` is the minimum bound the JS layer accepts —
+    // exercises the low end of the validation range against a real
+    // warehouse. The kernel's `pool_max_idle_per_host=1` doesn't cap
+    // *active* connections (reqwest opens more as needed); it caps
+    // *idle* connections retained in the pool. So a query still
+    // succeeds; this asserts the option doesn't break the wire path.
+    const binding = loadBinding();
+    const connection = await binding.openSession({
+      hostName: hostName as string,
+      httpPath: httpPath as string,
+      token: token as string,
+      maxConnections: 1,
+    });
+    let statement: NativeStatement | null = null;
+    try {
+      statement = await connection.executeStatement('SELECT 1 AS x');
+      const envelope = await statement.fetchNextBatch();
+      expect(envelope).to.not.equal(null);
+    } finally {
+      if (statement !== null) {
+        try {
+          await statement.close();
+        } catch (_) {
+          // best-effort cleanup
+        }
+      }
+      await connection.close();
+    }
+  });
+
+  it('opens a session with maxConnections=200 and runs a query', async () => {
+    // High-end value within typical SEA workload range. Proves the
+    // option carries values much larger than the kernel default
+    // (100) without breaking the wire path.
+    const binding = loadBinding();
+    const connection = await binding.openSession({
+      hostName: hostName as string,
+      httpPath: httpPath as string,
+      token: token as string,
+      maxConnections: 200,
+    });
+    let statement: NativeStatement | null = null;
+    try {
+      statement = await connection.executeStatement('SELECT 1 AS x');
+      const envelope = await statement.fetchNextBatch();
+      expect(envelope).to.not.equal(null);
+    } finally {
+      if (statement !== null) {
+        try {
+          await statement.close();
+        } catch (_) {
+          // best-effort cleanup
+        }
+      }
+      await connection.close();
+    }
+  });
+
+  it('omitting maxConnections (kernel default 100) still works', async () => {
+    // Default-path regression check — proves we haven't broken the
+    // existing no-options call site.
+    const binding = loadBinding();
+    const connection = await binding.openSession({
+      hostName: hostName as string,
+      httpPath: httpPath as string,
+      token: token as string,
+    });
+    let statement: NativeStatement | null = null;
+    try {
+      statement = await connection.executeStatement('SELECT 1 AS x');
+      const envelope = await statement.fetchNextBatch();
+      expect(envelope).to.not.equal(null);
+    } finally {
+      if (statement !== null) {
+        try {
+          await statement.close();
+        } catch (_) {
+          // best-effort cleanup
+        }
+      }
+      await connection.close();
+    }
+  });
+});

--- a/tests/unit/sea/auth-max-connections.test.ts
+++ b/tests/unit/sea/auth-max-connections.test.ts
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Databricks, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { expect } from 'chai';
+import { buildSeaConnectionOptions } from '../../../lib/sea/SeaAuth';
+import { ConnectionOptions } from '../../../lib/contracts/IDBSQLClient';
+import HiveDriverError from '../../../lib/errors/HiveDriverError';
+
+describe('SeaAuth — maxConnections plumbing', () => {
+  describe('buildSeaConnectionOptions forwards maxConnections', () => {
+    it('omits maxConnections when not supplied (kernel default applies)', () => {
+      const opts: ConnectionOptions = {
+        host: 'example.cloud.databricks.com',
+        path: '/sql/1.0/warehouses/abc',
+        token: 'dapi-fake-pat',
+      };
+
+      const native = buildSeaConnectionOptions(opts);
+      expect(native).to.not.have.property('maxConnections');
+    });
+
+    it('forwards maxConnections as a positive integer', () => {
+      const opts: ConnectionOptions = {
+        host: 'example.cloud.databricks.com',
+        path: '/sql/1.0/warehouses/abc',
+        token: 'dapi-fake-pat',
+        maxConnections: 200,
+      };
+
+      const native = buildSeaConnectionOptions(opts);
+      expect(native.maxConnections).to.equal(200);
+    });
+
+    it('accepts the minimum value (1)', () => {
+      const opts: ConnectionOptions = {
+        host: 'example.cloud.databricks.com',
+        path: '/sql/1.0/warehouses/abc',
+        token: 'dapi-fake-pat',
+        maxConnections: 1,
+      };
+
+      const native = buildSeaConnectionOptions(opts);
+      expect(native.maxConnections).to.equal(1);
+    });
+
+    it('rejects zero', () => {
+      const opts: ConnectionOptions = {
+        host: 'example.cloud.databricks.com',
+        path: '/sql/1.0/warehouses/abc',
+        token: 'dapi-fake-pat',
+        maxConnections: 0,
+      };
+
+      expect(() => buildSeaConnectionOptions(opts)).to.throw(HiveDriverError, /maxConnections.*positive integer/);
+    });
+
+    it('rejects negative values', () => {
+      const opts: ConnectionOptions = {
+        host: 'example.cloud.databricks.com',
+        path: '/sql/1.0/warehouses/abc',
+        token: 'dapi-fake-pat',
+        maxConnections: -5,
+      };
+
+      expect(() => buildSeaConnectionOptions(opts)).to.throw(HiveDriverError, /maxConnections.*positive integer/);
+    });
+
+    it('rejects non-integer values', () => {
+      const opts: ConnectionOptions = {
+        host: 'example.cloud.databricks.com',
+        path: '/sql/1.0/warehouses/abc',
+        token: 'dapi-fake-pat',
+        maxConnections: 1.5,
+      };
+
+      expect(() => buildSeaConnectionOptions(opts)).to.throw(HiveDriverError, /maxConnections.*positive integer/);
+    });
+
+    it('rejects NaN', () => {
+      const opts: ConnectionOptions = {
+        host: 'example.cloud.databricks.com',
+        path: '/sql/1.0/warehouses/abc',
+        token: 'dapi-fake-pat',
+        maxConnections: NaN,
+      };
+
+      expect(() => buildSeaConnectionOptions(opts)).to.throw(HiveDriverError, /maxConnections.*positive integer/);
+    });
+
+    it('forwards maxConnections through the OAuth M2M arm', () => {
+      const opts: ConnectionOptions = {
+        host: 'example.cloud.databricks.com',
+        path: '/sql/1.0/warehouses/abc',
+        authType: 'databricks-oauth',
+        oauthClientId: 'client-id',
+        oauthClientSecret: 'client-secret',
+        maxConnections: 50,
+      };
+
+      const native = buildSeaConnectionOptions(opts);
+      expect(native.authMode).to.equal('OAuthM2m');
+      expect(native.maxConnections).to.equal(50);
+    });
+
+    it('forwards maxConnections through the OAuth U2M arm', () => {
+      const opts: ConnectionOptions = {
+        host: 'example.cloud.databricks.com',
+        path: '/sql/1.0/warehouses/abc',
+        authType: 'databricks-oauth',
+        maxConnections: 25,
+      };
+
+      const native = buildSeaConnectionOptions(opts);
+      expect(native.authMode).to.equal('OAuthU2m');
+      expect(native.maxConnections).to.equal(25);
+    });
+  });
+});

--- a/tests/unit/sea/auth-max-connections.test.ts
+++ b/tests/unit/sea/auth-max-connections.test.ts
@@ -16,6 +16,8 @@ import { expect } from 'chai';
 import { buildSeaConnectionOptions } from '../../../lib/sea/SeaAuth';
 import { ConnectionOptions } from '../../../lib/contracts/IDBSQLClient';
 import HiveDriverError from '../../../lib/errors/HiveDriverError';
+import SeaBackend from '../../../lib/sea/SeaBackend';
+import { makeFakeBinding } from './_helpers/fakeBinding';
 
 describe('SeaAuth — maxConnections plumbing', () => {
   describe('buildSeaConnectionOptions forwards maxConnections', () => {
@@ -124,6 +126,93 @@ describe('SeaAuth — maxConnections plumbing', () => {
       const native = buildSeaConnectionOptions(opts);
       expect(native.authMode).to.equal('OAuthU2m');
       expect(native.maxConnections).to.equal(25);
+    });
+
+    // ─── DA round-1 M1 fixup — upper-bound (u32 ceiling) ───────────
+
+    it('accepts the maximum u32 value (4_294_967_295)', () => {
+      const MAX_U32 = 4_294_967_295;
+      const opts: ConnectionOptions = {
+        host: 'example.cloud.databricks.com',
+        path: '/sql/1.0/warehouses/abc',
+        token: 'dapi-fake-pat',
+        maxConnections: MAX_U32,
+      };
+
+      const native = buildSeaConnectionOptions(opts);
+      expect(native.maxConnections).to.equal(MAX_U32);
+    });
+
+    it('rejects values exceeding the napi u32 ceiling', () => {
+      const opts: ConnectionOptions = {
+        host: 'example.cloud.databricks.com',
+        path: '/sql/1.0/warehouses/abc',
+        token: 'dapi-fake-pat',
+        maxConnections: 4_294_967_296, // 2^32, one over u32 max
+      };
+
+      expect(() => buildSeaConnectionOptions(opts)).to.throw(
+        HiveDriverError,
+        /maxConnections.*exceeds.*u32 limit/,
+      );
+    });
+
+    it('rejects 2^53 - 1 (safe integer ceiling — would silently truncate at FFI)', () => {
+      const opts: ConnectionOptions = {
+        host: 'example.cloud.databricks.com',
+        path: '/sql/1.0/warehouses/abc',
+        token: 'dapi-fake-pat',
+        maxConnections: Number.MAX_SAFE_INTEGER,
+      };
+
+      // The JS layer rejects before the FFI boundary so the napi
+      // binding never sees a value it can't faithfully represent.
+      expect(() => buildSeaConnectionOptions(opts)).to.throw(
+        HiveDriverError,
+        /maxConnections.*exceeds.*u32 limit/,
+      );
+    });
+  });
+
+  // ─── DA round-1 M2 fixup — mock-binding round-trip ──────────────
+
+  describe('SeaBackend forwards maxConnections to the napi openSession call', () => {
+    it('passes the user-supplied maxConnections value through', async () => {
+      const { binding, calls } = makeFakeBinding();
+      const backend = new SeaBackend({ nativeBinding: binding });
+
+      await backend.connect({
+        host: 'example.cloud.databricks.com',
+        path: '/sql/1.0/warehouses/abc',
+        token: 'dapi-fake-pat',
+        maxConnections: 250,
+      });
+      await backend.openSession({});
+
+      const openCall = calls.find((c) => c.method === 'openSession');
+      expect(openCall, 'openSession must be called on the binding').to.not.equal(undefined);
+      const opts = openCall!.args[0] as { maxConnections?: number; authMode?: string };
+      expect(opts.maxConnections).to.equal(250);
+      expect(opts.authMode).to.equal('Pat');
+    });
+
+    it('omits maxConnections from the openSession call when not supplied', async () => {
+      const { binding, calls } = makeFakeBinding();
+      const backend = new SeaBackend({ nativeBinding: binding });
+
+      await backend.connect({
+        host: 'example.cloud.databricks.com',
+        path: '/sql/1.0/warehouses/abc',
+        token: 'dapi-fake-pat',
+      });
+      await backend.openSession({});
+
+      const openCall = calls.find((c) => c.method === 'openSession');
+      expect(openCall).to.not.equal(undefined);
+      const opts = openCall!.args[0] as { maxConnections?: number };
+      // `undefined` (not `0`) — the napi binding's `Option<u32>` reads
+      // this as None and applies the kernel default of 100.
+      expect(opts.maxConnections).to.equal(undefined);
     });
   });
 });


### PR DESCRIPTION
## Summary

Two features bundled into a single SEA-side PR:

1. **`maxConnections`** (F1) — exposes the kernel's `HttpConfig::pool_max_idle_per_host` knob through `ConnectionOptions.maxConnections` on the public client options. Forwarded through `buildSeaConnectionOptions` into the napi `openSession` call. When omitted, the kernel default (100) applies. Mirrors the Python connector's `max_connections` kwarg on the SEA backend. NodeJS Thrift backend does NOT expose this knob — it's a SEA-only extension; no parity break.

2. **Complex types as Arrow default lock-in** (F2) — adds a regression e2e test against pecotesting that selects ARRAY/MAP/STRUCT/nested ARRAY<STRUCT> and asserts the returned Arrow schema fields are `List`/`Map`/`Struct`/`List` (not `Utf8` JSON strings). Kernel `ResultConfig::complex_types_as_json` already defaults to `false` (Arrow-native), and the SEA wire request hardcodes `format = "ARROW_STREAM"` — so this is the existing default. The test locks the contract.

## Plumbing — F1

- `IDBSQLClient.ConnectionOptions.maxConnections?: number` with doc note that Thrift backend currently ignores it
- `SeaSessionDefaults` (the shared base across auth-mode variants) carries the field so all three auth modes (PAT, OAuth M2M, OAuth U2M) round-trip it
- `buildSeaConnectionOptions` validates positive-integer-ness at the JS boundary (rejects 0, negative, non-integer, NaN) with `HiveDriverError`
- `native/sea/index.d.ts` adds the field in step with kernel branch `msrathore/krn-max-connections`

## Cross-repo dependency

Requires kernel branch `msrathore/krn-max-connections` (PR https://github.com/databricks/databricks-sql-kernel/pull/74) for the napi-binding side.

## Downstream fixes / reviewer note

- Statement-option gaps around `queryTags`, `rowLimit`, and `statementConf` are fixed later in #403/#408. This PR is limited to `maxConnections` plus the complex-types-as-Arrow default lock.
- The final all-in-one validation branch includes those later statement-option fixes on top of this PR.
- 2026-06-01 review-fix cascade: carries the #382/#381/#384 review fixes (session defaults on `openSession`, neutral operation DTOs, declared `flatbuffers`, single IPC duration rewrite, cancel/close failure-state rollback, closed fetch → `OperationStateError(Closed)`).
- 2026-06-01 review-fix cascade: also carries the OAuth-aware native typings from #383 so the generated binding surface is not regressed in this downstream branch.

## Test plan

- [x] `tests/unit/sea/auth-max-connections.test.ts` — 9 cases passing (omit, valid, boundary 1, 0-reject, neg-reject, non-int-reject, NaN-reject, M2M arm, U2M arm)
- [x] Existing `auth-pat.test.ts` regression check — 8/8 pass
- [x] tsc: zero new TS errors from F1+F2 (16 errors total = 14 pre-existing in `SeaOperationBackend.ts` + 2 from missing `lib/version.ts` generated by prepare hook)
- [x] No lint errors in touched files (`IDBSQLClient.ts`, `SeaAuth.ts`, `SeaBackend.ts`, new tests)
- [ ] Live warehouse e2e — `tests/e2e/sea/complex-types-e2e.test.ts` runs against pecotesting when env vars set; pending merge of kernel PR to test full path
