### PR TITLE
Upgrade SQL kernel native packages to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Kernel backend (`useKernel: true`): upgrade published native packages from `0.2.0` to `1.0.0`.
 - Kernel backend (`useKernel: true`): preserve qualified `INTERVAL MONTH` and
   `INTERVAL DAY` parameter types on the SEA wire by using the kernel raw-parameter
   path.

--- a/native/kernel/README.md
+++ b/native/kernel/README.md
@@ -62,7 +62,7 @@ platform — each containing a single `.node` binary. `native/kernel/index.js`
 `process.platform` / `process.arch` at load time.
 
 > **Status:** the per-platform packages are published on npm (kernel
-> `0.2.0`) and declared in the driver's `optionalDependencies`, pinned to
+> `1.0.0`) and declared in the driver's `optionalDependencies`, pinned to
 > that exact version. `npm install` resolves only the package matching the
 > consumer's `process.platform` / `process.arch`; the others are skipped
 > (that is what `optionalDependencies` tolerates), so installing on an

--- a/native/kernel/index.js
+++ b/native/kernel/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@databricks/databricks-sql-kernel-android-arm64')
         const bindingPackageVersion = require('@databricks/databricks-sql-kernel-android-arm64/package.json').version
-        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@databricks/databricks-sql-kernel-android-arm-eabi')
         const bindingPackageVersion = require('@databricks/databricks-sql-kernel-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@databricks/databricks-sql-kernel-win32-x64-gnu')
         const bindingPackageVersion = require('@databricks/databricks-sql-kernel-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@databricks/databricks-sql-kernel-win32-x64-msvc')
         const bindingPackageVersion = require('@databricks/databricks-sql-kernel-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@databricks/databricks-sql-kernel-win32-ia32-msvc')
         const bindingPackageVersion = require('@databricks/databricks-sql-kernel-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@databricks/databricks-sql-kernel-win32-arm64-msvc')
         const bindingPackageVersion = require('@databricks/databricks-sql-kernel-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@databricks/databricks-sql-kernel-darwin-universal')
       const bindingPackageVersion = require('@databricks/databricks-sql-kernel-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@databricks/databricks-sql-kernel-darwin-x64')
         const bindingPackageVersion = require('@databricks/databricks-sql-kernel-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@databricks/databricks-sql-kernel-darwin-arm64')
         const bindingPackageVersion = require('@databricks/databricks-sql-kernel-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@databricks/databricks-sql-kernel-freebsd-x64')
         const bindingPackageVersion = require('@databricks/databricks-sql-kernel-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@databricks/databricks-sql-kernel-freebsd-arm64')
         const bindingPackageVersion = require('@databricks/databricks-sql-kernel-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@databricks/databricks-sql-kernel-linux-x64-musl')
           const bindingPackageVersion = require('@databricks/databricks-sql-kernel-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@databricks/databricks-sql-kernel-linux-x64-gnu')
           const bindingPackageVersion = require('@databricks/databricks-sql-kernel-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@databricks/databricks-sql-kernel-linux-arm64-musl')
           const bindingPackageVersion = require('@databricks/databricks-sql-kernel-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@databricks/databricks-sql-kernel-linux-arm64-gnu')
           const bindingPackageVersion = require('@databricks/databricks-sql-kernel-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@databricks/databricks-sql-kernel-linux-arm-musleabihf')
           const bindingPackageVersion = require('@databricks/databricks-sql-kernel-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@databricks/databricks-sql-kernel-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@databricks/databricks-sql-kernel-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@databricks/databricks-sql-kernel-linux-loong64-musl')
           const bindingPackageVersion = require('@databricks/databricks-sql-kernel-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@databricks/databricks-sql-kernel-linux-loong64-gnu')
           const bindingPackageVersion = require('@databricks/databricks-sql-kernel-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@databricks/databricks-sql-kernel-linux-riscv64-musl')
           const bindingPackageVersion = require('@databricks/databricks-sql-kernel-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@databricks/databricks-sql-kernel-linux-riscv64-gnu')
           const bindingPackageVersion = require('@databricks/databricks-sql-kernel-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@databricks/databricks-sql-kernel-linux-ppc64-gnu')
         const bindingPackageVersion = require('@databricks/databricks-sql-kernel-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@databricks/databricks-sql-kernel-linux-s390x-gnu')
         const bindingPackageVersion = require('@databricks/databricks-sql-kernel-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@databricks/databricks-sql-kernel-openharmony-arm64')
         const bindingPackageVersion = require('@databricks/databricks-sql-kernel-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@databricks/databricks-sql-kernel-openharmony-x64')
         const bindingPackageVersion = require('@databricks/databricks-sql-kernel-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@databricks/databricks-sql-kernel-openharmony-arm')
         const bindingPackageVersion = require('@databricks/databricks-sql-kernel-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '0.2.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.0.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -648,8 +648,8 @@ if (!nativeBinding || forceWasi) {
       if (!candidateFailed) {
         if (process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
           const bindingPackageVersion = require('@databricks/databricks-sql-kernel-wasm32-wasi/package.json').version
-          if (bindingPackageVersion !== '0.2.0') {
-            throw new Error(`WASI binding package version mismatch, expected 0.2.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.0.0') {
+            throw new Error(`WASI binding package version mismatch, expected 1.0.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
         }
         wasiBinding = require('@databricks/databricks-sql-kernel-wasm32-wasi')

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,14 +53,14 @@
         "node": ">=20.0.0"
       },
       "optionalDependencies": {
-        "@databricks/databricks-sql-kernel-darwin-arm64": "0.2.0",
-        "@databricks/databricks-sql-kernel-darwin-x64": "0.2.0",
-        "@databricks/databricks-sql-kernel-linux-arm64-gnu": "0.2.0",
-        "@databricks/databricks-sql-kernel-linux-arm64-musl": "0.2.0",
-        "@databricks/databricks-sql-kernel-linux-x64-gnu": "0.2.0",
-        "@databricks/databricks-sql-kernel-linux-x64-musl": "0.2.0",
-        "@databricks/databricks-sql-kernel-win32-arm64-msvc": "0.2.0",
-        "@databricks/databricks-sql-kernel-win32-x64-msvc": "0.2.0",
+        "@databricks/databricks-sql-kernel-darwin-arm64": "1.0.0",
+        "@databricks/databricks-sql-kernel-darwin-x64": "1.0.0",
+        "@databricks/databricks-sql-kernel-linux-arm64-gnu": "1.0.0",
+        "@databricks/databricks-sql-kernel-linux-arm64-musl": "1.0.0",
+        "@databricks/databricks-sql-kernel-linux-x64-gnu": "1.0.0",
+        "@databricks/databricks-sql-kernel-linux-x64-musl": "1.0.0",
+        "@databricks/databricks-sql-kernel-win32-arm64-msvc": "1.0.0",
+        "@databricks/databricks-sql-kernel-win32-x64-msvc": "1.0.0",
         "lz4-napi": "^2.9.0"
       }
     },
@@ -647,9 +647,9 @@
       }
     },
     "node_modules/@databricks/databricks-sql-kernel-darwin-arm64": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@databricks/databricks-sql-kernel-darwin-arm64/-/databricks-sql-kernel-darwin-arm64-0.2.0.tgz",
-      "integrity": "sha512-dSZJD1uileOqRDfs5KsW6m43PAl3GqzQMcETbRT1Zjw2FRLQDtLKTA3+VWmlUUHhIz583WeTps91Sjee79cXbA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@databricks/databricks-sql-kernel-darwin-arm64/-/databricks-sql-kernel-darwin-arm64-1.0.0.tgz",
+      "integrity": "sha512-qvZmAmqY6/ZoOA758mzDc2oX4EkRPyDnx/9wFu0IMCB8/wua/5Qz75BdDsMF6v7mGDUmg6rNU+Iw5l/ovML9+A==",
       "cpu": [
         "arm64"
       ],
@@ -663,9 +663,9 @@
       }
     },
     "node_modules/@databricks/databricks-sql-kernel-darwin-x64": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@databricks/databricks-sql-kernel-darwin-x64/-/databricks-sql-kernel-darwin-x64-0.2.0.tgz",
