### PR TITLE
prepare release 1.16.0-rc.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@databricks/sql",
-  "version": "1.15.0",
+  "version": "1.16.0-rc.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@databricks/sql",
-      "version": "1.15.0",
+      "version": "1.16.0-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "apache-arrow": "^13.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks/sql",
-  "version": "1.15.0",
+  "version": "1.16.0-rc.1",
   "description": "Driver for connection to Databricks SQL via Thrift API.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
Bump version to `1.16.0-rc.1` — a **pre-release / release candidate** so we can publish the npm-consumed kernel end-to-end and test the real artifact before GA.

- Publishes to the **`next`** dist-tag (not `latest`); `latest` stays `1.15.0`, so no `^`-range user auto-upgrades to the RC.
- First release that consumes `@databricks/databricks-sql-kernel-*@0.2.0` via `optionalDependencies` (merged in #434).
- No permanent `CHANGELOG.md` section yet — finalized at GA (`1.16.0`).

## Test plan
- [x] `npm install --package-lock-only` updates only the `version` fields in the lockfile
- [ ] CI green (note: `unit-test (14)` will be red until JFrog `db-npm` curation clears the 7-day cooldown on kernel `0.2.0` — same as #434)
- [ ] Dry-run release validates the secure pipeline handles the new optional deps + publishes to `next`

This pull request and its description were written by Isaac.