### PR TITLE
Revert the brace-expansion CVE suppressions from #463

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -30,29 +30,3 @@
 # This file starts empty -- populate iteratively as the first scan run
 # surfaces real false positives or dev-only findings worth excluding.
 # Do not pre-populate with speculative suppressions.
-
-# brace-expansion DoS advisories, both with NO published fix as of
-# 2026-08-05: the advisories name 1.1.17/1.1.18 and 2.1.4 as fixed, but
-# npm's latest published releases are 1.1.16 and 2.1.3. So there is
-# nothing to bump to -- we already bumped as far as the registry allows
-# (1.1.15 -> 1.1.16, 2.1.1 -> 2.1.3, which cleared the earlier
-# GHSA-3jxr-9vmj-r5cp).
-#
-# Dev-only: brace-expansion reaches us solely through the eslint /
-# glob / test-exclude toolchains via minimatch. `npm ls brace-expansion
-# --omit=dev` is empty, and both lockfile entries are marked
-# "dev": true, so it is not reachable from the published dist/.
-# The impact is DoS (ReDoS / OOM) on adversarial brace patterns, which
-# would require untrusted input to our own lint/test globs.
-#
-# Revisit when 1.1.18 / 2.1.4 land on npm and drop these entries.
-
-[[IgnoredVulns]]
-id = "GHSA-mh99-v99m-4gvg"
-ignoreUntil = "2027-02-05T00:00:00Z"
-reason = "dev-only (eslint/glob/test-exclude -> minimatch); not reachable from shipped dist/. No published fix: advisory lists 1.1.17 as fixed but 1.1.16 is npm's latest 1.x."
-
-[[IgnoredVulns]]
-id = "GHSA-rgw5-rvv9-x895"
-ignoreUntil = "2027-02-05T00:00:00Z"
-reason = "dev-only (eslint/glob/test-exclude -> minimatch); not reachable from shipped dist/. No published fix: advisory lists 1.1.18/2.1.4 as fixed but npm's latest are 1.1.16/2.1.3."


### PR DESCRIPTION
## Summary

Reverts the two `[[IgnoredVulns]]` entries I added in #463, restoring `osv-scanner.toml` to having no suppressions.

**The real dependency bumps from #463 are deliberately kept** — this PR touches only `osv-scanner.toml`:

| Package | Version | Kept? |
|---|---|---|
| `brace-expansion` | 1.1.15 → 1.1.16, 2.1.1 → 2.1.3 | ✅ kept |
| `ip-address` | 10.2.0 → 10.3.1 (**production** dep, via `socks`) | ✅ kept |
| `[[IgnoredVulns]]` × 2 | — | ❌ reverted |

## Why

`[[IgnoredVulns]]` entries are **CVE-id global** in OSV-Scanner v2.3.8 — they silence the advisory across *every* package it is reported against, not just `brace-expansion`. That is broader than the problem being solved, and (a limitation the config file itself documents) there is no way to scope a suppression to one package without blanket-ignoring all of that package's vulnerabilities.

More importantly, those entries landed inside a security-focused PR without a security reviewer explicitly signing off on the suppression decision. Backing them out so it can be judged on its own merits rather than riding along with the TLS fix.

## Consequence — intentional

**The `Security Scan` gate will fail on this PR.** Three dev-only findings resurface:

- `GHSA-mh99-v99m-4gvg` — brace-expansion 1.1.16 (fixed in 1.1.17)
- `GHSA-rgw5-rvv9-x895` — brace-expansion 1.1.16 (fixed in 1.1.18) and 2.1.3 (fixed in 2.1.4)

There is **no published fix**: the advisories name 1.1.17/1.1.18/2.1.4, but npm's latest releases are 1.1.16 and 2.1.3. The bumps in #463 already went as far as the registry allows.

These are **dev-only**: `brace-expansion` reaches us solely through the eslint / glob / test-exclude toolchains via `minimatch`. `npm ls brace-expansion --omit=dev` is empty and both lockfile entries are marked `"dev": true`, so it is not reachable from the published `dist/`. Impact is DoS (ReDoS / OOM) on adversarial brace patterns, which would require untrusted input to our own lint/test globs.

Note the gate was **already failing on `main` before #463** for these same dependencies, so this restores the prior state rather than introducing a new regression.

## Decision needed from reviewers

Pick one:

1. **Merge this** and accept a red `Security Scan` until 1.1.18 / 2.1.4 publish upstream.
2. **Close this** and keep the suppressions from #463 — with a security reviewer explicitly approving the global-scope trade-off and the 2027-02-05 expiry.
3. Suppress via some narrower mechanism, if one is preferred over `[[IgnoredVulns]]`.

## Testing

- `osv-scanner` v2.3.8 (the version CI pins) run locally: confirms exactly the three expected findings return, no others.
- Config-only change — no runtime code touched, so unit/e2e behaviour is unaffected.

This pull request and its description were written by Isaac.