-      "integrity": "sha512-JEe7TqLrXrAoN3SWsi7NgjAo6V+7jEvBwLswwhl0qUp1MoPrZT+y5Kf49vuHPlh61vFgi2F6NlCNfdB/8wpihg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@databricks/databricks-sql-kernel-darwin-x64/-/databricks-sql-kernel-darwin-x64-1.0.0.tgz",
+      "integrity": "sha512-JCveu6IaEkht4au2PlME6ZQfghO9EE9L9qhWHy3l7i4buHAokS8kBDfZefkwChQyVcbEw5bmiGVGiqWZ9TUhQA==",
       "cpu": [
         "x64"
       ],
@@ -679,9 +679,9 @@
       }
     },
     "node_modules/@databricks/databricks-sql-kernel-linux-arm64-gnu": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@databricks/databricks-sql-kernel-linux-arm64-gnu/-/databricks-sql-kernel-linux-arm64-gnu-0.2.0.tgz",
-      "integrity": "sha512-meJ2JF5w4qEiaiI9TNwg2iMgasadqeKSDAw3r3hWTEdzKwUY7saMTFNcjumwR8R3cQMCFJfp3YBOwKS5/hvN9A==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@databricks/databricks-sql-kernel-linux-arm64-gnu/-/databricks-sql-kernel-linux-arm64-gnu-1.0.0.tgz",
+      "integrity": "sha512-2K4rkj0Zy1fvOvwnzR2hakhhQGA0hU1+G2S83s6zLjBgsAQqSbj4CKlkyM4iHqZ2DTX2DbxoEy8HDNWTZpbRWg==",
       "cpu": [
         "arm64"
       ],
