### PR TITLE
[SEA-NodeJS] Sync execute via directResults: fix CREATE, drop close-drives, keep mid-run cancel

### DIFF
--- a/lib/sea/SeaSessionBackend.ts
+++ b/lib/sea/SeaSessionBackend.ts
@@ -183,24 +183,31 @@ export default class SeaSessionBackend implements ISessionBackend {
       options.queryTimeout !== undefined ? numberToInt64(options.queryTimeout).toNumber() : undefined;
 
     if (!runAsync) {
-      // Sync path: forward `queryTimeoutSecs` to the napi options — the kernel
-      // `execute()` honours it (server statement timeout).
+      // DEFAULT — directResults (the Thrift / JDBC / Python use_sea model). The
+      // kernel sends ExecuteStatement with the server inline wait (~10s default
+      // + on_wait_timeout=CONTINUE) and returns WITHOUT polling past it, as a
+      // single `AsyncStatement` handle:
+      //   - a fast query comes back seeded with the inline result, so the first
+      //     fetch/status is served with zero extra round-trips (and is
+      //     404-proof — a terminal handle never polls a released statement);
+      //   - a slow query comes back as a poll/cancel handle.
+      // Either way the handle is tied to a server-owned statement, so a long
+      // query stays cancellable (`asyncStatement.cancel()`) and `close()` is a
+      // clean release — no eager-handle / close-drives workaround. Fire-and-
+      // forget DDL/DML commits because the server runs it inline during the POST.
       const execOptions = this.buildExecuteOptions(options, queryTimeoutSecs);
-      let cancellableExecution;
+      let asyncStatement;
       try {
-        cancellableExecution =
+        asyncStatement =
           execOptions === undefined
-            ? await this.connection.executeStatementCancellable(statement)
-            : await this.connection.executeStatementCancellable(statement, execOptions);
+            ? await this.connection.executeStatement(statement)
+            : await this.connection.executeStatement(statement, execOptions);
       } catch (err) {
         throw this.logAndMapError('executeStatement', err);
       }
       return new SeaOperationBackend({
-        cancellableExecution: cancellableExecution!,
+        asyncStatement,
         context: this.context,
-        // The kernel honours `queryTimeoutSecs` on the sync `execute` path, so
-        // it is forwarded via the napi options (see `buildExecuteOptions`); the
-        // backend also keeps it as a deadline guard for parity with async.
         queryTimeoutSecs,
       });
     }

--- a/native/sea/index.d.ts
+++ b/native/sea/index.d.ts
@@ -142,8 +142,8 @@ export const enum AuthMode {
  * Authentication is selected by `authMode` (default [`AuthMode::Pat`]):
  * - `Pat` — `token` required.
  * - `OAuthM2m` — `oauthClientId` + `oauthClientSecret` required.
- * - `OAuthU2m` — `oauthClientId` / `oauthRedirectPort` optional (kernel
- *   defaults to the `databricks-cli` client on port 8020).
+ * - `OAuthU2m` — `oauthClientId` / `oauthRedirectPort` optional
+ *   (defaults to the `databricks-sql-connector` client on port 8020).
  *
  * Catalog / schema / sessionConf are applied once at session creation
  * and remain in effect for every statement run on the resulting
@@ -174,7 +174,7 @@ export interface ConnectionOptions {
   token?: string
   /**
    * OAuth client id. Required for [`AuthMode::OAuthM2m`]; optional for
-   * [`AuthMode::OAuthU2m`] (kernel defaults to `databricks-cli`).
+   * [`AuthMode::OAuthU2m`] (defaults to `databricks-sql-connector`).
    */
   oauthClientId?: string
   /** OAuth client secret. Required for [`AuthMode::OAuthM2m`]. */
@@ -575,21 +575,25 @@ export declare class Connection {
    */
   get sessionId(): string
   /**
-   * Execute a SQL statement and return a Statement handle that
-   * streams batches via `fetchNextBatch()`.
+   * Execute a SQL statement (directResults — the Thrift / JDBC / Python
+   * `use_sea` model) and return a single `AsyncStatement` handle. Sends
+   * ExecuteStatement with the server inline wait (`wait_timeout` default ~10s,
+   * `on_wait_timeout=CONTINUE`) and returns WITHOUT polling past it.
    *
-   * Catalog / schema / sessionConf are session-level
-   * (`openSession`). Per-statement options on `ExecuteOptions`:
-   * - `statementConf` — per-statement Spark conf overlay
-   * - `queryTags` — serialised to a comma-separated `key:value`
-   *   string and placed in `statement_conf["query_tags"]`,
-   *   matching NodeJS Thrift's `serializeQueryTags` wire shape
+   * The handle is uniform regardless of whether the query finished within the
+   * inline wait:
+   * - **fast query** — the handle is seeded with the inline result, so
+   *   `awaitResult()` returns it with zero extra round-trips and `status()`
+   *   reports the terminal state without a poll (the latency fast path; also
+   *   404-proof — a terminal handle never polls a released statement);
+   * - **slow query** — the handle is a poll/cancel handle the caller drives
+   *   (`status()` / `awaitResult()` / `cancel()`).
    *
-   * `options` is omitted/`None` for the no-options path; passing
-   * `{ statementConf: {} }` (an empty map) is treated the same as
-   * omission to keep the wire shape stable for the common case.
+   * This is the path that gives mid-run cancel for long queries WITHOUT the
+   * eager-handle / close-drives workaround: the returned handle always
+   * corresponds to a server-owned statement, and `close()` is a clean release.
    */
-  executeStatement(sql: string, options?: ExecuteOptions | undefined | null): Promise<Statement>
+  executeStatement(sql: string, options?: ExecuteOptions | undefined | null): Promise<AsyncStatement>
   /**
    * Execute a SQL statement on the blocking (sync) path, but return a
    * `CancellableExecution` handle so a concurrent JS task can cancel

--- a/tests/unit/sea/execution.test.ts
+++ b/tests/unit/sea/execution.test.ts
@@ -210,20 +210,9 @@ class FakeNativeConnection implements SeaConnection {
   // sync `runAsync: false` query path — the DEFAULT).
   public lastCancellableExecution?: FakeCancellableExecution;
 
-  // The bare blocking executeStatement path: the SEA backend's sync default
-  // routes through executeStatementCancellable (below), but the binding still
-  // exposes this for completeness.
-  public async executeStatement(sql: string, options?: unknown): Promise<SeaStatement> {
-    if (this.throwOnExecute) {
-      throw this.throwOnExecute;
-    }
-    this.lastSql = sql;
-    this.lastOptions = options;
-    return this.statementToReturn;
-  }
-
-  // Sync (`runAsync: false`, the DEFAULT) query path: records sql + options and
-  // returns a pending CancellableExecution whose result() drives the execute.
+  // Sync (`runAsync: false`) cancellable query path (retained for the
+  // executeStatementCancellable binding; the default execute path is the
+  // directResults `executeStatement` below).
   public async executeStatementCancellable(sql: string, options?: unknown): Promise<any> {
     if (this.throwOnExecute) {
       throw this.throwOnExecute;
@@ -232,6 +221,21 @@ class FakeNativeConnection implements SeaConnection {
     this.lastOptions = options;
     this.lastCancellableExecution = new FakeCancellableExecution();
     return this.lastCancellableExecution;
+  }
+
+  // directResults (`runAsync: false`, the DEFAULT) query path: records sql +
+  // options and returns a single `AsyncStatement` handle — the kernel `execute()`
+  // sends the inline-wait POST and returns one handle (seeded with the inline
+  // result on the fast path, a poll/cancel handle otherwise). `submitStatusValue`
+  // configures the state it reports.
+  public async executeStatement(sql: string, options?: unknown): Promise<any> {
+    if (this.throwOnExecute) {
+      throw this.throwOnExecute;
+    }
+    this.lastSql = sql;
+    this.lastOptions = options;
+    this.lastAsyncStatement = new FakeAsyncStatement(this.submitStatusValue);
+    return this.lastAsyncStatement;
   }
 
   // Async-submit path: records sql + per-statement options (for forwarding


### PR DESCRIPTION
## What

The default sync (`runAsync: false`) path now calls the kernel's folded directResults `execute()` (`Connection.executeStatement`), which returns a **single** `AsyncStatement` handle. The session wraps it with the operation backend's existing `asyncStatement` arm — **no arm to feature-detect**.

## Why this fixes the SEA gaps

The returned handle always corresponds to a server-owned statement:

- **fire-and-forget `CREATE`/`INSERT` commits** — the server runs it inline during the POST. Fixes the prior lazy-execute "CREATE didn't run" bug.
- **`close()` is a clean release**, never a drive-to-terminal — the eager-handle + close-drives workaround is gone.
- **mid-run cancel** via `op.cancel()` (`asyncStatement.cancel()`) once the handle is held (~80–300ms), at parity with the Thrift backend.
- **errors surface at `executeStatement`**, matching Thrift / Python `use_kernel`.

On the fast path the kernel handle is **seeded with the inline result**, so the first fetch/status is served with zero extra round-trips (and is 404-proof — a terminal handle never polls a released statement). On a warehouse that auto-closes the statement (`state=CLOSED`) after delivering its inline result, the kernel maps `CLOSED → Succeeded`, so this path no longer throws `OperationStateError(Closed)`.

This replaces the earlier enum approach (`executeStatement` returning a terminal `Statement` *or* an `AsyncStatement`, feature-detected via `awaitResult`) — one uniform handle.

## Dependency

Requires the kernel folded directResults `execute()`: databricks/databricks-sql-kernel#136. Regenerated napi router types (`executeStatement` now returns `AsyncStatement`); fallback package names stay on the driver's canonical `@databricks/sql-kernel-*`.

## Testing

Validated e2e (pecotesting) against **auto-closing AND non-auto-closing** warehouses: CREATE fire-and-forget commits (**12/12 = Thrift parity**), fetch-then-close (**12/12**), mid-run cancel, `close()` cheap (~140ms) on an abandoned long query, `SELECT 1` p50 179ms vs Thrift 168ms. Unit: SEA suite **247 passing**; eslint clean.

This pull request and its description were written by Isaac.
