### PR TITLE
ci: dispatch coverage-fanout on merged source PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -165,8 +165,8 @@ jobs:
 
   coverage:
     needs: [unit-test, e2e-test]
-    # Run when e2e is skipped (fork PRs) but still block on a real e2e failure.
-    if: ${{ !cancelled() && needs.unit-test.result == 'success' && needs.e2e-test.result != 'failure' }}
+    # Runs when e2e passed OR was skipped (fork PRs); a real e2e failure still blocks it.
+    if: ${{ needs.unit-test.result == 'success' && (needs.e2e-test.result == 'success' || needs.e2e-test.result == 'skipped') }}
     runs-on:
       group: databricks-protected-runner-group
       labels: linux-ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,14 +101,8 @@ jobs:
           retention-days: 1
 
   e2e-test:
-    # Skip on fork PRs only: e2e needs the azure-prod environment + warehouse
-    # secrets, which GitHub withholds from a fork's pull_request run — so it
-    # can't pass there and would otherwise permanently block the required
-    # `coverage` check (which needs this job), keeping fork PRs out of the merge
-    # queue. On internal PRs, push, and merge_group there is no
-    # `pull_request.head.repo.fork == true`, so this runs normally — a fork PR's
-    # code is still e2e-tested in the merge queue (base-repo context, secrets
-    # available) before it can merge.
+    # Skip on fork PRs (no access to azure-prod secrets); still runs on internal
+    # PRs, push, and in the merge queue, where fork code is e2e-tested before merge.
     if: ${{ github.event.pull_request.head.repo.fork != true }}
     runs-on:
       group: databricks-protected-runner-group
@@ -171,11 +165,7 @@ jobs:
 
   coverage:
     needs: [unit-test, e2e-test]
-    # Run whenever unit-test passed, tolerating a SKIPPED e2e-test (fork PRs,
-    # where e2e is skipped above). A default `needs` would auto-skip coverage
-    # when e2e is skipped, leaving this required check absent on fork heads and
-    # blocking the merge queue. A genuine e2e FAILURE (internal PR / merge_group)
-    # still blocks coverage — e2e stays enforced everywhere it can run.
+    # Run when e2e is skipped (fork PRs) but still block on a real e2e failure.
     if: ${{ !cancelled() && needs.unit-test.result == 'success' && needs.e2e-test.result != 'failure' }}
     runs-on:
       group: databricks-protected-runner-group
@@ -203,10 +193,8 @@ jobs:
           ls -1 coverage_*.tar | xargs -I '{}' -- tar -xvf '{}'
           rm coverage_*.tar
       - run: ls -la
-      # Upload to Codecov only when the token is available (non-fork). Forks
-      # can't access CODECOV_TOKEN, and with fail_ci_if_error the step would
-      # fail the required coverage check on forks. The report still generates
-      # from the unit-test artifacts; only the external upload is skipped.
+      # Skip the upload on forks — CODECOV_TOKEN is unavailable and
+      # fail_ci_if_error would fail the required coverage check.
       - name: Coverage
         if: ${{ github.event.pull_request.head.repo.fork != true }}
         uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,6 +101,15 @@ jobs:
           retention-days: 1
 
   e2e-test:
+    # Skip on fork PRs only: e2e needs the azure-prod environment + warehouse
+    # secrets, which GitHub withholds from a fork's pull_request run — so it
+    # can't pass there and would otherwise permanently block the required
+    # `coverage` check (which needs this job), keeping fork PRs out of the merge
+    # queue. On internal PRs, push, and merge_group there is no
+    # `pull_request.head.repo.fork == true`, so this runs normally — a fork PR's
+    # code is still e2e-tested in the merge queue (base-repo context, secrets
+    # available) before it can merge.
+    if: ${{ github.event.pull_request.head.repo.fork != true }}
     runs-on:
       group: databricks-protected-runner-group
       labels: linux-ubuntu-latest
@@ -162,6 +171,12 @@ jobs:
 
   coverage:
     needs: [unit-test, e2e-test]