@@ -695,9 +695,9 @@
       }
     },
     "node_modules/@databricks/databricks-sql-kernel-linux-arm64-musl": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@databricks/databricks-sql-kernel-linux-arm64-musl/-/databricks-sql-kernel-linux-arm64-musl-0.2.0.tgz",
-      "integrity": "sha512-YTCPs11w6purXCQwJBCh99oHBwTEW4q46OWxO9Rnddo1wJd8EPBa3Misw08URoUVuVuEfYGy5YtSvuPfkkj8Vw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@databricks/databricks-sql-kernel-linux-arm64-musl/-/databricks-sql-kernel-linux-arm64-musl-1.0.0.tgz",
+      "integrity": "sha512-JAdl0DXdT6dQo45JdUjzzOjVWVMC6/vr0S9CkaKgVo0MNrd/oqnlw4J180UzgFRT3pH1SYOtNPIJfV0ONlz6dw==",
       "cpu": [
         "arm64"
       ],
@@ -711,9 +711,9 @@
       }
     },
     "node_modules/@databricks/databricks-sql-kernel-linux-x64-gnu": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@databricks/databricks-sql-kernel-linux-x64-gnu/-/databricks-sql-kernel-linux-x64-gnu-0.2.0.tgz",
-      "integrity": "sha512-wIEJX2mtoCc/KGOzzbxXwOR5aUB5dBSUG1Ypp+JLI28XsZB2eCLcP4jyAQ+Uklxn+SU1hICuok+30t/7wSvKUg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@databricks/databricks-sql-kernel-linux-x64-gnu/-/databricks-sql-kernel-linux-x64-gnu-1.0.0.tgz",
+      "integrity": "sha512-CdGUz3s3ImMnfW07sxAG9fFjGy5AA2y2fy8rAEAKe4iJ02FpqTOxiDUixQg0kEGrCzLVlBOPG3xv+EdODYlHcQ==",
       "cpu": [
         "x64"
       ],
@@ -727,9 +727,9 @@
       }
     },
     "node_modules/@databricks/databricks-sql-kernel-linux-x64-musl": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@databricks/databricks-sql-kernel-linux-x64-musl/-/databricks-sql-kernel-linux-x64-musl-0.2.0.tgz",
