### PR TITLE
[SEA-NodeJS] SEA query parameters, metadata & getInfo

### DIFF
--- a/lib/sea/SeaInputValidation.ts
+++ b/lib/sea/SeaInputValidation.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Databricks, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Int64 from 'node-int64';
+import { DBSQLParameter, DBSQLParameterValue } from '../DBSQLParameter';
+import ParameterError from '../errors/ParameterError';
+
+/**
+ * Reject a parameter value that cannot be bound as a scalar. Arrays and plain
+ * objects stringify to garbage (e.g. `[1,2,3]` → `"1,2,3"`) that the server
+ * fails to coerce — on the Thrift path the operation never returns to
+ * FINISHED (a DoS hazard), and on SEA it surfaces an opaque server error. We
+ * fail fast at bind time instead, mirroring the kernel's compound-type
+ * rejection. `DBSQLParameter`, `Int64`, `Date`, and JS primitives are allowed.
+ *
+ * Parameter-marker counting and arity validation are intentionally NOT done
+ * here: the kernel's `statement::params` codec owns that check and binds
+ * exactly one placeholder style per statement, so duplicating the SQL-walk
+ * JS-side would only risk drift. The driver's sole bind-time job is this
+ * cheap, type-shape gate before the value crosses the napi boundary.
+ */
+export default function assertBindableValue(value: DBSQLParameter | DBSQLParameterValue, label: string): void {
+  if (value instanceof DBSQLParameter) return;
+  if (value === null || value === undefined) return;
+  if (Array.isArray(value)) {
+    throw new ParameterError(
+      `${label} is an array; compound types (ARRAY/MAP/STRUCT) are not bindable as a parameter value`,
+    );
+  }
+  if (typeof value === 'object' && !(value instanceof Date) && !(value instanceof Int64)) {
+    throw new ParameterError(
+      `${label} is an object; only scalar values (string/number/bigint/boolean), Date, and Int64 are bindable`,
+    );
+  }
+}

--- a/lib/sea/SeaNativeLoader.ts
+++ b/lib/sea/SeaNativeLoader.ts
@@ -33,6 +33,9 @@ import type {
   ConnectionOptions as NativeConnectionOptions,
   ArrowBatch as NativeArrowBatch,
   ArrowSchema as NativeArrowSchema,
+  ExecuteOptions as NativeExecuteOptions,
+  TypedValueInput as NativeTypedValueInput,
+  NamedTypedValueInput as NativeNamedTypedValueInput,
 } from '../../native/sea';
 
 // SEA-prefixed re-exports. The kernel-generated `.d.ts` keeps the
@@ -45,6 +48,16 @@ export type SeaArrowBatch = NativeArrowBatch;
 export type SeaArrowSchema = NativeArrowSchema;
 export type SeaConnection = NativeConnection;
 export type SeaStatement = NativeStatement;
+
+// Per-statement execution options and bound-parameter inputs are kernel
+// concerns: the napi binding generates the canonical shapes (`positionalParams`
+// / `namedParams` as `TypedValueInput` / `NamedTypedValueInput`, plus
+// `rowLimit`, `queryTimeoutSecs`, `statementConf`, `queryTags`). We re-export
+// rather than re-declare so the driver-side param codec can never drift from
+// the kernel contract.
+export type SeaNativeExecuteOptions = NativeExecuteOptions;
+export type SeaNativeTypedValueInput = NativeTypedValueInput;
+export type SeaNativeNamedTypedValueInput = NativeNamedTypedValueInput;
 
 /**
  * The full native binding surface, derived from the generated module

--- a/lib/sea/SeaPositionalParams.ts
+++ b/lib/sea/SeaPositionalParams.ts
@@ -13,22 +13,47 @@
 // limitations under the License.
 
 import { DBSQLParameter, DBSQLParameterValue } from '../DBSQLParameter';
+import ParameterError from '../errors/ParameterError';
 import { SeaNativeTypedValueInput, SeaNativeNamedTypedValueInput } from './SeaNativeLoader';
 import assertBindableValue from './SeaInputValidation';
 
 /**
  * Derive `(precision,scale)` from a decimal value string for the SEA
- * `DECIMAL(p,s)` type name — the kernel param codec requires the
- * parenthesised form (plain `"DECIMAL"` is rejected) so it can preserve
- * the caller's fractional digits. `"99.99"` ⇒ `"4,2"`; `"-123"` ⇒ `"3,0"`.
- * Clamped to the Databricks max precision of 38.
+ * `DECIMAL(p,s)` type name — the kernel param codec requires the parenthesised
+ * form (plain `"DECIMAL"` is rejected) so it preserves the caller's fractional
+ * digits. `"99.99"` ⇒ `"4,2"`; `"-123"` ⇒ `"3,0"`; `"0.00001"` ⇒ `"5,5"`.
+ *
+ * Precision is significant integer digits (insignificant leading zeros
+ * stripped, matching Spark's decimal-literal rule) plus the fractional scale.
+ * The value is NOT clamped: a non-numeric value, or one that needs precision >
+ * the Databricks maximum of 38, throws `ParameterError` at bind time rather
+ * than emitting an inconsistent `DECIMAL(38,…)` type alongside an
+ * unrepresentable value (which the kernel would reject or silently truncate).
  */
 function decimalPrecisionScale(v: string): string {
-  const digits = (v.match(/\d/g) ?? []).length;
-  const dot = v.indexOf('.');
-  const scale = dot < 0 ? 0 : (v.slice(dot + 1).match(/\d/g) ?? []).length;
-  const precision = Math.min(Math.max(digits, 1), 38);
-  return `${precision},${Math.min(scale, precision)}`;
+  // Accept an optional sign + plain decimal numeral only. Exponential form
+  // ("1e+21"), empty, and non-numeric ("abc") are rejected with a clear error
+  // instead of mis-deriving (p,s) and surfacing an opaque kernel failure.
+  const m = /^[+-]?(\d*)(?:\.(\d+))?$/.exec(v.trim());
+  const intPart = m?.[1] ?? '';
+  const fracPart = m?.[2] ?? '';
+  if (!m || (intPart === '' && fracPart === '')) {
+    throw new ParameterError(
+      `DECIMAL parameter value "${v}" is not a plain decimal numeral (expected [+-]?digits[.digits]).`,
+    );
+  }
+  const scale = fracPart.length;
+  // Significant integer digits: drop insignificant leading zeros ("007" → 1,
+  // "0" / "" → 0) so e.g. 0.00001 is DECIMAL(5,5), not DECIMAL(6,5).
+  const significantIntDigits = intPart.replace(/^0+/, '').length;
+  const precision = Math.max(significantIntDigits + scale, 1);
+  if (precision > 38) {
+    throw new ParameterError(
+      `DECIMAL parameter value "${v}" needs precision ${precision}, exceeding the Databricks maximum of 38. ` +
+        'Round/scale the value or bind it as a STRING.',
+    );
+  }
+  return `${precision},${scale}`;
 }
 
 /**

--- a/lib/sea/SeaPositionalParams.ts
+++ b/lib/sea/SeaPositionalParams.ts
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Databricks, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { DBSQLParameter, DBSQLParameterValue } from '../DBSQLParameter';
+import { SeaNativeTypedValueInput, SeaNativeNamedTypedValueInput } from './SeaNativeLoader';
+import assertBindableValue from './SeaInputValidation';
+
+/**
+ * Derive `(precision,scale)` from a decimal value string for the SEA
+ * `DECIMAL(p,s)` type name — the kernel param codec requires the
+ * parenthesised form (plain `"DECIMAL"` is rejected) so it can preserve
+ * the caller's fractional digits. `"99.99"` ⇒ `"4,2"`; `"-123"` ⇒ `"3,0"`.
+ * Clamped to the Databricks max precision of 38.
+ */
+function decimalPrecisionScale(v: string): string {
+  const digits = (v.match(/\d/g) ?? []).length;
+  const dot = v.indexOf('.');
+  const scale = dot < 0 ? 0 : (v.slice(dot + 1).match(/\d/g) ?? []).length;
+  const precision = Math.min(Math.max(digits, 1), 38);
+  return `${precision},${Math.min(scale, precision)}`;
+}
+
+/**
+ * Reduce a `DBSQLParameter | DBSQLParameterValue` to the napi
+ * `TypedValueInput` (`{ sqlType, value? }`) the kernel's positional-param
+ * codec (`parse_typed_value`) accepts. Reuses `DBSQLParameter.toSparkParameter`
+ * — the same type-inference + value-stringification the Thrift backend uses —
+ * then adapts the type name to the codec's expectations:
+ * - DECIMAL → `DECIMAL(p,s)` (parenthesised form required)
+ * - INTERVAL * → `INTERVAL` (the codec's single interval type name)
+ * - a missing value ⇒ SQL NULL (`parse_typed_value` maps `value: None` to NULL).
+ */
+function toTypedValueInput(value: DBSQLParameter | DBSQLParameterValue): SeaNativeTypedValueInput {
+  const param = value instanceof DBSQLParameter ? value : new DBSQLParameter({ value });
+  const spark = param.toSparkParameter();
+  const stringValue = spark.value?.stringValue ?? undefined;
+
+  // NULL: no value (and `VOID` ignores any type), matching toSparkParameter's
+  // type/value-less shape for null/undefined.
+  if (stringValue === undefined || stringValue === null) {
+    return { sqlType: 'VOID' };
+  }
+
+  let sqlType = spark.type ?? 'STRING';
+  const upper = sqlType.toUpperCase();
+  if (upper === 'DECIMAL') {
+    sqlType = `DECIMAL(${decimalPrecisionScale(stringValue)})`;
+  } else if (upper.startsWith('INTERVAL')) {
+    sqlType = 'INTERVAL';
+  }
+  return { sqlType, value: stringValue };
+}
+
+/**
+ * Convert the public `ordinalParameters` option into the napi
+ * `positionalParams` array (1-based `?` placeholders). Returns `undefined`
+ * when none were supplied, so the caller can keep the minimal no-options
+ * call shape.
+ */
+export function buildSeaPositionalParams(
+  ordinalParameters?: Array<DBSQLParameter | DBSQLParameterValue>,
+): Array<SeaNativeTypedValueInput> | undefined {
+  if (ordinalParameters === undefined || ordinalParameters.length === 0) {
+    return undefined;
+  }
+  return ordinalParameters.map((value, i) => {
+    assertBindableValue(value, `ordinalParameters[${i}]`);
+    return toTypedValueInput(value);
+  });
+}
+
+/**
+ * Convert the public `namedParameters` option (`Record<name, value>`) into
+ * the napi `namedParams` array (`:name` placeholders). Each value reuses the
+ * same `toTypedValueInput` mapping (DECIMAL → DECIMAL(p,s), NULL → VOID, …),
+ * then carries its name. Returns `undefined` when none were supplied.
+ */
+export function buildSeaNamedParams(
+  namedParameters?: Record<string, DBSQLParameter | DBSQLParameterValue>,
+): Array<SeaNativeNamedTypedValueInput> | undefined {
+  if (namedParameters === undefined || Object.keys(namedParameters).length === 0) {
+    return undefined;
+  }
+  return Object.keys(namedParameters).map((name) => {
+    assertBindableValue(namedParameters[name], `namedParameters[${name}]`);
+    return { name, ...toTypedValueInput(namedParameters[name]) };
+  });
+}