+    # Run whenever unit-test passed, tolerating a SKIPPED e2e-test (fork PRs,
+    # where e2e is skipped above). A default `needs` would auto-skip coverage
+    # when e2e is skipped, leaving this required check absent on fork heads and
+    # blocking the merge queue. A genuine e2e FAILURE (internal PR / merge_group)
+    # still blocks coverage — e2e stays enforced everywhere it can run.
+    if: ${{ !cancelled() && needs.unit-test.result == 'success' && needs.e2e-test.result != 'failure' }}
     runs-on:
       group: databricks-protected-runner-group
       labels: linux-ubuntu-latest
@@ -188,7 +203,12 @@ jobs:
           ls -1 coverage_*.tar | xargs -I '{}' -- tar -xvf '{}'
           rm coverage_*.tar
       - run: ls -la
+      # Upload to Codecov only when the token is available (non-fork). Forks
+      # can't access CODECOV_TOKEN, and with fail_ci_if_error the step would
+      # fail the required coverage check on forks. The report still generates
+      # from the unit-test artifacts; only the external upload is skipped.
       - name: Coverage
+        if: ${{ github.event.pull_request.head.repo.fork != true }}
         uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/skip-checks-reporter.yml
+++ b/.github/workflows/skip-checks-reporter.yml
@@ -1,0 +1,62 @@
+name: Report Integration Test Skip
+
+# Posts the PR-open "skipped" placeholder for the required
+# `Node.js Integration Tests` check.
+#
+# Why a separate workflow (not an inline job in trigger-integration-tests.yml):
+#   - `Node.js Integration Tests` is a required status check. A fork PR runs its
+#     own `pull_request` workflows with a READ-ONLY GITHUB_TOKEN, so an inline
+#     `github.token` stub can't post the check on a fork head (checks.create
+#     403s). That left fork PRs unable to satisfy the required check and stuck
+#     out of the merge queue.
+#   - `workflow_run` workflows always run in THIS (base) repo's context using the
+#     definition from the default branch, with a read-write token — even when the
+#     triggering run came from a fork. So this can post the placeholder on any PR
+#     head, fork or not, letting every PR auto-enqueue with no label.
+#
+# The required check is UNPINNED (no integration_id in the ruleset), so a
+# `github.token` (github-actions app) check satisfies it — no app token / secrets
+# needed here. The real suite is unaffected: it runs as the required gate on the
+# `merge_group` commit (posted by the driver-test app) and as a label preview.
+#
+# SECURITY: runs with a write token in a privileged context. It MUST NOT check out
+# or execute any PR/fork-controlled content — it only calls checks.create with a
+# static body; the sole fork-controlled input is the opaque `workflow_run.head_sha`
+# passed to the API. Do not add `actions/checkout` or a `run:` step that executes
+# repo content here.
+
+on:
+  workflow_run:
+    workflows: ["Trigger Integration Tests"]
+    types: [requested]
+
+jobs:
+  report-skip:
+    # Only for PR-triggered runs; the merge_group run posts the real required check.
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+    permissions:
+      checks: write
+    steps:
+      - name: Post skipped Node.js Integration Tests check
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'Node.js Integration Tests',
+              head_sha: process.env.HEAD_SHA,
+              status: 'completed',
+              conclusion: 'success',
+              completed_at: new Date().toISOString(),
+              output: {
+                title: 'Skipped on PR - runs in merge queue',
+                summary: 'Node.js integration tests are skipped on ordinary PR events and run as the required gate in the merge queue. Add the `integration-test` label to preview them on an internal PR.'
+              }
+            });

--- a/.github/workflows/skip-checks-reporter.yml
+++ b/.github/workflows/skip-checks-reporter.yml
@@ -14,10 +14,13 @@ name: Report Integration Test Skip
 #     triggering run came from a fork. So this can post the placeholder on any PR
 #     head, fork or not, letting every PR auto-enqueue with no label.
 #
