### PR TITLE
Fix brace-expansion DoS CVE-2026-13149 via overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+## Unreleased
+
+**Security (non-breaking):** clears the two `brace-expansion` DoS findings surfaced by OSV-Scanner. `brace-expansion` is a dev-only transitive dep (via `minimatch` under `eslint`/`mocha`/`nyc`) and is never bundled in the shipped `dist/`.
+
+- **`brace-expansion` pinned to `1.1.16` / `2.1.2` via `overrides`** — clears GHSA-3jxr-9vmj-r5cp (CVE-2026-13149, HIGH; exponential-time expansion DoS).
+- **GHSA-mh99-v99m-4gvg (CVE-2026-14257, HIGH; unbounded-expansion OOM DoS)** has no published fix (the fixed version `5.0.8` is not yet on npm; latest is `2.1.2`), so it cannot be resolved today. It is left **unsuppressed** so the scan keeps surfacing it and it gets remediated as soon as a fix is published. Exposure is limited: dev-only (transitive via minimatch under eslint/mocha/nyc), not in the production tree, and not bundled in the shipped `dist/`.
+
 ## 2.0.0
 
 **Breaking changes — completes the security cleanup that 1.17.0 could not do without breaking changes.**

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -30,3 +30,16 @@
 # This file starts empty -- populate iteratively as the first scan run
 # surfaces real false positives or dev-only findings worth excluding.
 # Do not pre-populate with speculative suppressions.
+#
+# NOTE (brace-expansion / CVE-2026-14257, GHSA-mh99-v99m-4gvg): this OOM
+# DoS is intentionally NOT suppressed. Its affected range is
+# `introduced=0, fixed=5.0.8` and 5.0.8 is not yet published to npm
+# (latest is 2.1.2), so there is no version to bump to -- it cannot be
+# resolved today. It is left visible so the scan keeps surfacing it and
+# it gets picked up as soon as a fix is published, rather than being
+# silently ignored. (It is dev-only -- pulled in transitively via
+# minimatch under eslint/mocha/nyc, not in the production tree, and not
+# bundled in the shipped dist/ -- so the exposure is limited to the local
+# lint/test toolchain.) The sibling CVE-2026-13149 (GHSA-3jxr-9vmj-r5cp)
+# IS fixed, via package.json `overrides` (brace-expansion@1 -> 1.1.16,
+# @2 -> 2.1.2).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1860,9 +1860,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://npm-proxy.dev.databricks.com/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4786,9 +4786,9 @@
       }
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://npm-proxy.dev.databricks.com/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7357,7 +7357,7 @@
           "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.16"
           }
         }
       }
@@ -7385,7 +7385,7 @@
           "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.16"
           }
         }
       }
@@ -8109,9 +8109,9 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://npm-proxy.dev.databricks.com/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -8758,7 +8758,7 @@
           "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.16"
           }
         }
       }
@@ -8896,7 +8896,7 @@
           "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.16"
           }
         },
         "ms": {
@@ -8934,7 +8934,7 @@
           "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.16"
           }
         },
         "semver": {
@@ -8982,7 +8982,7 @@
           "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.16"
           }
         },
         "resolve": {
@@ -9412,7 +9412,7 @@
           "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.16"
           }
         }
       }
@@ -10200,13 +10200,13 @@
       "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "2.1.2"
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-          "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+          "version": "2.1.2",
+          "resolved": "https://npm-proxy.dev.databricks.com/brace-expansion/-/brace-expansion-2.1.2.tgz",
+          "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0"
@@ -11309,7 +11309,7 @@
           "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.16"
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1861,7 +1861,7 @@
     },
     "node_modules/brace-expansion": {
       "version": "1.1.16",
-      "resolved": "https://npm-proxy.dev.databricks.com/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
       "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
@@ -4787,7 +4787,7 @@
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
       "version": "2.1.2",
-      "resolved": "https://npm-proxy.dev.databricks.com/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
       "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
@@ -8110,7 +8110,7 @@
     },
     "brace-expansion": {
       "version": "1.1.16",
-      "resolved": "https://npm-proxy.dev.databricks.com/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
       "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "requires": {
@@ -10205,7 +10205,7 @@
       "dependencies": {
         "brace-expansion": {
           "version": "2.1.2",
-          "resolved": "https://npm-proxy.dev.databricks.com/brace-expansion/-/brace-expansion-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
           "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -107,6 +107,8 @@
     "ip-address": "^10.1.1",
     "form-data": "^4.0.4",
     "uuid": "^11.1.1",
-    "serialize-javascript": "^7.0.5"
+    "serialize-javascript": "^7.0.5",
+    "brace-expansion@1": "1.1.16",
+    "brace-expansion@2": "2.1.2"
   }
 }


### PR DESCRIPTION
## What & why

Resolves the two `brace-expansion` DoS findings surfaced by OSV-Scanner. `brace-expansion` is a **dev-only** transitive dependency (pulled in via `minimatch` under `eslint`/`eslint-plugin-*`/`mocha`/`nyc` — all devDependencies) and is **not bundled** in the shipped `dist/` (see `.npmignore`), so exposure is limited to the local lint/test toolchain.

### Fixed
- **CVE-2026-13149 / GHSA-3jxr-9vmj-r5cp** (HIGH, exponential-time expansion DoS) — pinned `brace-expansion@1 -> 1.1.16` and `@2 -> 2.1.2` via `package.json` `overrides`. Confirmed cleared by a rescan.

### Left unsuppressed (no fix available)
- **CVE-2026-14257 / GHSA-mh99-v99m-4gvg** (HIGH, unbounded-expansion OOM DoS) has **no published fix**: the fixed version `5.0.8` is not on npm (latest across all lines is `2.1.2`; `npm view brace-expansion@5.0.8` → 404), and its affected range is `<= 5.0.7`, i.e. every published version. It is intentionally **left unsuppressed** so the scan keeps surfacing it and it gets remediated as soon as a fix is published. `osv-scanner.toml` carries a documentation-only note explaining this (no `[[IgnoredVulns]]` entry).

> Note: because CVE-2026-14257 is CVSS 7.5 and unfixable today, the Security Scan gate will report it until upstream publishes 5.0.8. This is expected and intentional.

## Verification
- OSV-Scanner: CVE-2026-13149 no longer appears on the bumped versions.
- E2E suite against a live warehouse: **106 passing, 0 failing** (3 pending — the interactive OAuth U2M harness, always skipped).

This pull request and its description were written by Isaac.