### PR TITLE
fix: repoint flatbuffers lockfile URLs to registry.npmjs.org

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3120,7 +3120,7 @@
     },
     "node_modules/flatbuffers": {
       "version": "23.5.26",
-      "resolved": "https://npm-proxy.dev.databricks.com/flatbuffers/-/flatbuffers-23.5.26.tgz",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-23.5.26.tgz",
       "integrity": "sha512-vE+SI9vrJDwi1oETtTIFldC/o9GsVKRM+s6EL0nQgxXlYV1Vc4Tk30hj4xGICftInKQKj1F3up2n8UbIVobISQ==",
       "license": "SEE LICENSE IN LICENSE"
     },
@@ -8823,7 +8823,7 @@
     },
     "flatbuffers": {
       "version": "23.5.26",
-      "resolved": "https://npm-proxy.dev.databricks.com/flatbuffers/-/flatbuffers-23.5.26.tgz",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-23.5.26.tgz",
       "integrity": "sha512-vE+SI9vrJDwi1oETtTIFldC/o9GsVKRM+s6EL0nQgxXlYV1Vc4Tk30hj4xGICftInKQKj1F3up2n8UbIVobISQ=="
     },
     "flatted": {


### PR DESCRIPTION
## Summary
Two `flatbuffers` entries in `package-lock.json` had `resolved` URLs pointing at `npm-proxy.dev.databricks.com` (a dev-only proxy). The protected release/CI runners can't reach it, and npm only rewrites `registry.npmjs.org` hosts to the configured JFrog `db-npm` registry — so `npm clean-install` in the release `build` job failed with `ECONNRESET`.

Repoint both to `registry.npmjs.org`. Integrity is content-addressed (same tarball), so only the host changes. Diff is exactly 2 lines.

## Why now
Caught by a dry-run of the RC release (`1.16.0-rc.1`) off the pipeline branch — the `build` job died on this before reaching publish. It would equally break the next **GA** release, so it's worth fixing on `main` regardless of the RC.

This pull request and its description were written by Isaac.