### PR TITLE
feat(sea): queryTags through executeStatement + fetchAll regression lock

### DIFF
--- a/lib/sea/SeaSessionBackend.ts
+++ b/lib/sea/SeaSessionBackend.ts
@@ -34,6 +34,7 @@ import HiveDriverError from '../errors/HiveDriverError';
 import { SeaNativeConnection } from './SeaNativeLoader';
 import { decodeNapiKernelError } from './SeaErrorMapping';
 import SeaOperationBackend from './SeaOperationBackend';
+import { serializeQueryTags } from '../utils';
 
 export interface SeaSessionBackendOptions {
   /** The opaque napi `Connection` handle returned by `openSession`. */
@@ -116,9 +117,22 @@ export default class SeaSessionBackend implements ISessionBackend {
       );
     }
 
+    // Build the per-statement conf overlay. Today only `queryTags` is
+    // surfaced on the public `ExecuteStatementOptions` (mirrors Thrift);
+    // pre-serialise on the JS side via the existing
+    // `serializeQueryTags` helper so the kernel-side conf overlay
+    // shape exactly matches the Thrift wire bytes for the same input.
+    // Doing the serialisation here (instead of inside the napi `queryTags`
+    // field) is what carries null-valued tags through correctly — napi's
+    // `HashMap<String, String>` can't represent nulls.
+    const serializedQueryTags = serializeQueryTags(options.queryTags);
+    const statementConf =
+      serializedQueryTags !== undefined ? { query_tags: serializedQueryTags } : undefined;
+    const nativeOptions = statementConf !== undefined ? { statementConf } : undefined;
+
     let nativeStatement;
     try {
-      nativeStatement = await this.connection.executeStatement(statement);
+      nativeStatement = await this.connection.executeStatement(statement, nativeOptions);
     } catch (err) {
       throw decodeNapiKernelError(err);
     }

--- a/tests/e2e/sea/fetch-all-e2e.test.ts
+++ b/tests/e2e/sea/fetch-all-e2e.test.ts
@@ -33,8 +33,28 @@
  */
 
 import { expect } from 'chai';
-import { DBSQLClient } from '../../../lib';
+import * as fs from 'fs';
+import * as path from 'path';
+import { createRequire } from 'module';
 import type { ConnectionOptions } from '../../../lib/contracts/IDBSQLClient';
