### PR TITLE
Reduce CloudFetch metric logging verbosity from INFO to DEBUG (#311)

### DIFF
--- a/lib/result/CloudFetchResultHandler.ts
+++ b/lib/result/CloudFetchResultHandler.ts
@@ -103,7 +103,7 @@ export default class CloudFetchResultHandler implements IResultsProvider<ArrowBa
 
     this.context
       .getLogger()
-      .log(LogLevel.info, `Result File Download speed from cloud storage ${cleanUrl}: ${speedMBps.toFixed(4)} MB/s`);
+      .log(LogLevel.debug, `Result File Download speed from cloud storage ${cleanUrl}: ${speedMBps.toFixed(4)} MB/s`);
 
     const speedThresholdMBps = this.context.getConfig().cloudFetchSpeedThresholdMBps;
     if (speedMBps < speedThresholdMBps) {

--- a/tests/unit/result/CloudFetchResultHandler.test.ts
+++ b/tests/unit/result/CloudFetchResultHandler.test.ts
@@ -5,6 +5,7 @@ import LZ4 from 'lz4';
 import { Request, Response } from 'node-fetch';
 import { ShouldRetryResult } from '../../../lib/connection/contracts/IRetryPolicy';
 import { HttpTransactionDetails } from '../../../lib/connection/contracts/IConnectionProvider';
+import { LogLevel } from '../../../lib/contracts/IDBSQLLogger';
 import CloudFetchResultHandler from '../../../lib/result/CloudFetchResultHandler';
 import ResultsProviderStub from '../.stubs/ResultsProviderStub';
 import { TRowSet, TSparkArrowResultLink, TStatusCode } from '../../../thrift/TCLIService_types';
@@ -197,6 +198,26 @@ describe('CloudFetchResultHandler', () => {
     expect(result['pendingLinks'].length).to.be.equal(expectedLinksCount);
     expect(result['downloadTasks'].length).to.be.equal(0);
     expect(context.invokeWithRetryStub.called).to.be.false;
+  });
+
+  it('should log cloud fetch download speed at debug level', async () => {
+    const context = new ClientContextStub({ cloudFetchConcurrentDownloads: 1 });
+    const rowSetProvider = new ResultsProviderStub([sampleRowSet1], undefined);
+    const result = new CloudFetchResultHandler(context, rowSetProvider, {
+      status: { statusCode: TStatusCode.SUCCESS_STATUS },
+    });
+
+    const logStub = sinon.stub(context.logger, 'log');
+    context.invokeWithRetryStub.callsFake(async () => ({
+      request: new Request('localhost'),
+      response: new Response(Buffer.concat([sampleArrowSchema, sampleArrowBatch]), { status: 200 }),
+    }));
+
+    await result.fetchNext({ limit: 10000 });
+
+    expect(logStub.calledWith(LogLevel.debug, sinon.match(/Result File Download speed from cloud storage/))).to.be.true;
+    expect(logStub.neverCalledWith(LogLevel.info, sinon.match(/Result File Download speed from cloud storage/))).to.be
+      .true;
   });
 
   it('should download batches according to settings', async () => {


### PR DESCRIPTION
Fixes #311 — reduce verbosity of cloud fetch metric logging.

Changes:
- Lower metric log level from `INFO` to `DEBUG` in `CloudFetchResultHandler`.
- Add unit test asserting debug-level logging in `tests/unit/result/CloudFetchResultHandler.test.ts`.

Note: Per contributor preference, `CHANGELOG.md` was NOT modified in this PR.