-      "integrity": "sha512-0wtWdOxYh7BfeklDpI0tpTk/ljdjJmCQsNFPLy2C7EnK60J3sroYzTaFqgn8Qqc7T03VHZl/6GG1pXC3zPuU1g==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@databricks/databricks-sql-kernel-linux-x64-musl/-/databricks-sql-kernel-linux-x64-musl-1.0.0.tgz",
+      "integrity": "sha512-XfKv2Bieuqsx6IlcsF2cn5eS6L0eyxiBuQzviSDWZctdPep4w7KXybjeM4QWttyvAegAomQ1bWyeb4cYPT8ruw==",
       "cpu": [
         "x64"
       ],
@@ -743,9 +743,9 @@
       }
     },
     "node_modules/@databricks/databricks-sql-kernel-win32-arm64-msvc": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@databricks/databricks-sql-kernel-win32-arm64-msvc/-/databricks-sql-kernel-win32-arm64-msvc-0.2.0.tgz",
-      "integrity": "sha512-gS4y1hIIDitr1d9bW6yWEkn4wMW7abinDwFFVUJtYsWkFS+rMq/8CwAYioqNprXQP+XEQS7fLiLYq/BYsQB3Aw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@databricks/databricks-sql-kernel-win32-arm64-msvc/-/databricks-sql-kernel-win32-arm64-msvc-1.0.0.tgz",
+      "integrity": "sha512-mrfP1tntdbTKSxdu1Z/AP6uQZD0lTqWtrtE/s1y6U/QxmhG6SVtpohkznwPKX080JyTrqL3+ul0AiIu80B1sFA==",
       "cpu": [
         "arm64"
       ],
@@ -759,9 +759,9 @@
       }
     },
     "node_modules/@databricks/databricks-sql-kernel-win32-x64-msvc": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@databricks/databricks-sql-kernel-win32-x64-msvc/-/databricks-sql-kernel-win32-x64-msvc-0.2.0.tgz",
-      "integrity": "sha512-zl6KtfB02eVsBNZEQ/kf/dhmesUqbVGwhSFb5oKlmtyj/1kah9R1FRKBVKTLt3v5n9LnjBnomV2s+DRxRSh4rA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@databricks/databricks-sql-kernel-win32-x64-msvc/-/databricks-sql-kernel-win32-x64-msvc-1.0.0.tgz",
+      "integrity": "sha512-rK/oEFkHHiLJQig2M2bMKmqxqBU+i6OwtQ8JLhPqriR/qvitA/hK/T7GmIBrj7C4S+CI9OKeRIc0S7Rh3r7qMw==",
       "cpu": [
         "x64"
       ],
@@ -7257,51 +7257,51 @@
       }
     },
     "@databricks/databricks-sql-kernel-darwin-arm64": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@databricks/databricks-sql-kernel-darwin-arm64/-/databricks-sql-kernel-darwin-arm64-0.2.0.tgz",
-      "integrity": "sha512-dSZJD1uileOqRDfs5KsW6m43PAl3GqzQMcETbRT1Zjw2FRLQDtLKTA3+VWmlUUHhIz583WeTps91Sjee79cXbA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@databricks/databricks-sql-kernel-darwin-arm64/-/databricks-sql-kernel-darwin-arm64-1.0.0.tgz",
+      "integrity": "sha512-qvZmAmqY6/ZoOA758mzDc2oX4EkRPyDnx/9wFu0IMCB8/wua/5Qz75BdDsMF6v7mGDUmg6rNU+Iw5l/ovML9+A==",
       "optional": true
     },
     "@databricks/databricks-sql-kernel-darwin-x64": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@databricks/databricks-sql-kernel-darwin-x64/-/databricks-sql-kernel-darwin-x64-0.2.0.tgz",