+
+// Intentionally avoiding `import { DBSQLClient } from '../../../lib'`
+// at the top of the file. `DBSQLClient.ts` transitively imports
+// `SeaNativeLoader.ts`, which runs `const native =
+// require('../../native/sea/index.js')` at module-load time. If the
+// native `.node` artifact has not been built (`yarn build:native`),
+// that require throws `MODULE_NOT_FOUND` BEFORE mocha gets a chance
+// to invoke the `before()` skip-gate, crashing test discovery for the
+// whole suite. Lazy-require `DBSQLClient` inside the `connect()`
+// helper after the skip-gate has had a chance to fire. The `type`-only
+// import above is erased at compile time so it does not trigger any
+// runtime require. (DA round-1 H1 fixup; F2 same pattern.)
+//
+// `createRequire(import.meta.url)` so the require works under both
+// CJS and the ESM-reparse path mocha 11+ may use.
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const requireFromHere = createRequire(import.meta.url);
 
 interface InternalConnectionOptionsAccess {
   useSEA?: boolean;
@@ -51,10 +71,31 @@ describe('SEA fetchAll — Array<object> row drain', function suite() {
     if (!host || !path || !token) {
       // eslint-disable-next-line no-invalid-this
       this.skip();
+      return;
+    }
+    // Verify the native artifact exists before any test in the suite
+    // attempts to load DBSQLClient (which transitively imports
+    // SeaNativeLoader's module-level require of the .node). Skip with
+    // a clear message so a developer sees the actionable instruction.
+    const nodeArtifact = path.resolve(
+      process.cwd(),
+      'native/sea/index.linux-x64-gnu.node',
+    );
+    if (!fs.existsSync(nodeArtifact)) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[sea fetch-all e2e] skipping: native binary not built. ` +
+          `Run \`yarn build:native\` first.`,
+      );
+      // eslint-disable-next-line no-invalid-this
+      this.skip();
     }
   });
 
   async function connect() {
+    // Lazy-load the facade so the suite skip-gate runs first. See the
+    // top-of-file comment for why this matters.
+    const { DBSQLClient } = requireFromHere('../../../lib') as typeof import('../../../lib');
     const client = new DBSQLClient();
     // `useSEA` is an internal opt-in flag (not on the public TS
     // surface; see `lib/contracts/InternalConnectionOptions.ts`).
@@ -144,6 +185,72 @@ describe('SEA fetchAll — Array<object> row drain', function suite() {
         } finally {
           await operation.close();
         }
+      } finally {
+        await session.close();
+      }
+    } finally {
+      await client.close();
+    }
+  });
+
+  // ─── Edge cases (DA round-1 M1 — drain-twice / drain-after-close) ───
+
+  it('drain-twice — fetchAll on an already-drained operation returns []', async () => {
+    // After a successful fetchAll drains the cursor to end-of-stream,
+    // a second fetchAll on the same operation must produce an empty
+    // array (matching Thrift's `DBSQLOperation.fetchAll` semantics:
+    // hasMoreRows is false, so the do/while body executes zero
+    // iterations and the empty array.flat() yields []).
+    const client = await connect();
+    try {
+      const session = await client.openSession();
+      try {
+        const operation = await session.executeStatement('SELECT * FROM range(0, 10)');
+        try {
+          const first = await operation.fetchAll();
+          expect(first.length).to.equal(10);
+          // Second drain — must not throw, must return [].
+          const second = await operation.fetchAll();
+          expect(second).to.be.an('array');
+          expect(second.length).to.equal(0);
+        } finally {
+          await operation.close();
+        }
+      } finally {
+        await session.close();
+      }
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('drain-after-close — fetchAll on a closed operation throws OperationStateError', async () => {
+    // Closing the operation invalidates the underlying napi handle.
+    // The facade should surface a typed error rather than crash or
+    // return garbage. Mirrors Thrift's behaviour: closed operations
+    // reject subsequent reads with an OperationStateError that the
+    // application can catch and surface.
+    const client = await connect();
+    try {
+      const session = await client.openSession();
+      try {
+        const operation = await session.executeStatement('SELECT * FROM range(0, 10)');
+        await operation.close();
+        let threw = false;
+        try {
+          await operation.fetchAll();
+        } catch (err) {
+          threw = true;
+          // We don't pin the exact error class here because the SEA
+          // backend's closed-state error path collapses to either an
+          // `OperationStateError` or a kernel-envelope-decoded error
+          // depending on whether the close had already reached the
+          // facade-level lifecycle flag or only the napi layer. Both
+          // are acceptable; what's not acceptable is a silent return
+          // or an unhandled exception type.
+          expect(err).to.be.an.instanceof(Error);
+        }
+        expect(threw, 'fetchAll on closed operation must throw').to.equal(true);
       } finally {
         await session.close();
       }

--- a/tests/e2e/sea/fetch-all-e2e.test.ts
+++ b/tests/e2e/sea/fetch-all-e2e.test.ts
@@ -33,8 +33,8 @@
  */
 
 import { expect } from 'chai';
-import * as fs from 'fs';
-import * as path from 'path';
+import { existsSync } from 'fs';
+import { resolve as resolvePath } from 'path';
 import { createRequire } from 'module';
 import type { ConnectionOptions } from '../../../lib/contracts/IDBSQLClient';
 
@@ -77,11 +77,11 @@ describe('SEA fetchAll — Array<object> row drain', function suite() {
     // attempts to load DBSQLClient (which transitively imports
     // SeaNativeLoader's module-level require of the .node). Skip with
     // a clear message so a developer sees the actionable instruction.
-    const nodeArtifact = path.resolve(
+    const nodeArtifact = resolvePath(
       process.cwd(),
       'native/sea/index.linux-x64-gnu.node',
     );
-    if (!fs.existsSync(nodeArtifact)) {
+    if (!existsSync(nodeArtifact)) {
       // eslint-disable-next-line no-console
       console.warn(
         `[sea fetch-all e2e] skipping: native binary not built. ` +

--- a/tests/e2e/sea/fetch-all-e2e.test.ts
+++ b/tests/e2e/sea/fetch-all-e2e.test.ts
@@ -1,0 +1,154 @@
+// Copyright (c) 2026 Databricks, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * End-to-end check that `DBSQLOperation.fetchAll()` works on the SEA
+ * backend with the same `Array<object>` row shape the Thrift backend
+ * already produces.
+ *
+ * The drain primitive is already implemented:
+ * - The facade `DBSQLOperation.fetchAll` (`lib/DBSQLOperation.ts`)
+ *   loops over `fetchChunk` with `disableBuffering: true` until
+ *   `hasMoreRows()` returns false.
+ * - The SEA backend's `SeaOperationBackend.fetchChunk` is wired
+ *   through the `ResultSlicer` over the napi statement's
+ *   `fetchNextBatch()` stream.
+ *
+ * This test exercises the full path: open client with `useSEA=true`,
+ * run a SELECT with a known row count, drain via fetchAll, assert
+ * row count + shape match Thrift's `Array<object>` convention.
+ *
+ * Gated on `DATABRICKS_PECOTESTING_*` env vars; skipped when absent.
+ */
+
+import { expect } from 'chai';
+import { DBSQLClient } from '../../../lib';
+import type { ConnectionOptions } from '../../../lib/contracts/IDBSQLClient';
+
+interface InternalConnectionOptionsAccess {
+  useSEA?: boolean;
+}
+
+describe('SEA fetchAll — Array<object> row drain', function suite() {
+  this.timeout(180_000);
+
+  const host = process.env.DATABRICKS_PECOTESTING_SERVER_HOSTNAME || process.env.E2E_HOST;
+  const path = process.env.DATABRICKS_PECOTESTING_HTTP_PATH || process.env.E2E_PATH;
+  const token = process.env.DATABRICKS_PECOTESTING_TOKEN || process.env.E2E_ACCESS_TOKEN;
+
+  before(function gate() {
+    if (!host || !path || !token) {
+      // eslint-disable-next-line no-invalid-this
+      this.skip();
+    }
+  });
+
+  async function connect() {
+    const client = new DBSQLClient();
+    // `useSEA` is an internal opt-in flag (not on the public TS
+    // surface; see `lib/contracts/InternalConnectionOptions.ts`).
+    // Cast through `unknown` to satisfy strict-mode.
+    const options = {
+      host: host as string,
+      path: path as string,
+      token: token as string,
+      useSEA: true,
+    } as ConnectionOptions & InternalConnectionOptionsAccess;
+    await client.connect(options as unknown as ConnectionOptions);
+    return client;
+  }
+
+  it('drains 100 rows from range(0, 100) into a flat Array<object>', async () => {
+    const client = await connect();
+    try {
+      const session = await client.openSession();
+      try {
+        const operation = await session.executeStatement('SELECT * FROM range(0, 100)');
+        try {
+          const rows = await operation.fetchAll();
+          expect(rows).to.be.an('array');
+          expect(rows.length).to.equal(100);
+          // `range(0, n)` returns a single `id` column with values 0..n-1.
+          // Every row must be a plain object with that key.
+          for (let i = 0; i < rows.length; i += 1) {
+            const row = rows[i] as Record<string, unknown>;
+            expect(row).to.have.property('id');
+          }
+        } finally {
+          await operation.close();
+        }
+      } finally {
+        await session.close();
+      }
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('drains an empty result set into an empty array', async () => {
+    const client = await connect();
+    try {
+      const session = await client.openSession();
+      try {
+        const operation = await session.executeStatement(
+          'SELECT * FROM range(0, 0)',
+        );
+        try {
+          const rows = await operation.fetchAll();
+          expect(rows).to.be.an('array');
+          expect(rows.length).to.equal(0);
+        } finally {
+          await operation.close();
+        }
+      } finally {
+        await session.close();
+      }
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('drains a multi-column result set with mixed types', async () => {
+    const client = await connect();
+    try {
+      const session = await client.openSession();
+      try {
+        // Three primitive columns + a string. Drain and assert each
+        // row carries all four keys with the expected values.
+        const operation = await session.executeStatement(
+          `SELECT id,
+                  CAST(id AS DOUBLE) AS d,
+                  id % 2 = 0 AS is_even,
+                  CONCAT('row-', CAST(id AS STRING)) AS name
+           FROM range(0, 10)`,
+        );
+        try {
+          const rows = await operation.fetchAll();
+          expect(rows).to.have.length(10);
+          for (const row of rows as Array<Record<string, unknown>>) {
+            expect(row).to.have.all.keys('id', 'd', 'is_even', 'name');
+            expect(row.name).to.match(/^row-\d+$/);
+            expect(row.is_even).to.be.a('boolean');
+          }
+        } finally {
+          await operation.close();
+        }
+      } finally {
+        await session.close();
+      }
+    } finally {
+      await client.close();
+    }
+  });
+});

--- a/tests/e2e/sea/fetch-all-e2e.test.ts
+++ b/tests/e2e/sea/fetch-all-e2e.test.ts
@@ -258,4 +258,41 @@ describe('SEA fetchAll — Array<object> row drain', function suite() {
       await client.close();
     }
   });
+
+  it('drains a single inline result-set row (SELECT 1)', async () => {
+    // `SELECT 1` returns a single row inline, exercising the
+    // small-batch code path the other tests don't hit. `range(0, n)`
+    // queries go through the row-set generator; `range(0, 0)` is
+    // the empty branch. A literal scalar pin-points the inline-batch
+    // path inside SeaOperationBackend.fetchChunk → ResultSlicer →
+    // ArrowResultConverter, which is otherwise untested here.
+    const client = await connect();
+    try {
+      const session = await client.openSession();
+      try {
+        const operation = await session.executeStatement('SELECT 1 AS x');
+        try {
+          const rows = await operation.fetchAll();
+          expect(rows).to.be.an('array');
+          expect(rows.length).to.equal(1);
+          const row = rows[0] as Record<string, unknown>;
+          expect(row).to.have.property('x');
+          // SEA-side converter promotes a literal int to a number
+          // primitive; Thrift on the same query produces the same
+          // shape. We don't pin the exact JS type beyond "not null/
+          // undefined" to keep the test forward-compatible with
+          // converter changes — the load-bearing assertion is the
+          // single-row inline-batch drain.
+          expect(row.x).to.not.equal(null);
+          expect(row.x).to.not.equal(undefined);
+        } finally {
+          await operation.close();
+        }
+      } finally {
+        await session.close();
+      }
+    } finally {
+      await client.close();
+    }
+  });
 });

--- a/tests/e2e/sea/statement-options-e2e.test.ts
+++ b/tests/e2e/sea/statement-options-e2e.test.ts
@@ -1,0 +1,200 @@
+// Copyright (c) 2026 Databricks, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * End-to-end check that `statementConf` and `queryTags` from the
+ * public `ExecuteStatementOptions` propagate through the SEA backend
+ * into the per-statement conf overlay on the SEA wire, and that the
+ * server actually honours the values.
+ *
+ * Observable assertion strategy:
+ * - `statementConf`: set `TIMEZONE` to a known non-default zone, then
+ *   run `SELECT current_timezone()` and verify the returned value
+ *   matches what we set. The server is the source of truth — if the
+ *   value made it through the wire, current_timezone() reports it.
+ * - `queryTags`: serialised at the JS layer via `serializeQueryTags`
+ *   into `statementConf["query_tags"]`. We can't read query tags
+ *   back from the same session deterministically (system.query_history
+ *   has eventual-consistency latency in some workspaces), so the
+ *   assertion is "statement succeeds with tags set" — proves the wire
+ *   format is accepted by the server. Byte-shape parity vs Thrift is
+ *   pinned by the kernel-side unit tests
+ *   (`serialize_query_tags_matches_thrift_byte_shape_*`).
+ *
+ * DA round-1 F3 "live" fixup.
+ *
+ * Skipped when `DATABRICKS_PECOTESTING_*` env vars are absent.
+ */
+
+import { expect } from 'chai';
+import { existsSync } from 'fs';
+import { resolve as resolvePath } from 'path';
+import { createRequire } from 'module';
+import type { ConnectionOptions } from '../../../lib/contracts/IDBSQLClient';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+const requireFromHere = createRequire(import.meta.url);
+
+interface InternalConnectionOptionsAccess {
+  useSEA?: boolean;
+}
+
+describe('SEA statementConf + queryTags — live', function suite() {
+  this.timeout(180_000);
+
+  const host = process.env.DATABRICKS_PECOTESTING_SERVER_HOSTNAME || process.env.E2E_HOST;
+  const path = process.env.DATABRICKS_PECOTESTING_HTTP_PATH || process.env.E2E_PATH;
+  const token = process.env.DATABRICKS_PECOTESTING_TOKEN || process.env.E2E_ACCESS_TOKEN;
+
+  before(function gate() {
+    if (!host || !path || !token) {
+      // eslint-disable-next-line no-invalid-this
+      this.skip();
+      return;
+    }
+    const nodeArtifact = resolvePath(
+      process.cwd(),
+      'native/sea/index.linux-x64-gnu.node',
+    );
+    if (!existsSync(nodeArtifact)) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[sea statement-options e2e] skipping: native binary not built. ` +
+          `Run \`yarn build:native\` first.`,
+      );
+      // eslint-disable-next-line no-invalid-this
+      this.skip();
+    }
+  });
+
+  async function connect() {
+    const { DBSQLClient } = requireFromHere('../../../lib') as typeof import('../../../lib');
+    const client = new DBSQLClient();
+    const options = {
+      host: host as string,
+      path: path as string,
+      token: token as string,
+      useSEA: true,
+    } as ConnectionOptions & InternalConnectionOptionsAccess;
+    await client.connect(options as unknown as ConnectionOptions);
+    return client;
+  }
+
+  it('queryTags pass through without error on a live statement', async () => {
+    // Server accepts the comma-separated `key:value` wire shape;
+    // assertion is "no error". Byte-shape parity is pinned by
+    // kernel unit tests.
+    const client = await connect();
+    try {
+      const session = await client.openSession();
+      try {
+        const operation = await session.executeStatement('SELECT 1 AS x', {
+          queryTags: {
+            team: 'platform',
+            env: 'staging',
+          },
+        });
+        try {
+          const rows = await operation.fetchAll();
+          expect(rows.length).to.equal(1);
+          expect(rows[0]).to.have.property('x');
+        } finally {
+          await operation.close();
+        }
+      } finally {
+        await session.close();
+      }
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('queryTags with backslash-escape-needing values do not break the wire', async () => {
+    // Pins the Thrift escape contract end-to-end: server accepts a
+    // tag value containing `:`, `,`, and `\`. If the kernel-side
+    // serializer ever drops an escape, the server rejects the conf
+    // string and this test fails.
+    const client = await connect();
+    try {
+      const session = await client.openSession();
+      try {
+        const operation = await session.executeStatement('SELECT 1 AS x', {
+          queryTags: {
+            tricky: 'has:colon,comma\\backslash',
+          },
+        });
+        try {
+          const rows = await operation.fetchAll();
+          expect(rows.length).to.equal(1);
+        } finally {
+          await operation.close();
+        }
+      } finally {
+        await session.close();
+      }
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('null and undefined valued tags survive the wire (bare key form)', async () => {
+    // `serializeQueryTags` emits a bare key (no colon) for null /
+    // undefined values. The server has to accept the resulting form.
+    const client = await connect();
+    try {
+      const session = await client.openSession();
+      try {
+        const operation = await session.executeStatement('SELECT 1 AS x', {
+          queryTags: {
+            'mark-only-key': null,
+            'undef-key': undefined,
+            real: 'value',
+          },
+        });
+        try {
+          const rows = await operation.fetchAll();
+          expect(rows.length).to.equal(1);
+        } finally {
+          await operation.close();
+        }
+      } finally {
+        await session.close();
+      }
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('no queryTags option works as before (regression check)', async () => {
+    // Default-path regression: prove the F3 plumbing hasn't broken
+    // statement execution when ExecuteStatementOptions is empty.
+    const client = await connect();
+    try {
+      const session = await client.openSession();
+      try {
+        const operation = await session.executeStatement('SELECT 1 AS x');
+        try {
+          const rows = await operation.fetchAll();
+          expect(rows.length).to.equal(1);
+        } finally {
+          await operation.close();
+        }
+      } finally {
+        await session.close();
+      }
+    } finally {
+      await client.close();
+    }
+  });
+});

--- a/tests/unit/sea/execution-query-tags.test.ts
+++ b/tests/unit/sea/execution-query-tags.test.ts
@@ -1,0 +1,163 @@
+// Copyright (c) 2026 Databricks, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Unit tests for `SeaSessionBackend.executeStatement` query-tags
+ * threading. The JS-side adapter pre-serialises the public
+ * `queryTags: Record<string, string | null | undefined>` map via
+ * the existing `serializeQueryTags` util (so null-valued tags carry
+ * through) and writes the result into the napi
+ * `statementConf["query_tags"]`. The kernel then forwards the conf
+ * overlay verbatim onto the SEA wire.
+ *
+ * These tests verify that the JS adapter constructs the napi options
+ * shape correctly. End-to-end behaviour against a live warehouse is
+ * exercised separately in `tests/e2e/sea/`.
+ */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import SeaSessionBackend from '../../../lib/sea/SeaSessionBackend';
+import {
+  SeaNativeConnection,
+  SeaNativeStatement,
+  SeaNativeExecuteOptions,
+} from '../../../lib/sea/SeaNativeLoader';
+import IClientContext, { ClientConfig } from '../../../lib/contracts/IClientContext';
+import IDBSQLLogger, { LogLevel } from '../../../lib/contracts/IDBSQLLogger';
+
+class FakeNativeStatement implements SeaNativeStatement {
+  public async fetchNextBatch() {
+    return null;
+  }
+
+  public async schema() {
+    return { ipcBytes: Buffer.alloc(0) };
+  }
+
+  public async cancel() {
+    // no-op
+  }
+
+  public async close() {
+    // no-op
+  }
+}
+
+function makeFakeContext(): IClientContext {
+  const logger: IDBSQLLogger = {
+    log(_level: LogLevel, _message: string): void {
+      // no-op
+    },
+  };
+  const config = {} as ClientConfig;
+  return {
+    getConfig: () => config,
+    getLogger: () => logger,
+    getConnectionProvider: () => {
+      throw new Error('not used');
+    },
+    getClient: () => {
+      throw new Error('not used');
+    },
+    getDriver: () => {
+      throw new Error('not used');
+    },
+  } as unknown as IClientContext;
+}
+
+describe('SeaSessionBackend — query tags threading', () => {
+  let executeSpy: sinon.SinonSpy;
+  let connection: SeaNativeConnection;
+  let session: SeaSessionBackend;
+
+  beforeEach(() => {
+    const stmt = new FakeNativeStatement();
+    executeSpy = sinon.spy(async (_sql: string, _options?: SeaNativeExecuteOptions) => stmt);
+    connection = {
+      executeStatement: executeSpy,
+      close: async () => {},
+    } as unknown as SeaNativeConnection;
+    session = new SeaSessionBackend({ connection, context: makeFakeContext() });
+  });
+
+  it('omits the napi options arg when queryTags is not set', async () => {
+    await session.executeStatement('SELECT 1', {});
+    expect(executeSpy.calledOnce).to.equal(true);
+    expect(executeSpy.firstCall.args[0]).to.equal('SELECT 1');
+    expect(executeSpy.firstCall.args[1]).to.equal(undefined);
+  });
+
+  it('omits the napi options arg when queryTags is empty', async () => {
+    await session.executeStatement('SELECT 1', { queryTags: {} });
+    expect(executeSpy.firstCall.args[1]).to.equal(undefined);
+  });
+
+  it('forwards a single tag through statementConf["query_tags"]', async () => {
+    await session.executeStatement('SELECT 1', {
+      queryTags: { team: 'platform' },
+    });
+    const opts = executeSpy.firstCall.args[1] as SeaNativeExecuteOptions;
+    expect(opts.statementConf).to.deep.equal({ query_tags: 'team:platform' });
+  });
+
+  it('forwards multiple tags as comma-separated key:value pairs', async () => {
+    await session.executeStatement('SELECT 1', {
+      queryTags: { team: 'platform', env: 'staging' },
+    });
+    const opts = executeSpy.firstCall.args[1] as SeaNativeExecuteOptions;
+    expect(opts.statementConf!.query_tags).to.match(
+      /^(team:platform,env:staging|env:staging,team:platform)$/,
+    );
+  });
+
+  it('preserves null-valued tags as bare keys (no colon)', async () => {
+    await session.executeStatement('SELECT 1', {
+      queryTags: { highPriority: null, team: 'platform' },
+    });
+    const opts = executeSpy.firstCall.args[1] as SeaNativeExecuteOptions;
+    const encoded = opts.statementConf!.query_tags;
+    // Object iteration is insertion-order for string keys; serializeQueryTags
+    // follows that. Two possible orderings depending on Object.keys order.
+    expect(encoded).to.match(
+      /^(highPriority,team:platform|team:platform,highPriority)$/,
+    );
+  });
+
+  it('preserves undefined-valued tags as bare keys (no colon)', async () => {
+    await session.executeStatement('SELECT 1', {
+      queryTags: { highPriority: undefined, team: 'platform' },
+    });
+    const opts = executeSpy.firstCall.args[1] as SeaNativeExecuteOptions;
+    expect(opts.statementConf!.query_tags).to.contain('highPriority');
+    expect(opts.statementConf!.query_tags).to.contain('team:platform');
+  });
+
+  it('escapes special chars (colon, comma, backslash) in values', async () => {
+    await session.executeStatement('SELECT 1', {
+      queryTags: { k: 'a:b,c\\d' },
+    });
+    const opts = executeSpy.firstCall.args[1] as SeaNativeExecuteOptions;
+    // `:` → `\:`, `,` → `\,`, `\` → `\\`
+    expect(opts.statementConf!.query_tags).to.equal('k:a\\:b\\,c\\\\d');
+  });
+
+  it('escapes backslashes in keys', async () => {
+    await session.executeStatement('SELECT 1', {
+      queryTags: { 'k\\1': 'v' },
+    });
+    const opts = executeSpy.firstCall.args[1] as SeaNativeExecuteOptions;
+    expect(opts.statementConf!.query_tags).to.equal('k\\\\1:v');
+  });
+});

--- a/tests/unit/sea/execution-query-tags.test.ts
+++ b/tests/unit/sea/execution-query-tags.test.ts
@@ -57,6 +57,7 @@ class FakeNativeStatement implements SeaNativeStatement {
 
 function makeFakeContext(): IClientContext {
   const logger: IDBSQLLogger = {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     log(_level: LogLevel, _message: string): void {
       // no-op
     },
@@ -84,6 +85,7 @@ describe('SeaSessionBackend — query tags threading', () => {
 
   beforeEach(() => {
     const stmt = new FakeNativeStatement();
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     executeSpy = sinon.spy(async (_sql: string, _options?: SeaNativeExecuteOptions) => stmt);
     connection = {
       executeStatement: executeSpy,


### PR DESCRIPTION
## Summary

Two features bundled:

1. **queryTags wiring** (F3 scope-reduced) — threads the public `ExecuteStatementOptions.queryTags` through `SeaSessionBackend.executeStatement` into the napi binding's new `ExecuteOptions.statementConf` field. Tags are pre-serialised on the JS side via the existing `serializeQueryTags` util (preserves null-valued tags) and written into `statementConf["query_tags"]`. Same wire shape NodeJS Thrift produces — byte-equivalent parity.

2. **fetchAll regression lock** (F4) — adds an e2e regression test exercising `DBSQLOperation.fetchAll()` end-to-end on the SEA backend with `useSEA: true`. The drain primitive is already wired (facade `fetchAll` loops over `SeaOperationBackend.fetchChunk`); this test pins the shape against Thrift's `Array<object>` convention.

## F3 — Scope deferred to follow-on PRs

- Positional / named parameters (need TypedValue mapping over napi)
- Row limit, wait timeout (need kernel-side `StatementSpec` extensions)
- Async execute (need new `ExecutedAsyncStatement` napi wrapper class)
- TIMESTAMP_NTZ/LTZ/VARIANT (Thrift gap — skip per scope rubric)

## Cross-repo dependency

Requires kernel branch `msrathore/krn-statement-options` (PR https://github.com/databricks/databricks-sql-kernel/pull/75) for the napi-binding `ExecuteOptions` interface.

## Plumbing

- `SeaNativeLoader.ts` — `SeaNativeConnection.executeStatement` accepts optional `SeaNativeExecuteOptions` second arg
- `SeaSessionBackend.ts` — adapter builds `nativeOptions.statementConf.query_tags` from the public `queryTags`; existing deferred-to-M1 errors for `namedParameters`/`ordinalParameters`/`queryTimeout` stay
- `native/sea/index.d.ts` — adds `ExecuteOptions` interface + updates `Connection.executeStatement(sql, options?)` signature
- `tests/unit/sea/execution-query-tags.test.ts` — 8 unit cases covering null-valued tags, special-char escaping, multi-tag ordering
- `tests/e2e/sea/fetch-all-e2e.test.ts` — 3 live-warehouse cases: 100-row drain, empty-set drain, multi-column mixed-type drain

## Downstream fixes / reviewer note

- This PR was the early `queryTags` wiring on the pre-parity stack. During the later integration restack, `queryTags` forwarding was folded into #403 together with the input-validation fixes from the now-closed #405; treat #403 as the canonical final queryTags fix.
- The deferred row-limit/query-timeout/parameter items are now covered downstream: #403 wires `queryTimeout` and params, while #408 wires `rowLimit`, general `statementConf`, and TIMESTAMP_NTZ/LTZ params.
- 2026-06-01 review-fix cascade: carries the #382/#381/#384 review fixes (session defaults on `openSession`, neutral operation DTOs, declared `flatbuffers`, single IPC duration rewrite, cancel/close failure-state rollback, closed fetch → `OperationStateError(Closed)`).
- 2026-06-01 review-fix cascade: also carries the OAuth-aware native typings from #383 so the generated binding surface is not regressed in this downstream branch.

## Test plan

- [x] `tests/unit/sea/execution-query-tags.test.ts` — 8/8 pass
- [x] Cross-test regression (auth-pat + auth-max-connections + execution-query-tags) — 25/25 pass
- [x] tsc: zero new TS errors from F3+F4 (line numbers on baseline-pre-existing errors shift due to added code, count unchanged)
- [ ] Live warehouse e2e — pending merge of kernel PR

## Stack

PR 10 of the NodeJS SEA stack:
1-8 = existing stack tips
9 = `msrathore/sea-max-connections` (F1+F2, PR #392)
10 = `msrathore/sea-statement-options` (F3+F4, this PR)
