### PR TITLE
feat(sea): per-statement metricViewMetadata knob on ExecuteStatementOptions

### DIFF
--- a/lib/contracts/IDBSQLSession.ts
+++ b/lib/contracts/IDBSQLSession.ts
@@ -33,6 +33,11 @@ export type ExecuteStatementOptions = {
    * forwarded via the Thrift `confOverlay`. Applies to a single statement only;
    * does not persist across queries.
    *
+   * Setting `false` is equivalent to omitting the option — both leave
+   * `confOverlay` untouched and the server's session default applies. The
+   * option is opt-in only; there is no way to explicitly clear a server
+   * default from the client.
+   *
    * Equivalent SEA wiring will route the same key through napi `statementConf`
    * once the kernel statement-options surface lands — until then this knob is
    * honored only on the Thrift backend.

--- a/lib/contracts/IDBSQLSession.ts
+++ b/lib/contracts/IDBSQLSession.ts
@@ -27,6 +27,17 @@ export type ExecuteStatementOptions = {
    * These tags apply only to this statement and do not persist across queries.
    */
   queryTags?: Record<string, string | null | undefined>;
+  /**
+   * Enable metric-view metadata expansion for this statement. When `true`, the
+   * Spark conf `spark.databricks.optimizer.enableMetricViewMetadata=true` is
+   * forwarded via the Thrift `confOverlay`. Applies to a single statement only;
+   * does not persist across queries.
+   *
+   * Equivalent SEA wiring will route the same key through napi `statementConf`
+   * once the kernel statement-options surface lands — until then this knob is
+   * honored only on the Thrift backend.
+   */
+  metricViewMetadata?: boolean;
 };
 
 export type TypeInfoRequest = {

--- a/lib/thrift-backend/ThriftSessionBackend.ts
+++ b/lib/thrift-backend/ThriftSessionBackend.ts
@@ -188,6 +188,13 @@ export default class ThriftSessionBackend implements ISessionBackend {
       request.confOverlay = { ...request.confOverlay, query_tags: serializedQueryTags };
     }
 
+    if (options.metricViewMetadata === true) {
+      request.confOverlay = {
+        ...request.confOverlay,
+        'spark.databricks.optimizer.enableMetricViewMetadata': 'true',
+      };
+    }
+
     if (ProtocolVersion.supportsCloudFetch(this.serverProtocolVersion)) {
       request.canDownloadResult = options.useCloudFetch ?? clientConfig.useCloudFetch;
     }

--- a/tests/unit/DBSQLSession.test.ts
+++ b/tests/unit/DBSQLSession.test.ts
@@ -298,6 +298,64 @@ describe('DBSQLSession', () => {
     });
   });
 