-      "integrity": "sha512-JEe7TqLrXrAoN3SWsi7NgjAo6V+7jEvBwLswwhl0qUp1MoPrZT+y5Kf49vuHPlh61vFgi2F6NlCNfdB/8wpihg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@databricks/databricks-sql-kernel-darwin-x64/-/databricks-sql-kernel-darwin-x64-1.0.0.tgz",
+      "integrity": "sha512-JCveu6IaEkht4au2PlME6ZQfghO9EE9L9qhWHy3l7i4buHAokS8kBDfZefkwChQyVcbEw5bmiGVGiqWZ9TUhQA==",
       "optional": true
     },
     "@databricks/databricks-sql-kernel-linux-arm64-gnu": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@databricks/databricks-sql-kernel-linux-arm64-gnu/-/databricks-sql-kernel-linux-arm64-gnu-0.2.0.tgz",
-      "integrity": "sha512-meJ2JF5w4qEiaiI9TNwg2iMgasadqeKSDAw3r3hWTEdzKwUY7saMTFNcjumwR8R3cQMCFJfp3YBOwKS5/hvN9A==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@databricks/databricks-sql-kernel-linux-arm64-gnu/-/databricks-sql-kernel-linux-arm64-gnu-1.0.0.tgz",
+      "integrity": "sha512-2K4rkj0Zy1fvOvwnzR2hakhhQGA0hU1+G2S83s6zLjBgsAQqSbj4CKlkyM4iHqZ2DTX2DbxoEy8HDNWTZpbRWg==",
       "optional": true
     },
     "@databricks/databricks-sql-kernel-linux-arm64-musl": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@databricks/databricks-sql-kernel-linux-arm64-musl/-/databricks-sql-kernel-linux-arm64-musl-0.2.0.tgz",
-      "integrity": "sha512-YTCPs11w6purXCQwJBCh99oHBwTEW4q46OWxO9Rnddo1wJd8EPBa3Misw08URoUVuVuEfYGy5YtSvuPfkkj8Vw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@databricks/databricks-sql-kernel-linux-arm64-musl/-/databricks-sql-kernel-linux-arm64-musl-1.0.0.tgz",
+      "integrity": "sha512-JAdl0DXdT6dQo45JdUjzzOjVWVMC6/vr0S9CkaKgVo0MNrd/oqnlw4J180UzgFRT3pH1SYOtNPIJfV0ONlz6dw==",
       "optional": true
     },
     "@databricks/databricks-sql-kernel-linux-x64-gnu": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@databricks/databricks-sql-kernel-linux-x64-gnu/-/databricks-sql-kernel-linux-x64-gnu-0.2.0.tgz",
-      "integrity": "sha512-wIEJX2mtoCc/KGOzzbxXwOR5aUB5dBSUG1Ypp+JLI28XsZB2eCLcP4jyAQ+Uklxn+SU1hICuok+30t/7wSvKUg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@databricks/databricks-sql-kernel-linux-x64-gnu/-/databricks-sql-kernel-linux-x64-gnu-1.0.0.tgz",
+      "integrity": "sha512-CdGUz3s3ImMnfW07sxAG9fFjGy5AA2y2fy8rAEAKe4iJ02FpqTOxiDUixQg0kEGrCzLVlBOPG3xv+EdODYlHcQ==",
       "optional": true
     },
     "@databricks/databricks-sql-kernel-linux-x64-musl": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@databricks/databricks-sql-kernel-linux-x64-musl/-/databricks-sql-kernel-linux-x64-musl-0.2.0.tgz",
-      "integrity": "sha512-0wtWdOxYh7BfeklDpI0tpTk/ljdjJmCQsNFPLy2C7EnK60J3sroYzTaFqgn8Qqc7T03VHZl/6GG1pXC3zPuU1g==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@databricks/databricks-sql-kernel-linux-x64-musl/-/databricks-sql-kernel-linux-x64-musl-1.0.0.tgz",
+      "integrity": "sha512-XfKv2Bieuqsx6IlcsF2cn5eS6L0eyxiBuQzviSDWZctdPep4w7KXybjeM4QWttyvAegAomQ1bWyeb4cYPT8ruw==",
       "optional": true
     },
     "@databricks/databricks-sql-kernel-win32-arm64-msvc": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@databricks/databricks-sql-kernel-win32-arm64-msvc/-/databricks-sql-kernel-win32-arm64-msvc-0.2.0.tgz",