--- a/lib/sea/SeaServerInfo.ts
+++ b/lib/sea/SeaServerInfo.ts
@@ -22,8 +22,8 @@ import { TGetInfoType, TGetInfoValue } from '../../thrift/TCLIService_types';
  * the values client-side.
  *
  * The Databricks Thrift server itself answers only three `TGetInfoType`s and
- * rejects every other value; we mirror that surface byte-for-byte so the SEA
- * path is a drop-in equivalent:
+ * rejects every other value; we mirror that surface so the SEA path is a
+ * drop-in equivalent:
  *
  *   | TGetInfoType        | Thrift server | SEA (here)        |
  *   |---------------------|---------------|-------------------|
@@ -31,6 +31,13 @@ import { TGetInfoType, TGetInfoValue } from '../../thrift/TCLIService_types';
  *   | CLI_DBMS_NAME   (17)| "Spark SQL"   | "Spark SQL"        |
  *   | CLI_DBMS_VER    (18)| "3.1.1"       | "3.1.1"            |
  *   | (any other)         | error         | undefined → error  |
+ *
+ * Empirically re-verified against a live warehouse over the Thrift path: the
+ * three values above are byte-identical to the server's, and the server
+ * returns an error for every other `TGetInfoType` (probed CLI_MAX_DRIVER_-
+ * CONNECTIONS, CLI_DATA_SOURCE_NAME, CLI_FETCH_DIRECTION, … — all errored). So
+ * the SEA "undefined → throw" path matches Thrift's effective behaviour rather
+ * than narrowing it.
  */
 
 /** Canonical DBMS product name — identical to the Thrift server's value. */

--- a/lib/sea/SeaServerInfo.ts
+++ b/lib/sea/SeaServerInfo.ts
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Databricks, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { TGetInfoType, TGetInfoValue } from '../../thrift/TCLIService_types';
+
+/**
+ * `getInfo` (JDBC `DatabaseMetaData` / ODBC `SQLGetInfo`) is a Thrift-protocol
+ * concept: the Thrift backend forwards `TGetInfoReq` to the server's `getInfo`
+ * RPC. The SEA REST protocol and the Rust kernel have **no** equivalent
+ * endpoint, so — exactly as JDBC does for `DatabaseMetaData` — we synthesize
+ * the values client-side.
+ *
+ * The Databricks Thrift server itself answers only three `TGetInfoType`s and
+ * rejects every other value; we mirror that surface byte-for-byte so the SEA
+ * path is a drop-in equivalent:
+ *
+ *   | TGetInfoType        | Thrift server | SEA (here)        |
+ *   |---------------------|---------------|-------------------|
+ *   | CLI_SERVER_NAME (13)| "Spark SQL"   | "Spark SQL"        |
+ *   | CLI_DBMS_NAME   (17)| "Spark SQL"   | "Spark SQL"        |
+ *   | CLI_DBMS_VER    (18)| "3.1.1"       | "3.1.1"            |
+ *   | (any other)         | error         | undefined → error  |
+ */
+
+/** Canonical DBMS product name — identical to the Thrift server's value. */
+export const SEA_DBMS_NAME = 'Spark SQL';
+
+/** Server-name answer — identical to the Thrift server's value. */
+export const SEA_SERVER_NAME = 'Spark SQL';
+
+/**
+ * DBMS version string. Mirrors the constant the Databricks Thrift server
+ * reports for `CLI_DBMS_VER` (the HiveServer2-compat Spark SQL version, not
+ * the DBR release). Kept in lock-step with Thrift for parity; if the server
+ * ever changes it the comparator's GET_INFO suite flags the drift.
+ */
+export const SEA_DBMS_VERSION = '3.1.1';
+
+/**
+ * Synthesize the `TGetInfoValue` for a `getInfo` request on the SEA path.
+ * Returns `undefined` for any `TGetInfoType` the (Thrift) server does not
+ * answer — the caller surfaces that as an error, matching Thrift's
+ * reject-unsupported-info-type behaviour.
+ */
+export function seaServerInfoValue(infoType: number): TGetInfoValue | undefined {
+  switch (infoType) {
+    case TGetInfoType.CLI_SERVER_NAME:
+      return new TGetInfoValue({ stringValue: SEA_SERVER_NAME });
+    case TGetInfoType.CLI_DBMS_NAME:
+      return new TGetInfoValue({ stringValue: SEA_DBMS_NAME });
+    case TGetInfoType.CLI_DBMS_VER:
+      return new TGetInfoValue({ stringValue: SEA_DBMS_VERSION });
+    default:
+      return undefined;
+  }
+}

