### PR TITLE
prepare release 1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+## 1.15.0
+
+- Add SPOG routing support: parse `?o=<workspaceId>` from `httpPath` and inject `x-databricks-org-id` on Thrift, telemetry, and feature-flag requests. Expose `customHeaders` on `ConnectionOptions` for caller-supplied headers (databricks/databricks-sql-nodejs#391 by @samikshya-db)
+- Telemetry: enable by default with feature-flag-controlled priority, and fix final-flush dropping on `client.close()` due to a close-ordering bug (databricks/databricks-sql-nodejs#327, #391 by @samikshya-db)
+- Fix Azure AD OAuth: tenant-aware discovery URL and correct scope resource (databricks/databricks-sql-nodejs#363 by @msrathore-db)
+- Fix: use a valid SPDX license identifier in `package.json` (databricks/databricks-sql-nodejs#389 by @sreekanth-db)
+
 ## 1.14.0
 
 - Add statement-level query tag support (databricks/databricks-sql-nodejs#366 by @sreekanth-db)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@databricks/sql",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@databricks/sql",
-      "version": "1.14.0",
-      "license": "Apache 2.0",
+      "version": "1.15.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "apache-arrow": "^13.0.0",
         "commander": "^9.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks/sql",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "Driver for connection to Databricks SQL via Thrift API.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
Bump version to `1.15.0` and add the `1.15.0` section to `CHANGELOG.md`.

### Notable changes since 1.14.0
- Add SPOG routing support: parse `?o=<workspaceId>` from `httpPath` and inject `x-databricks-org-id` on Thrift, telemetry, and feature-flag requests. Expose `customHeaders` on `ConnectionOptions` for caller-supplied headers (#391)
- Telemetry: enable by default with feature-flag-controlled priority, and fix final-flush dropping on `client.close()` due to a close-ordering bug (#327, #391)
- Fix Azure AD OAuth: tenant-aware discovery URL and correct scope resource (#363)
- Fix: use a valid SPDX license identifier in `package.json` (#389)

## Test plan
- [x] `npm install --package-lock-only` updates only `version` / `license` in lockfile (license change mirrors `package.json` fix in #389)
- [x] `npm run build` clean
- [x] Multi-DBR validation against 18.x-photon-scala2.13 passed for all 5 NodeConnector*_multi_dbr suites in `peco/correctness/node`
- [ ] CI green

This pull request was AI-assisted by Isaac.