-      "integrity": "sha512-gS4y1hIIDitr1d9bW6yWEkn4wMW7abinDwFFVUJtYsWkFS+rMq/8CwAYioqNprXQP+XEQS7fLiLYq/BYsQB3Aw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@databricks/databricks-sql-kernel-win32-arm64-msvc/-/databricks-sql-kernel-win32-arm64-msvc-1.0.0.tgz",
+      "integrity": "sha512-mrfP1tntdbTKSxdu1Z/AP6uQZD0lTqWtrtE/s1y6U/QxmhG6SVtpohkznwPKX080JyTrqL3+ul0AiIu80B1sFA==",
       "optional": true
     },
     "@databricks/databricks-sql-kernel-win32-x64-msvc": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@databricks/databricks-sql-kernel-win32-x64-msvc/-/databricks-sql-kernel-win32-x64-msvc-0.2.0.tgz",
-      "integrity": "sha512-zl6KtfB02eVsBNZEQ/kf/dhmesUqbVGwhSFb5oKlmtyj/1kah9R1FRKBVKTLt3v5n9LnjBnomV2s+DRxRSh4rA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@databricks/databricks-sql-kernel-win32-x64-msvc/-/databricks-sql-kernel-win32-x64-msvc-1.0.0.tgz",
+      "integrity": "sha512-rK/oEFkHHiLJQig2M2bMKmqxqBU+i6OwtQ8JLhPqriR/qvitA/hK/T7GmIBrj7C4S+CI9OKeRIc0S7Rh3r7qMw==",
       "optional": true
     },
     "@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -91,14 +91,14 @@
   },
   "optionalDependencies": {
     "lz4-napi": "^2.9.0",
-    "@databricks/databricks-sql-kernel-linux-x64-gnu": "0.2.0",
-    "@databricks/databricks-sql-kernel-linux-arm64-gnu": "0.2.0",
-    "@databricks/databricks-sql-kernel-linux-x64-musl": "0.2.0",
-    "@databricks/databricks-sql-kernel-linux-arm64-musl": "0.2.0",
-    "@databricks/databricks-sql-kernel-darwin-x64": "0.2.0",
-    "@databricks/databricks-sql-kernel-darwin-arm64": "0.2.0",
-    "@databricks/databricks-sql-kernel-win32-x64-msvc": "0.2.0",
-    "@databricks/databricks-sql-kernel-win32-arm64-msvc": "0.2.0"
+    "@databricks/databricks-sql-kernel-linux-x64-gnu": "1.0.0",
+    "@databricks/databricks-sql-kernel-linux-arm64-gnu": "1.0.0",
+    "@databricks/databricks-sql-kernel-linux-x64-musl": "1.0.0",
+    "@databricks/databricks-sql-kernel-linux-arm64-musl": "1.0.0",
+    "@databricks/databricks-sql-kernel-darwin-x64": "1.0.0",
+    "@databricks/databricks-sql-kernel-darwin-arm64": "1.0.0",
+    "@databricks/databricks-sql-kernel-win32-x64-msvc": "1.0.0",
+    "@databricks/databricks-sql-kernel-win32-arm64-msvc": "1.0.0"
   },
   "overrides": {
     "basic-ftp": "^5.3.1",


### PR DESCRIPTION
Upgrade all platform-specific `databricks-sql-kernel` packages from `0.2.0` to `1.0.0` and refresh their lockfile metadata through `npm-proxy.cloud.databricks.com`.

This also updates the napi-rs router version guard and release documentation.

Validation: `npm run build`; 329 kernel tests against the installed 1.0.0 binary; 1,290 full unit tests; Prettier and `git diff --check`.

---
<!-- GITHUB_MCP_FOOTER: This attribution is automatically appended by GitHub MCP. -->
_This PR was created with [GitHub MCP](http://go/mcps)._