+  describe('executeStatement with metricViewMetadata', () => {
+    const metricViewConfKey = 'spark.databricks.optimizer.enableMetricViewMetadata';
+
+    it('should forward the metric-view conf via confOverlay when metricViewMetadata is true', async () => {
+      const context = new ClientContextStub();
+      const driver = sinon.spy(context.driver);
+      const session = new DBSQLSession({ handle: sessionHandleStub, context });
+
+      await session.executeStatement('SELECT * FROM my_metric_view', { metricViewMetadata: true });
+
+      expect(driver.executeStatement.callCount).to.eq(1);
+      const req = driver.executeStatement.firstCall.args[0];
+      expect(req.confOverlay).to.deep.include({ [metricViewConfKey]: 'true' });
+    });
+
+    it('should not set the metric-view conf when metricViewMetadata is omitted', async () => {
+      const context = new ClientContextStub();
+      const driver = sinon.spy(context.driver);
+      const session = new DBSQLSession({ handle: sessionHandleStub, context });
+
+      await session.executeStatement('SELECT 1');
+
+      expect(driver.executeStatement.callCount).to.eq(1);
+      const req = driver.executeStatement.firstCall.args[0];
+      expect(req.confOverlay?.[metricViewConfKey]).to.be.undefined;
+    });
+
+    it('should not set the metric-view conf when metricViewMetadata is false', async () => {
+      const context = new ClientContextStub();
+      const driver = sinon.spy(context.driver);
+      const session = new DBSQLSession({ handle: sessionHandleStub, context });
+
+      await session.executeStatement('SELECT 1', { metricViewMetadata: false });
+
+      expect(driver.executeStatement.callCount).to.eq(1);
+      const req = driver.executeStatement.firstCall.args[0];
+      expect(req.confOverlay?.[metricViewConfKey]).to.be.undefined;
+    });
+
+    it('should coexist with queryTags in the same confOverlay', async () => {
+      const context = new ClientContextStub();
+      const driver = sinon.spy(context.driver);
+      const session = new DBSQLSession({ handle: sessionHandleStub, context });
+
+      await session.executeStatement('SELECT 1', {
+        metricViewMetadata: true,
+        queryTags: { team: 'eng' },
+      });
+
+      expect(driver.executeStatement.callCount).to.eq(1);
+      const req = driver.executeStatement.firstCall.args[0];
+      expect(req.confOverlay).to.deep.include({
+        [metricViewConfKey]: 'true',
+        query_tags: 'team:eng',
+      });
+    });
+  });
+
   describe('getTypeInfo', () => {
     it('should run operation', async () => {
       const session = createSessionForTest({ handle: sessionHandleStub, context: new ClientContextStub() });

--- a/tests/unit/DBSQLSession.test.ts
+++ b/tests/unit/DBSQLSession.test.ts
@@ -304,7 +304,7 @@ describe('DBSQLSession', () => {
     it('should forward the metric-view conf via confOverlay when metricViewMetadata is true', async () => {
       const context = new ClientContextStub();
       const driver = sinon.spy(context.driver);
-      const session = new DBSQLSession({ handle: sessionHandleStub, context });
+      const session = createSessionForTest({ handle: sessionHandleStub, context });
 
       await session.executeStatement('SELECT * FROM my_metric_view', { metricViewMetadata: true });
 
@@ -316,7 +316,7 @@ describe('DBSQLSession', () => {
     it('should not set the metric-view conf when metricViewMetadata is omitted', async () => {
       const context = new ClientContextStub();
       const driver = sinon.spy(context.driver);
-      const session = new DBSQLSession({ handle: sessionHandleStub, context });
+      const session = createSessionForTest({ handle: sessionHandleStub, context });
 
       await session.executeStatement('SELECT 1');
 
@@ -328,7 +328,7 @@ describe('DBSQLSession', () => {
     it('should not set the metric-view conf when metricViewMetadata is false', async () => {
       const context = new ClientContextStub();
       const driver = sinon.spy(context.driver);
-      const session = new DBSQLSession({ handle: sessionHandleStub, context });
+      const session = createSessionForTest({ handle: sessionHandleStub, context });
 
       await session.executeStatement('SELECT 1', { metricViewMetadata: false });
 
@@ -340,7 +340,7 @@ describe('DBSQLSession', () => {
     it('should coexist with queryTags in the same confOverlay', async () => {
       const context = new ClientContextStub();
       const driver = sinon.spy(context.driver);
-      const session = new DBSQLSession({ handle: sessionHandleStub, context });
+      const session = createSessionForTest({ handle: sessionHandleStub, context });
 
       await session.executeStatement('SELECT 1', {
         metricViewMetadata: true,


### PR DESCRIPTION
## Summary

Adds an explicit `metricViewMetadata?: boolean` knob to `ExecuteStatementOptions`. When `true`, the Thrift backend forwards `spark.databricks.optimizer.enableMetricViewMetadata=true` via the outgoing `TExecuteStatementReq.confOverlay`, scoped to a single statement.

This is the C7 (metric-view-metadata) cluster of the autonomous Thrift↔SEA parity drive — audit refs:
- Row 1.17 of `sea-workflow/audits/2026-05-28-cross-driver-audit.md` — Path forward: "explicit `metricViewMetadata` knob on `ExecuteStatementOptions` (not just session-level)."
- Row 2.18 — F12 in the PR #347 audit.

### What changed
- `lib/contracts/IDBSQLSession.ts`: new `metricViewMetadata?: boolean` field on `ExecuteStatementOptions` with JSDoc explaining the per-statement scope and the SEA wiring gap.
- `lib/DBSQLSession.ts`: when the option is `true`, merge the Spark conf key into `request.confOverlay` alongside any `query_tags` already serialized there.
- `tests/unit/DBSQLSession.test.ts`: four unit tests covering set / unset / explicit-false / coexists-with-queryTags.

### SEA wiring
The SEA backend will route the same key through napi `statementConf` once the kernel statement-options surface lands (kernel PR #75 + NodeJS PR #393). Until then the option is honored only on Thrift; the public JSDoc states this so users do not silently lose the conf on SEA. Cross-driver round-trip is exercised in the companion driver-test PR.

### Test plan
- [x] `npm test -- tests/unit/DBSQLSession.test.ts` — all 4 new tests pass; the only failing test (`canDecompressLZ4Result` at line 235) is a pre-existing failure on origin/main, unrelated to this change.
- [x] `npm run lint` — clean.
- [ ] Live warehouse round-trip — covered in the companion driver-test PR (`databricks/databricks-driver-test#NNN`), where `BackendComparator.forEachBackend` exercises both Thrift and SEA legs against the pecotesting warehouse with `DATABRICKS_PECOTESTING_TOKEN_PERSONAL`.
- [ ] Cross-driver validation — Python `python-sea-oracle` agent has been asked to verify `statement_conf={"spark.databricks.optimizer.enableMetricViewMetadata": "true"}` round-trips on `use_sea=True`; reply pending.

### Notes
- DCO sign-off + `Co-authored-by: Isaac` trailer on the commit.
- Per-statement scope contract: setting the option on one execute() must NOT leak to the session. The companion driver-test asserts this by checking `SET <key>` on the same session after the call.