### PR TITLE
ci: fix dead driver-test workflow link in dispatch comment

### DIFF
--- a/.github/workflows/trigger-integration-tests.yml
+++ b/.github/workflows/trigger-integration-tests.yml
@@ -207,7 +207,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: 'Node.js integration tests triggered. [View workflow run](https://github.com/databricks/databricks-driver-test/actions/workflows/databricks-nodejs-integration-tests.yml).'
+              body: 'Node.js integration tests triggered. [View workflow runs](https://github.com/databricks/databricks-driver-test/actions/workflows/databricks-sql-nodejs-integration-tests.yml). The result posts back here as the "Node.js Integration Tests" check.'
             });
 
   merge-queue-nodejs:


### PR DESCRIPTION
## Summary

The cross-repo dispatch sender comments "Node.js integration tests triggered" on the PR with a link to the driver-test receiver workflow. The link pointed to `databricks-nodejs-integration-tests.yml`, which **does not exist (404)** — the actual receiver file is `databricks-sql-nodejs-integration-tests.yml` (missing `sql-`).

Fixed the filename and clarified that the authoritative result is the **"Node.js Integration Tests"** check posted back on the PR (whose `details_url` links the specific driver-test run — the sender can't link the run directly since `repository_dispatch` returns no run ID).

## Test Plan
- [x] Corrected target `databricks-sql-nodejs-integration-tests.yml` resolves 200 on driver-test `main`
- [x] Workflow YAML parses; no stale `databricks-nodejs-integration-tests.yml` reference remains
- [x] End-to-end flow verified green this session (sender dispatch → receiver run 30073691703 → both thrift+sea legs success → check posted back)

This pull request and its description were written by Isaac.