--- a/lib/sea/SeaSessionBackend.ts
+++ b/lib/sea/SeaSessionBackend.ts
@@ -31,6 +31,8 @@ import {
 import Status from '../dto/Status';
 import InfoValue from '../dto/InfoValue';
 import HiveDriverError from '../errors/HiveDriverError';
+import ParameterError from '../errors/ParameterError';
+import { LogLevel } from '../contracts/IDBSQLLogger';
 import { SeaConnection, SeaNativeExecuteOptions, SeaStatement } from './SeaNativeLoader';
 import { decodeNapiKernelError } from './SeaErrorMapping';
 import SeaOperationBackend from './SeaOperationBackend';
@@ -85,9 +87,16 @@ export default class SeaSessionBackend implements ISessionBackend {
   /**
    * `getInfo` (JDBC `DatabaseMetaData` / ODBC `SQLGetInfo`) has no SEA/kernel
    * endpoint, so — exactly as JDBC does for `DatabaseMetaData` — we synthesize
-   * the answer client-side, mirroring the three `TGetInfoType`s the Databricks
-   * Thrift server answers (server name / DBMS name / DBMS version) and
-   * rejecting every other value the same way the server does. See
+   * the answer client-side for the three `TGetInfoType`s the Databricks server
+   * answers (server name / DBMS name / DBMS version) and reject the rest.
+   *
+   * This is NOT a SEA-only contract narrowing: probing the live warehouse over
+   * the Thrift path confirms the server itself returns an error for every
+   * other `TGetInfoType` (CLI_MAX_DRIVER_CONNECTIONS, CLI_DATA_SOURCE_NAME, …),
+   * and the three values it does answer are byte-identical to the constants we
+   * synthesize (`"Spark SQL"` / `"Spark SQL"` / `"3.1.1"`, re-verified live).
+   * So rejecting an unsupported type matches Thrift's effective behaviour — we
+   * just surface a clearer, typed error than the server's opaque one. See
    * {@link seaServerInfoValue}.
    */
   public async getInfo(infoType: number): Promise<InfoValue> {
@@ -95,8 +104,10 @@ export default class SeaSessionBackend implements ISessionBackend {
     const value = seaServerInfoValue(infoType);
     if (value === undefined) {
       throw new HiveDriverError(
-        `SEA getInfo: unsupported TGetInfoType ${infoType}. The SEA/kernel path answers only the ` +
-          `info types the Databricks server itself supports (server name, DBMS name, DBMS version).`,
+        `SEA getInfo: unsupported TGetInfoType ${infoType}. Only the info types the Databricks ` +
+          `server itself answers are supported: CLI_SERVER_NAME (13), CLI_DBMS_NAME (17), ` +
+          `CLI_DBMS_VER (18). The server rejects every other type on the Thrift path too, so this ` +
+          `is not a SEA-specific restriction.`,
       );
     }
     return new InfoValue(value);
@@ -123,14 +134,14 @@ export default class SeaSessionBackend implements ISessionBackend {
     this.failIfClosed();
 
     // Positional (`?`) and named (`:name`) parameters are mutually exclusive —
-    // the kernel param codec binds exactly one placeholder style per
-    // statement, so passing both is a caller error we surface up-front.
+    // the kernel param codec binds exactly one placeholder style per statement.
+    // Use the SAME error type and message as the Thrift backend
+    // (`ThriftSessionBackend.getQueryParameters`) so a caller catching
+    // `ParameterError` for this case behaves identically across backends.
     const positionalParams = buildSeaPositionalParams(options.ordinalParameters);
     const namedParams = buildSeaNamedParams(options.namedParameters);
     if (positionalParams !== undefined && namedParams !== undefined) {
-      throw new HiveDriverError(
-        'SEA executeStatement: ordinalParameters and namedParameters are mutually exclusive — pass only one.',
-      );
+      throw new ParameterError('Driver does not support both ordinal and named parameters.');
     }
 
     if (options.queryTimeout !== undefined) {
@@ -168,16 +179,16 @@ export default class SeaSessionBackend implements ISessionBackend {
       execOptions = { positionalParams, namedParams };
     }
 
-    let nativeStatement;
+    let nativeStatement: SeaStatement;
     try {
       nativeStatement =
         execOptions === undefined
           ? await this.connection.executeStatement(statement)
           : await this.connection.executeStatement(statement, execOptions);
     } catch (err) {
-      throw decodeNapiKernelError(err);
+      throw this.logAndMapError('executeStatement', err);
     }
-    return this.wrapStatement(nativeStatement!);
+    return this.wrapStatement(nativeStatement);
   }
 
   /** Wrap a napi `Statement` (from execute or a metadata call) as an operation backend. */
@@ -244,8 +255,19 @@ export default class SeaSessionBackend implements ISessionBackend {
 
   public async getPrimaryKeys(request: PrimaryKeysRequest): Promise<IOperationBackend> {
     this.failIfClosed();
+    // The kernel requires a catalog for primary-key lookup (`Identifier::new`
+    // rejects an empty string). The Thrift backend can forward an undefined
+    // catalog and let the server resolve a default; the SEA/kernel path cannot,
+    // so reject up front with a clear, actionable message rather than passing
+    // `''` and surfacing the kernel's opaque "identifier must not be empty".
+    if (request.catalogName === undefined || request.catalogName === '') {
+      throw new HiveDriverError(
+        'SEA getPrimaryKeys requires a catalog — pass `catalogName` explicitly. (The Thrift backend ' +
+          'can omit it and let the server resolve a default; the SEA kernel path requires it.)',
+      );
+    }
     return this.runMetadata(() =>
-      this.connection.getPrimaryKeys(request.catalogName ?? '', request.schemaName, request.tableName),
+      this.connection.getPrimaryKeys(request.catalogName as string, request.schemaName, request.tableName),
     );
   }
 
@@ -265,13 +287,25 @@ export default class SeaSessionBackend implements ISessionBackend {
 
   /** Run a napi metadata call, mapping kernel errors and wrapping the result handle. */
   private async runMetadata(call: () => Promise<SeaStatement>): Promise<IOperationBackend> {
-    let nativeStatement;
+    let nativeStatement: SeaStatement;
     try {
       nativeStatement = await call();
     } catch (err) {
-      throw decodeNapiKernelError(err);
+      throw this.logAndMapError('metadata', err);
     }
     return this.wrapStatement(nativeStatement);
+  }
+
+  /**
+   * Map a napi/kernel error to a typed driver error and emit a debug breadcrumb
+   * first, matching the rest of the SEA backend's logging convention
+   * (`SeaOperationLifecycle` / `SeaOperationBackend`). Metadata and bound-param
+   * execute failures otherwise threw with no on-call signal.
+   */
+  private logAndMapError(op: string, err: unknown): Error {
+    const mapped = decodeNapiKernelError(err);
+    this.context.getLogger().log(LogLevel.debug, `SEA ${op} failed for session ${this._id}: ${mapped.message}`);
+    return mapped;
   }
 
   public async close(): Promise<Status> {

--- a/lib/sea/SeaSessionBackend.ts
+++ b/lib/sea/SeaSessionBackend.ts
@@ -31,9 +31,11 @@ import {
 import Status from '../dto/Status';
 import InfoValue from '../dto/InfoValue';
 import HiveDriverError from '../errors/HiveDriverError';
-import { SeaConnection } from './SeaNativeLoader';
+import { SeaConnection, SeaNativeExecuteOptions, SeaStatement } from './SeaNativeLoader';
 import { decodeNapiKernelError } from './SeaErrorMapping';
 import SeaOperationBackend from './SeaOperationBackend';
+import { buildSeaPositionalParams, buildSeaNamedParams } from './SeaPositionalParams';
+import { seaServerInfoValue } from './SeaServerInfo';
 
 export interface SeaSessionBackendOptions {
   /** The opaque napi `Connection` handle returned by `openSession`. */
@@ -80,8 +82,24 @@ export default class SeaSessionBackend implements ISessionBackend {
     return this._id;
   }
 
-  public async getInfo(_infoType: number): Promise<InfoValue> {
-    throw new HiveDriverError('SeaSessionBackend.getInfo: not implemented yet (deferred to M1)');
+  /**
+   * `getInfo` (JDBC `DatabaseMetaData` / ODBC `SQLGetInfo`) has no SEA/kernel
+   * endpoint, so — exactly as JDBC does for `DatabaseMetaData` — we synthesize
+   * the answer client-side, mirroring the three `TGetInfoType`s the Databricks
+   * Thrift server answers (server name / DBMS name / DBMS version) and
+   * rejecting every other value the same way the server does. See
+   * {@link seaServerInfoValue}.
+   */
+  public async getInfo(infoType: number): Promise<InfoValue> {
+    this.failIfClosed();
+    const value = seaServerInfoValue(infoType);
+    if (value === undefined) {
+      throw new HiveDriverError(
+        `SEA getInfo: unsupported TGetInfoType ${infoType}. The SEA/kernel path answers only the ` +
+          `info types the Databricks server itself supports (server name, DBMS name, DBMS version).`,
+      );
+    }
+    return new InfoValue(value);
   }
 
   /**
@@ -104,10 +122,17 @@ export default class SeaSessionBackend implements ISessionBackend {
   public async executeStatement(statement: string, options: ExecuteStatementOptions): Promise<IOperationBackend> {
     this.failIfClosed();
 
-    // M0 surfaces a clear error rather than silently dropping M1-only knobs.
-    if (options.namedParameters !== undefined || options.ordinalParameters !== undefined) {
-      throw new HiveDriverError('SEA executeStatement: query parameters are not supported in M0 (deferred to M1)');
+    // Positional (`?`) and named (`:name`) parameters are mutually exclusive —
+    // the kernel param codec binds exactly one placeholder style per
+    // statement, so passing both is a caller error we surface up-front.
+    const positionalParams = buildSeaPositionalParams(options.ordinalParameters);
+    const namedParams = buildSeaNamedParams(options.namedParameters);
+    if (positionalParams !== undefined && namedParams !== undefined) {
+      throw new HiveDriverError(
+        'SEA executeStatement: ordinalParameters and namedParameters are mutually exclusive — pass only one.',
+      );
     }
+
     if (options.queryTimeout !== undefined) {
       throw new HiveDriverError('SEA executeStatement: queryTimeout is not supported in M0 (deferred to M1)');
     }
@@ -136,53 +161,117 @@ export default class SeaSessionBackend implements ISessionBackend {
       );
     }
 
+    // Only build the napi options object when there is something to send —
+    // the no-params path keeps the minimal call shape (`executeStatement(sql)`).
+    let execOptions: SeaNativeExecuteOptions | undefined;
+    if (positionalParams !== undefined || namedParams !== undefined) {
+      execOptions = { positionalParams, namedParams };
+    }
+
     let nativeStatement;
     try {
-      nativeStatement = await this.connection.executeStatement(statement);
+      nativeStatement =
+        execOptions === undefined
+          ? await this.connection.executeStatement(statement)
+          : await this.connection.executeStatement(statement, execOptions);
     } catch (err) {
       throw decodeNapiKernelError(err);
     }
+    return this.wrapStatement(nativeStatement!);
+  }
+
+  /** Wrap a napi `Statement` (from execute or a metadata call) as an operation backend. */
+  private wrapStatement(nativeStatement: SeaStatement): IOperationBackend {
     return new SeaOperationBackend({
-      statement: nativeStatement!,
+      statement: nativeStatement,
       context: this.context,
-      id: nativeStatement!.statementId,
+      id: nativeStatement.statementId,
     });
   }
 
+  /**
+   * Metadata calls forward to the kernel's metadata surface (`listCatalogs`,
+   * `listTables`, …), each of which returns a napi `Statement` whose result
+   * carries the JDBC-shaped columns. We wrap that handle exactly like an
+   * executed statement. The kernel owns the SQL synthesis, the column
+   * projection, and (for `listTables`) the client-side `TABLE_TYPE` filter —
+   * the driver only maps the request fields to positional arguments.
+   *
+   * The `runAsync` / `maxRows` request fields are not threaded here: `runAsync`
+   * is deprecated, and `maxRows` is applied by the facade at fetch time (same
+   * as the Thrift path), so the napi call takes only the filter arguments.
+   */
   public async getTypeInfo(_request: TypeInfoRequest): Promise<IOperationBackend> {
-    throw new HiveDriverError('SeaSessionBackend.getTypeInfo: not implemented yet (deferred to M1)');
+    this.failIfClosed();
+    return this.runMetadata(() => this.connection.listTypeInfo());
   }
 
   public async getCatalogs(_request: CatalogsRequest): Promise<IOperationBackend> {
-    throw new HiveDriverError('SeaSessionBackend.getCatalogs: not implemented yet (deferred to M1)');
+    this.failIfClosed();
+    return this.runMetadata(() => this.connection.listCatalogs());
   }
 
-  public async getSchemas(_request: SchemasRequest): Promise<IOperationBackend> {
-    throw new HiveDriverError('SeaSessionBackend.getSchemas: not implemented yet (deferred to M1)');
+  public async getSchemas(request: SchemasRequest): Promise<IOperationBackend> {
+    this.failIfClosed();
+    return this.runMetadata(() => this.connection.listSchemas(request.catalogName, request.schemaName));
   }
 
-  public async getTables(_request: TablesRequest): Promise<IOperationBackend> {
-    throw new HiveDriverError('SeaSessionBackend.getTables: not implemented yet (deferred to M1)');
+  public async getTables(request: TablesRequest): Promise<IOperationBackend> {
+    this.failIfClosed();
+    return this.runMetadata(() =>
+      this.connection.listTables(request.catalogName, request.schemaName, request.tableName, request.tableTypes),
+    );
   }
 
   public async getTableTypes(_request: TableTypesRequest): Promise<IOperationBackend> {
-    throw new HiveDriverError('SeaSessionBackend.getTableTypes: not implemented yet (deferred to M1)');
+    this.failIfClosed();
+    return this.runMetadata(() => this.connection.listTableTypes());
   }
 
-  public async getColumns(_request: ColumnsRequest): Promise<IOperationBackend> {
-    throw new HiveDriverError('SeaSessionBackend.getColumns: not implemented yet (deferred to M1)');
+  public async getColumns(request: ColumnsRequest): Promise<IOperationBackend> {
+    this.failIfClosed();
+    return this.runMetadata(() =>
+      this.connection.listColumns(request.catalogName, request.schemaName, request.tableName, request.columnName),
+    );
   }
 
-  public async getFunctions(_request: FunctionsRequest): Promise<IOperationBackend> {
-    throw new HiveDriverError('SeaSessionBackend.getFunctions: not implemented yet (deferred to M1)');
+  public async getFunctions(request: FunctionsRequest): Promise<IOperationBackend> {
+    this.failIfClosed();
+    return this.runMetadata(() =>
+      this.connection.listFunctions(request.catalogName, request.schemaName, request.functionName),
+    );
   }
 
-  public async getPrimaryKeys(_request: PrimaryKeysRequest): Promise<IOperationBackend> {
-    throw new HiveDriverError('SeaSessionBackend.getPrimaryKeys: not implemented yet (deferred to M1)');
+  public async getPrimaryKeys(request: PrimaryKeysRequest): Promise<IOperationBackend> {
+    this.failIfClosed();
+    return this.runMetadata(() =>
+      this.connection.getPrimaryKeys(request.catalogName ?? '', request.schemaName, request.tableName),
+    );
   }
 
-  public async getCrossReference(_request: CrossReferenceRequest): Promise<IOperationBackend> {
-    throw new HiveDriverError('SeaSessionBackend.getCrossReference: not implemented yet (deferred to M1)');
+  public async getCrossReference(request: CrossReferenceRequest): Promise<IOperationBackend> {
+    this.failIfClosed();
+    return this.runMetadata(() =>
+      this.connection.getCrossReference(
+        request.parentCatalogName,
+        request.parentSchemaName,
+        request.parentTableName,
+        request.foreignCatalogName,
+        request.foreignSchemaName,
+        request.foreignTableName,
+      ),
+    );
+  }
+
+  /** Run a napi metadata call, mapping kernel errors and wrapping the result handle. */
+  private async runMetadata(call: () => Promise<SeaStatement>): Promise<IOperationBackend> {
+    let nativeStatement;
+    try {
+      nativeStatement = await call();
+    } catch (err) {
+      throw decodeNapiKernelError(err);
+    }
+    return this.wrapStatement(nativeStatement);
   }
 
   public async close(): Promise<Status> {

--- a/native/sea/index.d.ts
+++ b/native/sea/index.d.ts
@@ -19,9 +19,8 @@
  *
  * `rowLimit` (SEA `row_limit`) and `queryTimeoutSecs` (the per-statement
  * server wait timeout) are exposed here and threaded onto the kernel
- * `StatementSpec`. Positional and named parameters remain deferred: they
- * require a non-trivial JS↔napi `TypedValue` mapping and land in a
- * follow-on PR.
+ * `StatementSpec`. `positionalParams` (`?`) and `namedParams` (`:name`)
+ * carry bound query parameters, decoded via `params::parse_typed_value`.
  *
  * **Tag-order caveat (M4 parity note).** The napi `queryTags` field
  * is a Rust `HashMap<String, String>` whose iteration order is
@@ -70,8 +69,46 @@ export interface ExecuteOptions {
    * server statement timeout (JDBC `setQueryTimeout`). Maps to
    * `StatementSpec.query_timeout_secs`. Distinct from the
    * connection-level transport timeout. The SEA wire caps it at 50s.
+   *
+   * **Applies to `executeStatement` only.** The async `submitStatement`
+   * path always sends `wait_timeout=0s` (so the server returns a
+   * `statement_id` immediately and never blocks), which means this
+   * field is *not* consulted on the submit path — the caller drives
+   * completion via `AsyncStatement.status()` / `awaitResult()` and is
+   * responsible for its own timeout (e.g. `Promise.race`). Passing
+   * `queryTimeoutSecs` to `submitStatement` is silently ignored. This
+   * matches the Python `use_sea` async-submit contract, where the
+   * wait-timeout and any statement timeout are orthogonal.
    */
   queryTimeoutSecs?: number
+  /**
+   * Positional parameters, in 1-based wire order. Index `i` in this
+   * Vec corresponds to the `i+1`-th `?` placeholder in the SQL.
+   * Each entry is a `{ sqlType, value }` pair — `value` is the
+   * string-encoded literal or `null` for SQL NULL. Mirrors
+   * `StatementSpec::positional_params`; decoded via [`parse_typed_value`].
+   */
+  positionalParams?: Array<TypedValueInput>
+  /**
+   * Named parameters (`:name` placeholders). Each carries its `name`
+   * alongside the `{ sqlType, value? }` pair. Mapped to a kernel
+   * `TypedValue` via the same [`parse_typed_value`] codec and bound with
+   * `StatementSpec::param_named`. Named is the SEA-spec-required public
+   * param form (`StatementParameter.name` is `openapi_required`);
+   * positional is the documented-undocumented variant. The two are
+   * mutually exclusive at the SQL level (`?` vs `:name`).
+   */
+  namedParams?: Array<NamedTypedValueInput>
+}
+/**
+ * A named bound parameter — a [`TypedValueInput`] plus its `:name`. Kept a
+ * distinct napi object (rather than an optional `name` on `TypedValueInput`)
+ * so the positional surface stays a clean ordered list with no name field.
+ */
+export interface NamedTypedValueInput {
+  name: string
+  sqlType: string
+  value?: string
 }
 /**
  * Authentication mode selector crossing the napi boundary. The string
@@ -189,6 +226,50 @@ export interface ConnectionOptions {
    * `2^32 - 1` round-trip safely (any reasonable pool size fits).
    */
   maxConnections?: number
+  /**
+   * Render `INTERVAL` / `DURATION` result columns as strings
+   * (`ResultConfig.intervals_as_string`). The kernel default is
+   * native Arrow `month_interval` / `duration[us]` types; the NodeJS
+   * Thrift driver surfaces intervals as strings, so the SEA driver
+   * sets this `true` for byte-compatible parity. Omitted ⇒ kernel
+   * default (native Arrow interval types).
+   */
+  intervalsAsString?: boolean
+  /**
+   * Render complex (`ARRAY` / `MAP` / `STRUCT` / `VARIANT`) result
+   * columns as JSON strings (`ResultConfig.complex_types_as_json`)
+   * instead of native Arrow nested types. Omitted ⇒ kernel default
+   * (native Arrow nested types, which the NodeJS Arrow decoder
+   * already renders identically to the Thrift path).
+   */
+  complexTypesAsJson?: boolean
+  /**
+   * Whether to verify the server's TLS certificate.
+   *
+   * Omitted / `true` ⇒ strict validation against the system / Mozilla
+   * trust store (full chain + expiry + hostname), matching JDBC / ODBC
+   * and every modern HTTPS client. This is the **default** for the SEA
+   * backend — secure by default.
+   *
+   * `false` ⇒ permissive: accept self-signed / untrusted / expired
+   * certs AND skip the hostname-vs-SNI check. This is **insecure** (no
+   * protection against active MITM); it exists only as an opt-out for
+   * parity with the legacy NodeJS Thrift driver, which hard-codes
+   * `rejectUnauthorized: false`. Prefer pairing strict checking with
+   * `custom_ca_cert` over disabling verification entirely.
+   *
+   * Maps onto the kernel [`TlsConfig::accept_self_signed`] +
+   * [`TlsConfig::skip_hostname_verification`] (both = `!check`).
+   */
+  checkServerCertificate?: boolean
+  /**
+   * PEM-encoded CA certificate bytes to add to the trust store on
+   * top of the system roots. Use for corporate TLS-inspecting
+   * proxies that re-sign TLS, or on-prem deployments with an
+   * internal CA. Honoured regardless of `check_server_certificate`.
+   * Maps onto the kernel [`TlsConfig::custom_ca_cert`].
+   */
+  customCaCert?: Buffer
 }
 /**
  * Open a Databricks SQL session and return an opaque `Connection`
@@ -200,6 +281,39 @@ export interface ConnectionOptions {
  * to camelCase for free functions).
  */
 export declare function openSession(options: ConnectionOptions): Promise<Connection>
+/**
+ * JS-visible binding for a single positional parameter.
+ *
+ * Shape mirrors the `TSparkParameter` wire object the Thrift backend
+ * already emits via `DBSQLParameter.toSparkParameter()` — `type` is the
+ * canonical Databricks SQL type name (`"INT"`, `"STRING"`,
+ * `"DECIMAL(10,2)"`, ...), `value` is the string-encoded literal or
+ * `None` for SQL NULL.
+ *
+ * Why a string for `value` instead of a tagged JS union: round-tripping
+ * arbitrary JS values across the FFI requires either (a) a custom
+ * napi `FromNapiValue` per arm, or (b) a `serde_json::Value`-style
+ * dynamic dispatch on the Rust side. The Node-driver adapter already
+ * stringifies before calling the binding (see `DBSQLParameter` and the
+ * existing pyo3 wrapper), so the string-in / string-parsed contract
+ * adds no JS-side complexity and keeps the kernel-side validation in
+ * one place.
+ */
+export interface TypedValueInput {
+  /**
+   * Canonical Databricks SQL type name. Case-insensitive for the
+   * simple variants; for DECIMAL the parenthesised form
+   * (`"DECIMAL(10,2)"`) is required so the kernel can extract
+   * precision/scale.
+   */
+  sqlType: string
+  /**
+   * String-encoded value. `None` always produces `TypedValue::Null`
+   * regardless of `sql_type` — matches the connector's
+   * `VoidParameter` shape and the pyo3 binding's contract.
+   */
+  value?: string
+}
 /**
  * A single Arrow IPC stream payload encoding one record batch (plus
  * the schema header so the JS-side reader is stateless).
@@ -231,6 +345,143 @@ export interface ArrowSchema {
  */
 export declare function version(): string
 /**
+ * Opaque async-statement handle.
+ *
+ * Returned by `Connection.submitStatement(...)` after the kernel
+ * `Statement::submit()` returns (server sent `wait_timeout=0s`, so
+ * the response carries a `statement_id` but the statement is still
+ * `Pending`/`Running`). JS drives polling via `status()` /
+ * `awaitResult()`.
+ *
+ * Concurrency shape: `status()`, `awaitResult()`, and `close()` take
+ * `inner.lock()` and hold the guard across the kernel `.await` (tokio
+ * `Mutex` is FIFO), so `status()` / `close()` queue behind any
+ * in-flight `awaitResult()` until it returns naturally. `cancel()` is
+ * the deliberate exception: it does **not** touch `inner` — it fires
+ * through the detached `AsyncStatementCanceller` (session +
+ * statement_id, captured at construction), so an explicit
+ * `stmt.cancel()` interrupts an in-flight `awaitResult()` instead of
+ * queueing behind it. The server-side cancel flips the statement
+ * terminal, which the parked `awaitResult()` poll loop observes
+ * (`Cancelled`) and returns on. The kernel's `AwaitResultCancelGuard`
+ * still covers the drop-cancel case (Promise.race / timeout)
+ * independently — see module docs.
+ */
+export declare class AsyncStatement {
+  /**
+   * Server-issued statement id. Cached at construction; readable
+   * even after `close()` so JS-side log lines can correlate
+   * against kernel / server logs which key on the same id.
+   */
+  get statementId(): string
+  /**
+   * One-shot status check. Returns a string enum matching the
+   * kernel `StatementStatus` shape:
+   * `'Pending' | 'Running' | 'Succeeded' | 'Failed' |
+   * 'Cancelled' | 'Closed' | 'Unknown'`. (`'Unknown'` is the
+   * `#[non_exhaustive]` forward-compat catch-all that
+   * `StatementStatus::as_str` can return — consumers switching on
+   * the state must handle it.) Returns
+   * `KernelError(InvalidStatementHandle)` if the statement has
+   * been explicitly `close()`d.
+   *
+   * The `Failed` variant collapses to the string `'Failed'` on
+   * the JS side; the underlying error envelope (sql_state /
+   * error_code / query_id) is surfaced by `awaitResult()`'s
+   * rejection, which is where callers actually need the typed
+   * error. `status()` is intended for polling progress UIs
+   * that only need the state name.
+   */
+  status(): Promise<string>
+  /**
+   * Block until the server reaches a terminal state, then return
+   * an `AsyncResultHandle` that wraps the materialised result
+   * stream. The handle exposes `fetchNextBatch()` / `schema()`
+   * for consuming the result, plus `statementId` for log
+   * correlation.
+   *
+   * Drop-cancel safety: kernel `await_result` installs
+   * `AwaitResultCancelGuard` which fires a fire-and-forget
+   * `cancel_statement` if the future is dropped mid-poll
+   * (timeout, tokio::select! loser, JS-side `Promise.race`
+   * loser). The `util::guarded` `catch_unwind` here covers the
+   * V8-panic-across-boundary case on top. Returns
+   * `KernelError(InvalidStatementHandle)` if the statement has
+   * been explicitly `close()`d.
+   */
+  awaitResult(): Promise<AsyncResultHandle>
+  /**
+   * Server-side cancel. Returns
+   * `KernelError(InvalidStatementHandle)` if the statement has
+   * been explicitly `close()`d. Idempotent against a server
+   * that already reached a terminal state — the kernel's
+   * `cancel_statement` is a no-op there.
+   *
+   * **Lock-free by design.** Unlike `status()` / `awaitResult()` /
+   * `close()`, this does not take `inner.lock()` — it fires through
+   * the detached `AsyncStatementCanceller` captured at construction.
+   * That lets `stmt.cancel()` interrupt an in-flight `awaitResult()`
+   * (which holds the mutex for the whole poll) instead of queueing
+   * behind it: the server-side cancel flips the statement terminal,
+   * the parked `awaitResult()` poll loop observes `Cancelled` and
+   * returns. The closed-state check reads a lock-free flag so a
+   * cancel after an explicit `close()` still surfaces
+   * `InvalidStatementHandle`.
+   */
+  cancel(): Promise<void>
+  /**
+   * Explicit close. Idempotent — a second call on an
+   * already-closed handle returns `Ok(())`. On `Err`, the napi
+   * inner is already `None`, so a JS-side retry sees the
+   * closed-handle short-circuit and returns `Ok(())` without
+   * re-attempting the wire call. The kernel's own `Drop`
+   * fire-and-forget retry runs once in the background.
+   */
+  close(): Promise<void>
+}
+/**
+ * Opaque result-fetch handle returned by
+ * `AsyncStatement.awaitResult()`. Wraps a kernel `ResultStream`
+ * directly; structurally analogous to the sync `Statement`'s
+ * fetch-side surface (`fetchNextBatch` / `schema` /
+ * `statementId`).
+ *
+ * `cancel()` / `close()` are not exposed: the parent
+ * `AsyncStatement` owns server-side lifecycle. A `close()` here
+ * would create dual-ownership of the same statement_id with
+ * inconsistent close semantics. Callers `close()` the parent
+ * `AsyncStatement` after they're done fetching.
+ *
+ * Schema is cached at construction so it survives the underlying
+ * stream being drained; mirrors the sync `Statement.schema()`
+ * post-close contract.
+ */
+export declare class AsyncResultHandle {
+  /**
+   * Server-issued statement id. Cached at construction; readable
+   * for log correlation. Matches the parent `AsyncStatement`'s
+   * `statementId`.
+   */
+  get statementId(): string
+  /**
+   * Pull the next batch of results. Returns `null` when the
+   * stream is exhausted. The returned `ArrowBatch.ipcBytes` is a
+   * complete Arrow IPC stream (schema header + 1 record-batch
+   * message), suitable for handing to `apache-arrow`'s
+   * `RecordBatchReader`. Byte-identical to the sync
+   * `Statement.fetchNextBatch()` payload for the same query.
+   */
+  fetchNextBatch(): Promise<ArrowBatch | null>
+  /**
+   * Result schema as an Arrow IPC payload (schema header only,
+   * no record-batch message). Available before any batches have
+   * been fetched. Sync because the body has no `.await` —
+   * `encode_ipc_stream` is pure CPU work over the cached
+   * `Arc<Schema>`.
+   */
+  schema(): ArrowSchema
+}
+/**
  * Opaque connection handle wrapping a kernel `Session`.
  *
  * `inner` is `Arc<Mutex<Option<Session>>>` so:
@@ -240,15 +491,16 @@ export declare function version(): string
  * - `close()` can `.take()` the session to consume it for the kernel's
  *   move-by-value `Session::close(self)` signature.
  *
- * **Current concurrency shape** — `executeStatement` holds
- * `inner.lock()` across `stmt.execute().await`, so two concurrent
- * `Promise.all([executeStatement(q1), executeStatement(q2)])` calls
- * on the same Connection serialise even though the kernel transport
- * supports concurrent statements per session, and `close()` blocks
- * behind any in-flight execute. The kernel's `Session::statement()`
- * is `&self`-callable, so the right shape is `Arc<Session>` with
- * concurrent execute paths; that lands in the follow-up lock-shape
- * refactor — see
+ * **Concurrency shape** — both `executeStatement` and
+ * `submitStatement` build the kernel `Statement` under `inner.lock()`
+ * and then RELEASE the guard before the wire call
+ * (`stmt.execute().await` / `stmt.submit().await`). `Session::statement()`
+ * is `&self`-callable and only clones the session's internal `Arc`, so
+ * the built statement is independent of the guard. Concurrent
+ * `Promise.all([executeStatement(q1), submitStatement(q2)])` therefore
+ * serialise only for the microsecond statement-build, not the network
+ * round-trip, and `close()` never blocks behind an in-flight execute or
+ * submit. See
  * `sea-workflow/jira-candidates/2026-05-24-napi-cancel-during-fetch.md`.
  */
 export declare class Connection {
@@ -275,6 +527,29 @@ export declare class Connection {
    */
   executeStatement(sql: string, options?: ExecuteOptions | undefined | null): Promise<Statement>
   /**
+   * Submit a SQL statement and return immediately with an
+   * `AsyncStatement` handle, without blocking until the query
+   * finishes. The kernel's `Statement::submit()` sends
+   * `wait_timeout=0s`, so the server responds as soon as it has a
+   * `statement_id` (state `Pending`/`Running`); JS drives polling
+   * via `AsyncStatement.status()` and materialises results with
+   * `AsyncStatement.awaitResult()`.
+   *
+   * This is the async-execution path the Thrift backend always
+   * uses (`runAsync: true`): the SEA backend submits, returns a
+   * pending operation handle, and polls to terminal during
+   * fetch. Option semantics (statementConf / queryTags /
+   * rowLimit / positional + named params) match `executeStatement`,
+   * with one carve-out: `queryTimeoutSecs` is **ignored** here.
+   * Submit always sends `wait_timeout=0s` so the call returns
+   * immediately, leaving no server wait to bound; the caller drives
+   * completion and its own timeout via `status()` / `awaitResult()`
+   * (e.g. `Promise.race`). Only the blocking-vs-pending return
+   * contract — and that timeout carve-out — differ from
+   * `executeStatement`.
+   */
+  submitStatement(sql: string, options?: ExecuteOptions | undefined | null): Promise<AsyncStatement>
+  /**
    * Explicit close. Awaits the server-side `DeleteSession` so the
    * JS caller can observe failures (auth revoked mid-session,
    * warehouse stopped, network error). Idempotent — a second call
@@ -291,6 +566,67 @@ export declare class Connection {
    * semantics for `DeleteSession`, layer them above this method.
    */
   close(): Promise<void>
+  /**
+   * All catalogs visible to the session.
+   *
+   * JDBC `getCatalogs` shape: `TABLE_CAT: Utf8`.
+   */
+  listCatalogs(): Promise<Statement>
+  /**
+   * Schemas filtered by catalog (exact) and schema name pattern.
+   *
+   * JDBC `getSchemas` shape: `TABLE_SCHEM, TABLE_CATALOG`.
+   */
+  listSchemas(catalog?: string | undefined | null, schemaPattern?: string | undefined | null): Promise<Statement>
+  /**
+   * Tables filtered by catalog (exact), schema (pattern), table (pattern).
+   *
+   * JDBC `getTables` shape: 10 columns. `tableTypes`, when provided,
+   * filters rows by `TABLE_TYPE` kernel-side.
+   *
+   * `tableTypes` is an advisory filter. Databricks `SHOW TABLES` does
+   * NOT honour the table-type filter server-side; the kernel applies
+   * it client-side after the result returns. Callers expecting
+   * server-side rejection of off-type tables should not rely on this.
+   */
+  listTables(catalog?: string | undefined | null, schemaPattern?: string | undefined | null, tablePattern?: string | undefined | null, tableTypes?: Array<string> | undefined | null): Promise<Statement>
+  /**
+   * Columns of tables matching the filter.
+   *
+   * JDBC `getColumns` shape: 23 columns.
+   */
+  listColumns(catalog?: string | undefined | null, schemaPattern?: string | undefined | null, tablePattern?: string | undefined | null, columnPattern?: string | undefined | null): Promise<Statement>
+  /**
+   * Functions visible to the session. `catalog` is exact;
+   * `schemaPattern` and `functionPattern` are SQL LIKE.
+   */
+  listFunctions(catalog?: string | undefined | null, schemaPattern?: string | undefined | null, functionPattern?: string | undefined | null): Promise<Statement>
+  /**
+   * Procedures visible to the session. `catalog` is exact;
+   * `schemaPattern` and `procedurePattern` are SQL LIKE.
+   */
+  listProcedures(catalog?: string | undefined | null, schemaPattern?: string | undefined | null, procedurePattern?: string | undefined | null): Promise<Statement>
+  /**
+   * All table types (`TABLE`, `VIEW`, `SYSTEM TABLE`, …).
+   * No wire call — static in-memory result.
+   */
+  listTableTypes(): Promise<Statement>
+  /**
+   * SQL data types supported by the workspace.
+   * No wire call — static in-memory result.
+   */
+  listTypeInfo(): Promise<Statement>
+  /**
+   * Primary keys for the given table. All three identifiers are
+   * exact — ODBC `SQLPrimaryKeys` does not support patterns.
+   */
+  getPrimaryKeys(catalog: string, schema: string, table: string): Promise<Statement>
+  /**
+   * Foreign-key relationships. The foreign side must be fully
+   * specified (catalog + schema + table); the parent side is
+   * optional. All identifiers are exact — no LIKE patterns.
+   */
+  getCrossReference(parentCatalog: string | undefined | null, parentSchema: string | undefined | null, parentTable: string | undefined | null, foreignCatalog: string, foreignSchema: string, foreignTable: string): Promise<Statement>
 }
 /**
  * Opaque executed-statement handle.
@@ -317,6 +653,51 @@ export declare class Statement {
    * kernel / server logs which key on the same id.
    */
   get statementId(): string
+  /**
+   * Number of rows modified by the statement (UPDATE / INSERT /
+   * DELETE / MERGE). `null` for SELECT and on warehouses that don't
+   * surface the counter. Mirrors Thrift's
+   * `TGetOperationStatusResp.numModifiedRows`.
+   */
+  numModifiedRows(): Promise<number | null>
+  /**
+   * Server-supplied user-facing message. Mirrors Thrift's
+   * `TGetOperationStatusResp.displayMessage`. **PII / sensitive-
+   * data note:** may contain SQL fragments or parameter values —
+   * redact before centralised logging.
+   *
+   * Populated on `Succeeded` / `Closed-with-inline-data` paths.
+   * On terminal-error states (`Failed` / `Cancelled` /
+   * `Closed-no-data`) the kernel returns an Error instead of a
+   * `Statement`, and the same field rides on the JS Error envelope
+   * under the same `displayMessage` key.
+   */
+  displayMessage(): Promise<string | null>
+  /**
+   * Server-supplied diagnostic detail — multi-line operator /
+   * stack context. Mirrors Thrift's
+   * `TGetOperationStatusResp.diagnosticInfo`. For support surfaces,
+   * not user-facing. Same reachability + PII caveats as
+   * `displayMessage`.
+   */
+  diagnosticInfo(): Promise<string | null>
+  /**
+   * Server-supplied JSON blob with extended error details. Mirrors
+   * Thrift's `TGetOperationStatusResp.errorDetailsJson`.
+   * Pass-through string — JS callers parse with `JSON.parse` if
+   * they need structured access.
+   *
+   * **Server-side gating:** populated only when the workspace has
+   * `spark.databricks.sql.errorDetailsJson.enabled = true` on the
+   * underlying SQL cluster. The flag is internal-only / default-
+   * false in the Databricks runtime, so for most JS callers this
+   * will return `null`. Admin-enabled workspaces return content
+   * shaped like `{"errorClass": "...", "messageTemplate": "..."}`.
+   *
+   * **Unbounded:** when populated, server can return a multi-MB
+   * blob; size before logging.
+   */
+  errorDetailsJson(): Promise<string | null>
   /**
    * Pull the next batch of results. Returns `null` when the stream
    * is exhausted. The returned `ArrowBatch.ipcBytes` is a complete
@@ -348,19 +729,25 @@ export declare class Statement {
   /**
    * Server-side cancel.
    *
-   * Short-circuits to `Ok(())` if `fetchNextBatch` has already
-   * returned `null` (stream naturally exhausted) — matches the
-   * JDBC `Statement.cancel()` no-op-after-completion contract, so
-   * JS callers can fire cancel defensively without distinguishing
-   * "real cancel" from "raced with natural completion."
+   * For executed statements: short-circuits to `Ok(())` if
+   * `fetchNextBatch` has already returned `null` (stream
+   * naturally exhausted) — matches the JDBC `Statement.cancel()`
+   * no-op-after-completion contract, so JS callers can fire cancel
+   * defensively without distinguishing "real cancel" from "raced
+   * with natural completion."
+   *
+   * For metadata streams: no-op (the kernel has no in-flight
+   * cancellation surface for metadata calls today).
    *
    * Returns `KernelError(InvalidStatementHandle)` if the statement
    * has been explicitly `close()`d.
    */
   cancel(): Promise<void>
   /**
-   * Explicit close. Awaits the server-side `CloseStatement` so the
-   * JS caller can observe failures (auth revoked mid-session,
+   * Explicit close.
+   *
+   * For executed statements: awaits the server-side `CloseStatement`
+   * so the JS caller can observe failures (auth revoked mid-session,
    * network error, server-side error). Idempotent — a second call
    * on an already-closed statement returns `Ok`.
    *
@@ -376,6 +763,10 @@ export declare class Statement {
    * runtime. The JS caller can log the error but cannot drive a
    * further retry. If you need retry-on-failure semantics for
    * `CloseStatement`, layer them above this method.
+   *
+   * For metadata streams: drops the stream (no server round-trip
+   * needed — metadata results have no in-flight server-side
+   * resource to release).
    */
   close(): Promise<void>
 }

--- a/native/sea/index.js
+++ b/native/sea/index.js
@@ -310,8 +310,10 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { Connection, AuthMode, openSession, Statement, version } = nativeBinding
+const { AsyncStatement, AsyncResultHandle, Connection, AuthMode, openSession, Statement, version } = nativeBinding
 
+module.exports.AsyncStatement = AsyncStatement
+module.exports.AsyncResultHandle = AsyncResultHandle
 module.exports.Connection = Connection
 module.exports.AuthMode = AuthMode
 module.exports.openSession = openSession

--- a/tests/unit/sea/execution.test.ts
+++ b/tests/unit/sea/execution.test.ts
@@ -21,6 +21,7 @@ import { SeaNativeBinding, SeaConnection, SeaStatement } from '../../../lib/sea/
 import IClientContext, { ClientConfig } from '../../../lib/contracts/IClientContext';
 import IDBSQLLogger, { LogLevel } from '../../../lib/contracts/IDBSQLLogger';
 import HiveDriverError from '../../../lib/errors/HiveDriverError';
+import ParameterError from '../../../lib/errors/ParameterError';
 import { ConnectionOptions } from '../../../lib/contracts/IDBSQLClient';
 
 // -----------------------------------------------------------------------------
@@ -434,7 +435,7 @@ describe('SeaSessionBackend', () => {
     expect(connection.lastOptions).to.equal(undefined);
   });
 
-  it('executeStatement rejects mixing ordinal and named parameters (mutually exclusive)', async () => {
+  it('executeStatement rejects mixing ordinal and named parameters with the same ParameterError as Thrift', async () => {
     const connection = new FakeNativeConnection();
     const session = makeSession(connection);
     let thrown: unknown;
@@ -443,8 +444,10 @@ describe('SeaSessionBackend', () => {
     } catch (err) {
       thrown = err;
     }
-    expect(thrown).to.be.instanceOf(HiveDriverError);
-    expect((thrown as Error).message).to.match(/mutually exclusive/);
+    // Cross-backend parity: ThriftSessionBackend throws ParameterError with this
+    // exact message, so a caller catching ParameterError behaves identically.
+    expect(thrown).to.be.instanceOf(ParameterError);
+    expect((thrown as Error).message).to.equal('Driver does not support both ordinal and named parameters.');
   });
 
   it('executeStatement rejects queryTimeout (M1)', async () => {
@@ -519,6 +522,24 @@ describe('SeaSessionBackend', () => {
       ['getPrimaryKeys', 'main', 'def', 't'],
       ['getCrossReference', 'pc', 'ps', 'pt', 'fc', 'fs', 'ft'],
     ]);
+  });
+
+  it('getPrimaryKeys rejects an omitted catalog up front (the kernel requires one)', async () => {
+    const connection = new FakeNativeConnection();
+    const session = makeSession(connection);
+    for (const request of [{ schemaName: 'def', tableName: 't' }, { catalogName: '', schemaName: 'def', tableName: 't' }]) {
+      let thrown: unknown;
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        await session.getPrimaryKeys(request);
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown, `expected reject for ${JSON.stringify(request)}`).to.be.instanceOf(HiveDriverError);
+      expect((thrown as Error).message).to.match(/requires a catalog/);
+    }
+    // The kernel call must NOT be reached (no empty-identifier sent over FFI).
+    expect(connection.metadataCalls.filter((c) => c[0] === 'getPrimaryKeys')).to.have.length(0);
   });
 
   it('getInfo synthesizes the three server-answered info types and rejects the rest', async () => {

--- a/tests/unit/sea/execution.test.ts
+++ b/tests/unit/sea/execution.test.ts
@@ -423,7 +423,9 @@ describe('SeaSessionBackend', () => {
     const connection = new FakeNativeConnection();
     const session = makeSession(connection);
     await session.executeStatement('SELECT :x', { namedParameters: { x: 7 } });
-    const options = connection.lastOptions as { namedParams?: Array<{ name: string; sqlType: string; value?: string }> };
+    const options = connection.lastOptions as {
+      namedParams?: Array<{ name: string; sqlType: string; value?: string }>;
+    };
     expect(options.namedParams).to.have.length(1);
     expect(options.namedParams?.[0]).to.deep.equal({ name: 'x', sqlType: 'INTEGER', value: '7' });
   });
@@ -527,7 +529,10 @@ describe('SeaSessionBackend', () => {
   it('getPrimaryKeys rejects an omitted catalog up front (the kernel requires one)', async () => {
     const connection = new FakeNativeConnection();
     const session = makeSession(connection);
-    for (const request of [{ schemaName: 'def', tableName: 't' }, { catalogName: '', schemaName: 'def', tableName: 't' }]) {
+    for (const request of [
+      { schemaName: 'def', tableName: 't' },
+      { catalogName: '', schemaName: 'def', tableName: 't' },
+    ]) {
       let thrown: unknown;
       try {
         // eslint-disable-next-line no-await-in-loop

--- a/tests/unit/sea/execution.test.ts
+++ b/tests/unit/sea/execution.test.ts
@@ -77,6 +77,14 @@ class FakeNativeConnection implements SeaConnection {
 
   public lastSql?: string;
 
+  // Records the per-statement options object passed to executeStatement
+  // (undefined for the no-options path) so param-forwarding can be asserted.
+  public lastOptions?: unknown;
+
+  // Records every metadata call as `[method, ...args]` so the session
+  // backend's request → napi-argument mapping can be asserted.
+  public metadataCalls: Array<unknown[]> = [];
+
   public throwOnExecute: Error | null = null;
 
   public statementToReturn: FakeNativeStatement = new FakeNativeStatement();
@@ -84,14 +92,80 @@ class FakeNativeConnection implements SeaConnection {
   // Mirrors the kernel `Connection.sessionId` getter.
   public readonly sessionId = '01ef-fake-session-id';
 
-  // Session-level migration: per-statement options were removed, so the
-  // binding's executeStatement takes only `sql`.
-  public async executeStatement(sql: string): Promise<SeaStatement> {
+  // The merged kernel binding takes an optional per-statement `ExecuteOptions`
+  // (positional/named params, statementConf, …). Record it for assertions.
+  public async executeStatement(sql: string, options?: unknown): Promise<SeaStatement> {
     if (this.throwOnExecute) {
       throw this.throwOnExecute;
     }
     this.lastSql = sql;
+    this.lastOptions = options;
     return this.statementToReturn;
+  }
+
+  // Async-submit path (PR 2 territory); present only so the fake satisfies
+  // the full `Connection` surface. Not exercised by these tests.
+  public submitStatement(): Promise<never> {
+    throw new Error('submitStatement not used in this test');
+  }
+
+  private recordMetadata(method: string, args: unknown[]): Promise<SeaStatement> {
+    this.metadataCalls.push([method, ...args]);
+    return Promise.resolve(this.statementToReturn);
+  }
+
+  public listProcedures(catalog?: unknown, schemaPattern?: unknown, procedurePattern?: unknown) {
+    return this.recordMetadata('listProcedures', [catalog, schemaPattern, procedurePattern]);
+  }
+
+  public listCatalogs() {
+    return this.recordMetadata('listCatalogs', []);
+  }
+
+  public listSchemas(catalog?: unknown, schemaPattern?: unknown) {
+    return this.recordMetadata('listSchemas', [catalog, schemaPattern]);
+  }
+
+  public listTables(catalog?: unknown, schemaPattern?: unknown, tablePattern?: unknown, tableTypes?: unknown) {
+    return this.recordMetadata('listTables', [catalog, schemaPattern, tablePattern, tableTypes]);
+  }
+
+  public listColumns(catalog?: unknown, schemaPattern?: unknown, tablePattern?: unknown, columnPattern?: unknown) {
+    return this.recordMetadata('listColumns', [catalog, schemaPattern, tablePattern, columnPattern]);
+  }
+
+  public listFunctions(catalog?: unknown, schemaPattern?: unknown, functionPattern?: unknown) {
+    return this.recordMetadata('listFunctions', [catalog, schemaPattern, functionPattern]);
+  }
+
+  public listTableTypes() {
+    return this.recordMetadata('listTableTypes', []);
+  }
+
+  public listTypeInfo() {
+    return this.recordMetadata('listTypeInfo', []);
+  }
+
+  public getPrimaryKeys(catalog: unknown, schema: unknown, table: unknown) {
+    return this.recordMetadata('getPrimaryKeys', [catalog, schema, table]);
+  }
+
+  public getCrossReference(
+    parentCatalog: unknown,
+    parentSchema: unknown,
+    parentTable: unknown,
+    foreignCatalog: unknown,
+    foreignSchema: unknown,
+    foreignTable: unknown,
+  ) {
+    return this.recordMetadata('getCrossReference', [
+      parentCatalog,
+      parentSchema,
+      parentTable,
+      foreignCatalog,
+      foreignSchema,
+      foreignTable,
+    ]);
   }
 
   public async close(): Promise<void> {
@@ -333,29 +407,44 @@ describe('SeaSessionBackend', () => {
     expect(op.id).to.be.a('string').and.have.length.greaterThan(0);
   });
 
-  it('executeStatement rejects namedParameters (M1)', async () => {
+  it('executeStatement forwards ordinalParameters as napi positionalParams', async () => {
     const connection = new FakeNativeConnection();
     const session = makeSession(connection);
-    let thrown: unknown;
-    try {
-      await session.executeStatement('SELECT :x', { namedParameters: { x: 1 } });
-    } catch (err) {
-      thrown = err;
-    }
-    expect(thrown).to.be.instanceOf(HiveDriverError);
-    expect((thrown as Error).message).to.match(/parameters/);
+    await session.executeStatement('SELECT ?', { ordinalParameters: [42, 'hi'] });
+    const options = connection.lastOptions as { positionalParams?: Array<{ sqlType: string; value?: string }> };
+    expect(options, 'options should be passed').to.not.equal(undefined);
+    expect(options.positionalParams).to.have.length(2);
+    expect(options.positionalParams?.[0]).to.deep.equal({ sqlType: 'INTEGER', value: '42' });
+    expect(options.positionalParams?.[1]).to.deep.equal({ sqlType: 'STRING', value: 'hi' });
   });
 
-  it('executeStatement rejects ordinalParameters (M1)', async () => {
+  it('executeStatement forwards namedParameters as napi namedParams (:name carried)', async () => {
+    const connection = new FakeNativeConnection();
+    const session = makeSession(connection);
+    await session.executeStatement('SELECT :x', { namedParameters: { x: 7 } });
+    const options = connection.lastOptions as { namedParams?: Array<{ name: string; sqlType: string; value?: string }> };
+    expect(options.namedParams).to.have.length(1);
+    expect(options.namedParams?.[0]).to.deep.equal({ name: 'x', sqlType: 'INTEGER', value: '7' });
+  });
+
+  it('executeStatement sends no options object on the no-params path', async () => {
+    const connection = new FakeNativeConnection();
+    const session = makeSession(connection);
+    await session.executeStatement('SELECT 1', {});
+    expect(connection.lastOptions).to.equal(undefined);
+  });
+
+  it('executeStatement rejects mixing ordinal and named parameters (mutually exclusive)', async () => {
     const connection = new FakeNativeConnection();
     const session = makeSession(connection);
     let thrown: unknown;
     try {
-      await session.executeStatement('SELECT ?', { ordinalParameters: [1] });
+      await session.executeStatement('SELECT ?, :x', { ordinalParameters: [1], namedParameters: { x: 2 } });
     } catch (err) {
       thrown = err;
     }
     expect(thrown).to.be.instanceOf(HiveDriverError);
+    expect((thrown as Error).message).to.match(/mutually exclusive/);
   });
 
   it('executeStatement rejects queryTimeout (M1)', async () => {
@@ -393,31 +482,60 @@ describe('SeaSessionBackend', () => {
     });
   }
 
-  it('metadata methods throw deferred-M1 errors', async () => {
+  // Metadata calls forward to the kernel's metadata surface and wrap the
+  // returned napi `Statement` as a `SeaOperationBackend`. Each case asserts
+  // the request → napi-argument mapping (the only logic the driver owns).
+  it('metadata calls forward to the napi binding with mapped arguments', async () => {
     const connection = new FakeNativeConnection();
     const session = makeSession(connection);
-    for (const method of [
-      'getInfo',
-      'getTypeInfo',
-      'getCatalogs',
-      'getSchemas',
-      'getTables',
-      'getTableTypes',
-      'getColumns',
-      'getFunctions',
-      'getPrimaryKeys',
-      'getCrossReference',
-    ] as const) {
-      let thrown: unknown;
-      try {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        await (session as any)[method]({});
-      } catch (err) {
-        thrown = err;
-      }
-      expect(thrown, `expected ${method} to throw`).to.be.instanceOf(HiveDriverError);
-      expect((thrown as Error).message).to.match(/M1|not implemented/);
+
+    const op = await session.getCatalogs({});
+    expect(op).to.be.instanceOf(SeaOperationBackend);
+
+    await session.getSchemas({ catalogName: 'main', schemaName: 'def%' });
+    await session.getTables({ catalogName: 'main', schemaName: 'def', tableName: 't%', tableTypes: ['TABLE', 'VIEW'] });
+    await session.getColumns({ catalogName: 'main', schemaName: 'def', tableName: 't', columnName: 'c%' });
+    await session.getFunctions({ catalogName: 'main', schemaName: 'def', functionName: 'f%' });
+    await session.getTableTypes({});
+    await session.getTypeInfo({});
+    await session.getPrimaryKeys({ catalogName: 'main', schemaName: 'def', tableName: 't' });
+    await session.getCrossReference({
+      parentCatalogName: 'pc',
+      parentSchemaName: 'ps',
+      parentTableName: 'pt',
+      foreignCatalogName: 'fc',
+      foreignSchemaName: 'fs',
+      foreignTableName: 'ft',
+    });
+
+    expect(connection.metadataCalls).to.deep.equal([
+      ['listCatalogs'],
+      ['listSchemas', 'main', 'def%'],
+      ['listTables', 'main', 'def', 't%', ['TABLE', 'VIEW']],
+      ['listColumns', 'main', 'def', 't', 'c%'],
+      ['listFunctions', 'main', 'def', 'f%'],
+      ['listTableTypes'],
+      ['listTypeInfo'],
+      ['getPrimaryKeys', 'main', 'def', 't'],
+      ['getCrossReference', 'pc', 'ps', 'pt', 'fc', 'fs', 'ft'],
+    ]);
+  });
+
+  it('getInfo synthesizes the three server-answered info types and rejects the rest', async () => {
+    const connection = new FakeNativeConnection();
+    const session = makeSession(connection);
+    // CLI_DBMS_NAME (17) → "Spark SQL".
+    const info = await session.getInfo(17);
+    expect(info.getValue()).to.equal('Spark SQL');
+    // An unsupported info type (e.g. CLI_MAX_DRIVER_CONNECTIONS) is rejected,
+    // mirroring the Thrift server's reject-unsupported behaviour.
+    let thrown: unknown;
+    try {
+      await session.getInfo(0);
+    } catch (err) {
+      thrown = err;
     }
+    expect(thrown).to.be.instanceOf(HiveDriverError);
   });
 
   it('close() forwards to the native connection', async () => {

--- a/tests/unit/sea/inputValidation.test.ts
+++ b/tests/unit/sea/inputValidation.test.ts
@@ -27,7 +27,9 @@ describe('SeaInputValidation.assertBindableValue', () => {
     expect(() => assertBindableValue(null, 'p')).to.not.throw();
     expect(() => assertBindableValue(new Date(), 'p')).to.not.throw();
     expect(() => assertBindableValue(new Int64(5), 'p')).to.not.throw();
-    expect(() => assertBindableValue(new DBSQLParameter({ type: DBSQLParameterType.INTEGER, value: 1 }), 'p')).to.not.throw();
+    expect(() =>
+      assertBindableValue(new DBSQLParameter({ type: DBSQLParameterType.INTEGER, value: 1 }), 'p'),
+    ).to.not.throw();
   });
 
   it('rejects arrays (compound types)', () => {

--- a/tests/unit/sea/inputValidation.test.ts
+++ b/tests/unit/sea/inputValidation.test.ts
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Databricks, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { expect } from 'chai';
+import Int64 from 'node-int64';
+import assertBindableValue from '../../../lib/sea/SeaInputValidation';
+import { DBSQLParameter, DBSQLParameterType } from '../../../lib/DBSQLParameter';
+import ParameterError from '../../../lib/errors/ParameterError';
+
+describe('SeaInputValidation.assertBindableValue', () => {
+  it('accepts scalars, Date, Int64, bigint, null, and DBSQLParameter', () => {
+    expect(() => assertBindableValue(42, 'p')).to.not.throw();
+    expect(() => assertBindableValue('x', 'p')).to.not.throw();
+    expect(() => assertBindableValue(true, 'p')).to.not.throw();
+    expect(() => assertBindableValue(BigInt(10), 'p')).to.not.throw();
+    expect(() => assertBindableValue(null, 'p')).to.not.throw();
+    expect(() => assertBindableValue(new Date(), 'p')).to.not.throw();
+    expect(() => assertBindableValue(new Int64(5), 'p')).to.not.throw();
+    expect(() => assertBindableValue(new DBSQLParameter({ type: DBSQLParameterType.INTEGER, value: 1 }), 'p')).to.not.throw();
+  });
+
+  it('rejects arrays (compound types)', () => {
+    expect(() => assertBindableValue([1, 2, 3] as never, 'ordinalParameters[0]')).to.throw(ParameterError, /array/);
+  });
+
+  it('rejects plain objects', () => {
+    expect(() => assertBindableValue({ a: 1 } as never, 'p')).to.throw(ParameterError, /object/);
+  });
+});

--- a/tests/unit/sea/positionalParams.test.ts
+++ b/tests/unit/sea/positionalParams.test.ts
@@ -39,6 +39,27 @@ describe('SeaPositionalParams.buildSeaPositionalParams', () => {
     ).to.deep.equal([{ sqlType: 'DECIMAL(3,0)', value: '-123' }]);
   });
 
+  it('clamps DECIMAL precision to the Databricks max of 38', () => {
+    // 40 integer digits → precision clamped to 38 (scale 0).
+    expect(
+      buildSeaPositionalParams([
+        new DBSQLParameter({ type: DBSQLParameterType.DECIMAL, value: '1234567890123456789012345678901234567890' }),
+      ]),
+    ).to.deep.equal([{ sqlType: 'DECIMAL(38,0)', value: '1234567890123456789012345678901234567890' }]);
+  });
+
+  it('collapses every INTERVAL subtype to the kernel codec\'s single "INTERVAL" type name', () => {
+    expect(
+      buildSeaPositionalParams([
+        new DBSQLParameter({ type: DBSQLParameterType.INTERVALMONTH, value: '13' }),
+        new DBSQLParameter({ type: DBSQLParameterType.INTERVALDAY, value: '1 02:03:04' }),
+      ]),
+    ).to.deep.equal([
+      { sqlType: 'INTERVAL', value: '13' },
+      { sqlType: 'INTERVAL', value: '1 02:03:04' },
+    ]);
+  });
+
   it('maps NULL to a value-less VOID input', () => {
     expect(buildSeaPositionalParams([null])).to.deep.equal([{ sqlType: 'VOID' }]);
   });

--- a/tests/unit/sea/positionalParams.test.ts
+++ b/tests/unit/sea/positionalParams.test.ts
@@ -15,6 +15,7 @@
 import { expect } from 'chai';
 import { buildSeaPositionalParams, buildSeaNamedParams } from '../../../lib/sea/SeaPositionalParams';
 import { DBSQLParameter, DBSQLParameterType } from '../../../lib/DBSQLParameter';
+import ParameterError from '../../../lib/errors/ParameterError';
 
 describe('SeaPositionalParams.buildSeaPositionalParams', () => {
   it('returns undefined for no params (keeps the no-options fast path)', () => {
@@ -30,22 +31,36 @@ describe('SeaPositionalParams.buildSeaPositionalParams', () => {
     ]);
   });
 
+  const decimal = (value: string) => () =>
+    buildSeaPositionalParams([new DBSQLParameter({ type: DBSQLParameterType.DECIMAL, value })]);
+
   it('emits DECIMAL in the parenthesised DECIMAL(p,s) form the kernel codec requires', () => {
-    expect(
-      buildSeaPositionalParams([new DBSQLParameter({ type: DBSQLParameterType.DECIMAL, value: '99.99' })]),
-    ).to.deep.equal([{ sqlType: 'DECIMAL(4,2)', value: '99.99' }]);
-    expect(
-      buildSeaPositionalParams([new DBSQLParameter({ type: DBSQLParameterType.DECIMAL, value: '-123' })]),
-    ).to.deep.equal([{ sqlType: 'DECIMAL(3,0)', value: '-123' }]);
+    expect(decimal('99.99')()).to.deep.equal([{ sqlType: 'DECIMAL(4,2)', value: '99.99' }]);
+    expect(decimal('-123')()).to.deep.equal([{ sqlType: 'DECIMAL(3,0)', value: '-123' }]);
   });
 
-  it('clamps DECIMAL precision to the Databricks max of 38', () => {
-    // 40 integer digits → precision clamped to 38 (scale 0).
-    expect(
-      buildSeaPositionalParams([
-        new DBSQLParameter({ type: DBSQLParameterType.DECIMAL, value: '1234567890123456789012345678901234567890' }),
-      ]),
-    ).to.deep.equal([{ sqlType: 'DECIMAL(38,0)', value: '1234567890123456789012345678901234567890' }]);
+  it('excludes insignificant leading zeros from precision (Spark decimal-literal rule)', () => {
+    // 0.00001 → DECIMAL(5,5), not DECIMAL(6,5) (the integer "0" is not significant).
+    expect(decimal('0.00001')()).to.deep.equal([{ sqlType: 'DECIMAL(5,5)', value: '0.00001' }]);
+    // "007.50" → significant int "7" (1) + scale 2 ⇒ DECIMAL(3,2).
+    expect(decimal('007.50')()).to.deep.equal([{ sqlType: 'DECIMAL(3,2)', value: '007.50' }]);
+    // "0" ⇒ DECIMAL(1,0) (minimum precision 1).
+    expect(decimal('0')()).to.deep.equal([{ sqlType: 'DECIMAL(1,0)', value: '0' }]);
+  });
+
+  it('rejects a DECIMAL that needs precision > 38 instead of clamping-and-sending', () => {
+    // 40 integer digits can't fit DECIMAL(38,…); clamping the type while sending
+    // the full value is internally inconsistent — reject at bind time instead.
+    expect(decimal('1234567890123456789012345678901234567890')).to.throw(
+      ParameterError,
+      /exceeding the Databricks maximum of 38/,
+    );
+  });
+
+  it('rejects a non-numeric / exponential DECIMAL value', () => {
+    expect(decimal('1e+21')).to.throw(ParameterError, /not a plain decimal numeral/);
+    expect(decimal('abc')).to.throw(ParameterError, /not a plain decimal numeral/);
+    expect(decimal('')).to.throw(ParameterError, /not a plain decimal numeral/);
   });
 
   it('collapses every INTERVAL subtype to the kernel codec\'s single "INTERVAL" type name', () => {

--- a/tests/unit/sea/positionalParams.test.ts
+++ b/tests/unit/sea/positionalParams.test.ts
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Databricks, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { expect } from 'chai';
+import { buildSeaPositionalParams, buildSeaNamedParams } from '../../../lib/sea/SeaPositionalParams';
+import { DBSQLParameter, DBSQLParameterType } from '../../../lib/DBSQLParameter';
+
+describe('SeaPositionalParams.buildSeaPositionalParams', () => {
+  it('returns undefined for no params (keeps the no-options fast path)', () => {
+    expect(buildSeaPositionalParams(undefined)).to.equal(undefined);
+    expect(buildSeaPositionalParams([])).to.equal(undefined);
+  });
+
+  it('infers types from raw values, matching DBSQLParameter rules', () => {
+    expect(buildSeaPositionalParams([42, 'hello', true])).to.deep.equal([
+      { sqlType: 'INTEGER', value: '42' },
+      { sqlType: 'STRING', value: 'hello' },
+      { sqlType: 'BOOLEAN', value: 'TRUE' },
+    ]);
+  });
+
+  it('emits DECIMAL in the parenthesised DECIMAL(p,s) form the kernel codec requires', () => {
+    expect(
+      buildSeaPositionalParams([new DBSQLParameter({ type: DBSQLParameterType.DECIMAL, value: '99.99' })]),
+    ).to.deep.equal([{ sqlType: 'DECIMAL(4,2)', value: '99.99' }]);
+    expect(
+      buildSeaPositionalParams([new DBSQLParameter({ type: DBSQLParameterType.DECIMAL, value: '-123' })]),
+    ).to.deep.equal([{ sqlType: 'DECIMAL(3,0)', value: '-123' }]);
+  });
+
+  it('maps NULL to a value-less VOID input', () => {
+    expect(buildSeaPositionalParams([null])).to.deep.equal([{ sqlType: 'VOID' }]);
+  });
+
+  it('honours explicit DATE / TIMESTAMP types', () => {
+    expect(
+      buildSeaPositionalParams([
+        new DBSQLParameter({ type: DBSQLParameterType.DATE, value: '2024-01-15' }),
+        new DBSQLParameter({ type: DBSQLParameterType.TIMESTAMP, value: '2024-01-15 10:30:00' }),
+      ]),
+    ).to.deep.equal([
+      { sqlType: 'DATE', value: '2024-01-15' },
+      { sqlType: 'TIMESTAMP', value: '2024-01-15 10:30:00' },
+    ]);
+  });
+});
+
+describe('SeaPositionalParams.buildSeaNamedParams', () => {
+  it('returns undefined for no named params', () => {
+    expect(buildSeaNamedParams(undefined)).to.equal(undefined);
+    expect(buildSeaNamedParams({})).to.equal(undefined);
+  });
+
+  it('emits {name, sqlType, value} triples, reusing the same type mapping', () => {
+    expect(
+      buildSeaNamedParams({
+        n: 42,
+        s: 'hello',
+        d: new DBSQLParameter({ type: DBSQLParameterType.DECIMAL, value: '99.99' }),
+      }),
+    ).to.deep.include.members([
+      { name: 'n', sqlType: 'INTEGER', value: '42' },
+      { name: 's', sqlType: 'STRING', value: 'hello' },
+      { name: 'd', sqlType: 'DECIMAL(4,2)', value: '99.99' },
+    ]);
+  });
+
+  it('maps a named NULL to a value-less VOID input (with the name)', () => {
+    expect(buildSeaNamedParams({ x: null })).to.deep.equal([{ name: 'x', sqlType: 'VOID' }]);
+  });
+});

--- a/tests/unit/sea/serverInfo.test.ts
+++ b/tests/unit/sea/serverInfo.test.ts
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Databricks, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { expect } from 'chai';
+import {
+  seaServerInfoValue,
+  SEA_DBMS_NAME,
+  SEA_SERVER_NAME,
+  SEA_DBMS_VERSION,
+} from '../../../lib/sea/SeaServerInfo';
+import { TGetInfoType } from '../../../thrift/TCLIService_types';
+
+describe('SeaServerInfo.seaServerInfoValue', () => {
+  it('CLI_DBMS_NAME matches Thrift exactly ("Spark SQL")', () => {
+    expect(seaServerInfoValue(TGetInfoType.CLI_DBMS_NAME)?.stringValue).to.equal('Spark SQL');
+    expect(SEA_DBMS_NAME).to.equal('Spark SQL');
+  });
+
+  it('CLI_DBMS_VER matches the Thrift server version constant', () => {
+    expect(seaServerInfoValue(TGetInfoType.CLI_DBMS_VER)?.stringValue).to.equal('3.1.1');
+    expect(SEA_DBMS_VERSION).to.equal('3.1.1');
+  });
+
+  it('CLI_SERVER_NAME matches Thrift exactly ("Spark SQL")', () => {
+    const v = seaServerInfoValue(TGetInfoType.CLI_SERVER_NAME)?.stringValue;
+    expect(v).to.equal(SEA_SERVER_NAME);
+    expect(v).to.equal('Spark SQL');
+  });
+
+  it('all three answered info types are byte-identical to Thrift', () => {
+    expect(seaServerInfoValue(TGetInfoType.CLI_SERVER_NAME)?.stringValue).to.equal('Spark SQL');
+    expect(seaServerInfoValue(TGetInfoType.CLI_DBMS_NAME)?.stringValue).to.equal('Spark SQL');
+    expect(seaServerInfoValue(TGetInfoType.CLI_DBMS_VER)?.stringValue).to.equal('3.1.1');
+  });
+
+  it('returns undefined for info types the Thrift server rejects (e.g. CLI_MAX_DRIVER_CONNECTIONS)', () => {
+    expect(seaServerInfoValue(TGetInfoType.CLI_MAX_DRIVER_CONNECTIONS)).to.equal(undefined);
+    expect(seaServerInfoValue(TGetInfoType.CLI_USER_NAME)).to.equal(undefined);
+    expect(seaServerInfoValue(99999)).to.equal(undefined);
+  });
+});

--- a/tests/unit/sea/serverInfo.test.ts
+++ b/tests/unit/sea/serverInfo.test.ts
@@ -13,12 +13,7 @@
 // limitations under the License.
 
 import { expect } from 'chai';
-import {
-  seaServerInfoValue,
-  SEA_DBMS_NAME,
-  SEA_SERVER_NAME,
-  SEA_DBMS_VERSION,
-} from '../../../lib/sea/SeaServerInfo';
+import { seaServerInfoValue, SEA_DBMS_NAME, SEA_SERVER_NAME, SEA_DBMS_VERSION } from '../../../lib/sea/SeaServerInfo';
 import { TGetInfoType } from '../../../thrift/TCLIService_types';
 
 describe('SeaServerInfo.seaServerInfoValue', () => {


### PR DESCRIPTION
## What

Consolidates three SEA session-backend capabilities into one focused PR, each a **thin adapter over the merged kernel** (which does the heavy lifting):

### 1. Bound parameters
- Forwards `ordinalParameters` / `namedParameters` to the kernel's `ExecuteOptions.positionalParams` / `namedParams`.
- Reuses the existing `DBSQLParameter.toSparkParameter` codec (the same type-inference the Thrift path uses), then adapts the type name to the kernel codec: `DECIMAL` → `DECIMAL(p,s)`, `INTERVAL *` → `INTERVAL`, missing value → `VOID`/NULL.
- Positional (`?`) and named (`:name`) parameters are **mutually exclusive** — rejected up-front.

### 2. Metadata
- `getCatalogs` / `getSchemas` / `getTables` / `getColumns` / `getFunctions` / `getTableTypes` / `getTypeInfo` / `getPrimaryKeys` / `getCrossReference` forward to the kernel `Connection.list*` / `get*` methods and wrap the returned `Statement`.
- The kernel owns SQL synthesis, column projection, and the client-side `TABLE_TYPE` filter — the driver only maps request fields to positional arguments. (The previously-proposed driver-side `SeaTableTypeFilter` is therefore **not needed** and was dropped.)

### 3. getInfo
- Synthesized client-side (the SEA REST protocol / kernel have no `getInfo` endpoint), mirroring the three `TGetInfoType` values the Databricks Thrift server answers (server name / DBMS name / DBMS version) and rejecting every other value — byte-identical to the Thrift path.

## Notes
- `SeaInputValidation` is slimmed to the single bind-time gate the driver genuinely needs (`assertBindableValue`); parameter-marker counting is the kernel's job, so the JS SQL-walk was removed to avoid drift.
- `SeaNativeLoader` **re-exports** the kernel's `ExecuteOptions` / `TypedValueInput` / `NamedTypedValueInput` types rather than re-declaring them, so driver param shapes can't drift from the kernel contract.
- Regenerates the committed napi `.d.ts` snapshot against the merged kernel (matches how prior SEA PRs #380 / #409 landed binding updates).

## Testing
- Full unit suite green (1112 passing); `lib/` lints clean.
- **Validated against a live warehouse** via the SEA path: positional + named params return bound values, mutual-exclusion is rejected, all 9 metadata calls return rows (incl. kernel-side `tableTypes=[VIEW]` filter), and `getInfo(CLI_DBMS_NAME)` returns `Spark SQL`.

This pull request and its description were written by Isaac.