-# The required check is UNPINNED (no integration_id in the ruleset), so a
-# `github.token` (github-actions app) check satisfies it — no app token / secrets
-# needed here. The real suite is unaffected: it runs as the required gate on the
-# `merge_group` commit (posted by the driver-test app) and as a label preview.
+# The required check is PINNED to the driver-test app's integration id in the
+# ruleset, so the placeholder must be posted BY that app — hence this mints the
+# INTEGRATION_TEST_APP token (scoped to this repo) and posts with it, rather than
+# using `github.token` (github-actions app), which would not satisfy the pinned
+# gate. Secrets are available here because this runs in the base-repo context. The
+# real suite is unaffected: it runs as the required gate on the `merge_group`
+# commit (also posted by the driver-test app) and as a label preview.
 #
 # SECURITY: runs with a write token in a privileged context. It MUST NOT check out
 # or execute any PR/fork-controlled content — it only calls checks.create with a
@@ -40,12 +43,21 @@ jobs:
     permissions:
       checks: write
     steps:
+      - name: Generate GitHub App token (this repo)
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ secrets.INTEGRATION_TEST_APP_ID }}
+          private-key: ${{ secrets.INTEGRATION_TEST_PRIVATE_KEY }}
+          owner: databricks
+          repositories: databricks-sql-nodejs
+
       - name: Post skipped Node.js Integration Tests check
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         with:
-          github-token: ${{ github.token }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             await github.rest.checks.create({
               owner: context.repo.owner,

--- a/.github/workflows/skip-checks-reporter.yml
+++ b/.github/workflows/skip-checks-reporter.yml
@@ -30,7 +30,7 @@ name: Report Integration Test Skip
 
 on:
   workflow_run:
-    workflows: ["Trigger Integration Tests"]
+    workflows: ['Trigger Integration Tests']
     types: [requested]
 
 jobs:

--- a/.github/workflows/trigger-integration-tests.yml
+++ b/.github/workflows/trigger-integration-tests.yml
@@ -208,7 +208,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: 'Node.js integration tests triggered. [View workflow run](https://github.com/databricks/databricks-driver-test/actions/workflows/databricks-nodejs-integration-tests.yml).'
+              body: 'Node.js integration tests triggered. [View workflow runs](https://github.com/databricks/databricks-driver-test/actions/workflows/databricks-sql-nodejs-integration-tests.yml). The result posts back here as the "Node.js Integration Tests" check.'
             });
 
   merge-queue-nodejs:

--- a/.github/workflows/trigger-integration-tests.yml
+++ b/.github/workflows/trigger-integration-tests.yml
@@ -305,10 +305,14 @@ jobs:
     if: |
       github.event_name == 'pull_request' &&
       github.event.action == 'closed' &&
-      github.event.pull_request.merged == true
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main'
     runs-on:
       group: databricks-protected-runner-group
       labels: linux-ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Check if driver source changed
         id: changed

--- a/.github/workflows/trigger-integration-tests.yml
+++ b/.github/workflows/trigger-integration-tests.yml
@@ -22,7 +22,7 @@ name: Trigger Integration Tests
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, synchronize, reopened, labeled, closed]
   merge_group:
 
 jobs:
@@ -93,7 +93,7 @@ jobs:
             });
 
   skip-integration-tests-pr:
-    if: github.event_name == 'pull_request' && github.event.action != 'labeled'
+    if: github.event_name == 'pull_request' && github.event.action != 'labeled' && github.event.action != 'closed'
     runs-on:
       group: databricks-protected-runner-group
       labels: linux-ubuntu-latest
@@ -292,3 +292,57 @@ jobs:
                 summary: 'An error occurred while dispatching Node.js integration tests. Check this workflow run for details.'
               }
             });
