### PR TITLE
ci: run main.yml checks on merge_group (prerequisite for a merge queue)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
     branches:
       - main
+  # Run the same required checks (lint / unit-test / e2e-test / coverage) on the
+  # merge queue's transient ref. Required so a merge queue can be enabled on
+  # `main`: the queue waits on these checks for each merge group, and without a
+  # `merge_group` trigger they would never run and every queued PR would stall.
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Why

Prerequisite for enabling a **merge queue** on `main`. A merge queue gates each merge group on the branch's required status checks — but those checks only run if their workflow triggers on the **`merge_group`** event. `main.yml` currently triggers on `push`/`pull_request` only, so enabling a queue without this change would leave every queued PR **stalled** waiting for checks that never run.

## What

Adds `merge_group:` to `main.yml`'s `on:` block. All four required-check jobs (`lint`, `unit-test (14/16/18/20)`, `e2e-test`, `coverage`) have no event-level guards, so they run on the merge-group ref exactly as on `pull_request`. Mirrors the Python connector (`code-coverage.yml` runs on `merge_group` for the same reason).

## Sequence

1. **This PR** (merge_group trigger) — merge first.
2. Then add the `merge_queue` rule to the `main` ruleset (Squash / ALLGREEN, mirroring Python).

Enabling the queue before this lands would stall merges, so this must go first.

This pull request and its description were written by Isaac.