### PR TITLE
prepare release 1.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release History
 
+## 1.16.0
+
+- **New: optional kernel backend (`useKernel: true`).** Adds an alternative connection path backed by the native `@databricks/databricks-sql-kernel` client (a Rust core exposed via napi-rs), shipped as prebuilt per-platform packages (linux x64/arm64 gnu+musl, macOS x64/arm64, Windows x64/arm64) pulled in automatically as optional dependencies. The kernel talks to Databricks over the **SEA (Statement Execution API) HTTP transport** — not Thrift — with CloudFetch and inline-Arrow result fetching, through the same `DBSQLClient` surface. Supports PAT and OAuth (M2M/U2M) auth. Requires Node >= 18; on older Node the binding is not loaded and `useKernel: true` raises a clear error directing you to the Thrift backend. The default backend remains Thrift — opt in per connection. (databricks/databricks-sql-nodejs#378, #380, #409, #410, #411, #412, #416, #428, #434 by @msrathore-db)
+- Kernel backend behavior is aligned with Thrift so application code works the same either way: named/positional query parameters, metadata calls, TLS/mTLS with a custom CA, custom headers and user-agent, HTTP/SOCKS proxy and socket timeout, configurable retry/backoff, session query tags, async submit + `cancel()`, operation id/schema, and INTERVAL/type parity. Kernel logs surface through the same `DBSQLLogger` sink. (databricks/databricks-sql-nodejs#417, #420, #421, #426, #430, #431 by @msrathore-db)
+- Make retry-policy knobs (max attempts, min/max backoff, overall timeout) configurable via `connect()` for both backends (databricks/databricks-sql-nodejs#433 by @msrathore-db)
+- Retry transient network errors and fix a CloudFetch prefetch promise-rejection leak (databricks/databricks-sql-nodejs#424 by @msrathore-db)
+- Telemetry: emit `sql_operation`, `auth_type`, and `driver_connection_params` (databricks/databricks-sql-nodejs#396 by @samikshya-db)
+
 ## 1.15.0
 
 - Add SPOG routing support: parse `?o=<workspaceId>` from `httpPath` and inject `x-databricks-org-id` on Thrift, telemetry, and feature-flag requests. Expose `customHeaders` on `ConnectionOptions` for caller-supplied headers (databricks/databricks-sql-nodejs#391 by @samikshya-db)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@databricks/sql",
-  "version": "1.16.0-rc.1",
+  "version": "1.16.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@databricks/sql",
-      "version": "1.16.0-rc.1",
+      "version": "1.16.0",
       "license": "Apache-2.0",
       "dependencies": {
         "apache-arrow": "^13.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@databricks/sql",
-  "version": "1.16.0-rc.1",
+  "version": "1.16.0",
   "description": "Driver for connection to Databricks SQL via Thrift API.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
Bump version to `1.16.0` and add the `1.16.0` section to `CHANGELOG.md`. This is the first GA exposing the opt-in **kernel backend** (`useKernel: true`); the default backend remains Thrift.

### Notable changes since 1.15.0
- **New: optional kernel backend (`useKernel: true`)** — Rust core via napi-rs, shipped as prebuilt per-platform packages, over the SEA HTTP transport. Requires Node >= 18; opt in per connection. (#378, #380, #409–#412, #416, #428, #434)
- Kernel/Thrift behavior parity: params, metadata, TLS/mTLS, custom headers/UA, proxy + socketTimeout, retry/backoff, query tags, async + cancel, INTERVAL parity; unified logging. (#417, #420, #421, #426, #430, #431)
- Configurable retry-policy knobs via `connect()` for both backends. (#433)
- Retry transient network errors + CloudFetch prefetch-rejection leak fix. (#424)
- Telemetry: emit `sql_operation`, `auth_type`, `driver_connection_params`. (#396)

## Test plan
- [x] `npm install --package-lock-only` changes only the version field in the lockfile
- [ ] CI green
- [x] Kernel cross-OS/arch validation (kernel-rc-cross-os workflow): green on Node 18/20/22 across linux gnu+musl, arm64 gnu+musl, darwin-arm64, win32-x64

## Notes
- Tarball will gain the kernel files (`dist/kernel/*`, `native/kernel/index.{js,d.ts}`) vs 1.15.0 — additive, expected. The `.node` binaries are NOT in the tarball (they ship via optionalDependencies).
- Node 16 support is a planned follow-up (1.16.1), gated on republishing `databricks-sql-kernel` with `engines >=16`.

This pull request was AI-assisted by Isaac.