+
+  # =============================================================================
+  # After merge: trigger the multi-language coverage fan-out.
+  # Fires when a PR lands on main (merge queue or direct merge) and touched
+  # driver source. Dispatches `coverage-fanout` to databricks-driver-test, whose
+  # coverage-fanout-tracker.yml opens a tracking issue and runs the
+  # language-agnostic fan-out (a spec authored from THIS PR's diff, conformed as
+  # tests across every driver) as peco-engineer-bot.
+  # =============================================================================
+  trigger-coverage-fanout:
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+    steps:
+      - name: Check if driver source changed
+        id: changed
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # pinned
+        with:
+          script: |
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            // The whole repo IS the driver. Count a merge as source-affecting when it changes a file under lib/.
+            // Docs/CI/test-only merges do not warrant a full multi-language fan-out.
+            const isSource = (f) => f.startsWith('lib/');
+            const srcChanged = files.some((f) => isSource(f.filename));
+            console.log(`driver source changed: ${srcChanged}`);
+            core.setOutput('source', srcChanged.toString());
+
+      - name: Generate GitHub App token (databricks-driver-test)
+        if: steps.changed.outputs.source == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # pinned
+        with:
+          app-id: ${{ secrets.INTEGRATION_TEST_APP_ID }}
+          private-key: ${{ secrets.INTEGRATION_TEST_PRIVATE_KEY }}
+          owner: databricks
+          repositories: databricks-driver-test
+
+      - name: Dispatch coverage-fanout
+        if: steps.changed.outputs.source == 'true'
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          repository: databricks/databricks-driver-test
+          event-type: coverage-fanout
+          client-payload: '{"reference_repo": "${{ github.repository }}", "pr_number": "${{ github.event.pull_request.number }}", "pr_url": "${{ github.event.pull_request.html_url }}"}'

--- a/.github/workflows/trigger-integration-tests.yml
+++ b/.github/workflows/trigger-integration-tests.yml
@@ -175,7 +175,8 @@ jobs:
               "pr_repo": "${{ github.repository }}",
               "pr_url": "${{ github.event.pull_request.html_url }}",
               "pr_title": "${{ steps.sanitize.outputs.result }}",
-              "pr_author": "${{ github.event.pull_request.user.login }}"
+              "pr_author": "${{ github.event.pull_request.user.login }}",
+              "proxy_mode": "replay"
             }
 
       - name: Fail check on dispatch error
@@ -270,7 +271,8 @@ jobs:
               "pr_repo": "${{ github.repository }}",
               "pr_url": "${{ github.server_url }}/${{ github.repository }}/pull/${{ steps.extract-pr.outputs.pr_number }}",
               "pr_title": "Merge queue validation",
-              "pr_author": "merge-queue"
+              "pr_author": "merge-queue",
+              "proxy_mode": "replay"
             }
 
       - name: Fail check on dispatch error

--- a/.github/workflows/trigger-integration-tests.yml
+++ b/.github/workflows/trigger-integration-tests.yml
@@ -327,9 +327,13 @@ jobs:
               pull_number: context.payload.pull_request.number,
               per_page: 100,
             });
-            // The whole repo IS the driver. Count a merge as source-affecting when it changes a file under lib/.
-            // Docs/CI/test-only merges do not warrant a full multi-language fan-out.
-            const isSource = (f) => f.startsWith('lib/');
+            // The whole repo IS the driver. Count a merge as source-affecting when it changes driver
+            // source: lib/ (JS/TS), native/ (kernel bindings), thrift/ (Thrift defs), or the KERNEL_REV
+            // pin. Docs/CI/test-only merges do not warrant a full multi-language fan-out. (Matches the
+            // source roots called out in the "run on every change" comments above — a merge that only
+            // bumps KERNEL_REV or edits native/ or thrift/ still affects the Thrift/kernel backends.)
+            const isSource = (f) =>
+              f.startsWith('lib/') || f.startsWith('native/') || f.startsWith('thrift/') || f === 'KERNEL_REV';
             const srcChanged = files.some((f) => isSource(f.filename));
             console.log(`driver source changed: ${srcChanged}`);
             core.setOutput('source', srcChanged.toString());

--- a/.github/workflows/trigger-integration-tests.yml
+++ b/.github/workflows/trigger-integration-tests.yml
@@ -316,7 +316,7 @@ jobs:
     steps:
       - name: Check if driver source changed
         id: changed
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # pinned
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const files = await github.paginate(github.rest.pulls.listFiles, {
@@ -335,12 +335,13 @@ jobs:
       - name: Generate GitHub App token (databricks-driver-test)
         if: steps.changed.outputs.source == 'true'
         id: app-token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # pinned
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         with:
           app-id: ${{ secrets.INTEGRATION_TEST_APP_ID }}
           private-key: ${{ secrets.INTEGRATION_TEST_PRIVATE_KEY }}
           owner: databricks
           repositories: databricks-driver-test
+          permission-contents: write
 
       - name: Dispatch coverage-fanout
         if: steps.changed.outputs.source == 'true'

--- a/.github/workflows/trigger-integration-tests.yml
+++ b/.github/workflows/trigger-integration-tests.yml
@@ -92,32 +92,16 @@ jobs:
               body
             });
 
-  skip-integration-tests-pr:
-    if: github.event_name == 'pull_request' && github.event.action != 'labeled' && github.event.action != 'closed'
-    runs-on:
-      group: databricks-protected-runner-group
-      labels: linux-ubuntu-latest
-    permissions:
-      checks: write
-    steps:
-      - name: Skip Node.js Integration Tests
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
-        with:
-          github-token: ${{ github.token }}
-          script: |
-            await github.rest.checks.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: 'Node.js Integration Tests',
-              head_sha: context.payload.pull_request.head.sha,
-              status: 'completed',
-              conclusion: 'success',
-              completed_at: new Date().toISOString(),
-              output: {
-                title: 'Skipped on PR - runs in merge queue',
-                summary: 'Node.js integration tests are skipped on ordinary PR events and run as a required gate in the merge queue. Add the `integration-test` label to preview them on this PR.'
-              }
-            });
+  # NOTE: the PR-open "skipped" placeholder for the required
+  # `Node.js Integration Tests` check is NOT posted here anymore. It is posted by
+  # the companion workflow `skip-checks-reporter.yml`, which runs on `workflow_run`
+  # in the base-repo context. That context has a read-write token even for
+  # fork-triggered runs, so it can post the check on EVERY PR head — including fork
+  # PRs, whose own `pull_request` run gets a read-only token and cannot post checks
+  # (the previous inline `github.token` stub 403'd on forks, so fork PRs could never
+  # satisfy the now-required check and were stuck out of the merge queue). See
+  # skip-checks-reporter.yml. The real suite still runs as the required gate on the
+  # merge_group commit and as a label preview.
 
   trigger-tests-pr:
     if: |


### PR DESCRIPTION
## Summary

Wires **databricks-sql-nodejs** into the multi-language coverage fan-out in `databricks/databricks-driver-test`. When a PR merges to `main` and touched driver source (a file under `lib/`), dispatch a `coverage-fanout` `repository_dispatch` to driver-test; its `coverage-fanout-tracker.yml` opens a tracking issue and runs the language-agnostic fan-out — a spec authored from **this PR's diff**, conformed as tests across every driver (csharp/python/go/nodejs/rust/kernel/jdbc).

Same sender `adbc-drivers/databricks` already runs; this is one of a set of sibling PRs bringing the remaining driver repos onto the flow.

## What it does

- Adds `closed` to the `pull_request` trigger types; the new `trigger-coverage-fanout` job gates on `github.event.pull_request.merged == true`.
- **Source-path filter** (`lib/`): docs/CI/test-only merges don't kick off a full 7-leg fan-out.
- Reuses the existing `INTEGRATION_TEST_APP_ID`/`_PRIVATE_KEY` App token (scoped to driver-test) + the same `peter-evans/repository-dispatch` pin adbc uses.
- Tightens `skip-integration-tests-pr`'s guard to exclude `closed` so it doesn't re-stamp a check on merged PRs.

## Test Plan

- [x] YAML validates; job-guard audit confirms no existing job misfires on the new `closed` event.
- [ ] After merge: a subsequent merged source PR shows a `coverage-fanout` dispatch + a new tracking issue in `databricks/databricks-driver-test`.

This pull request and its description were written by Isaac.